### PR TITLE
Assign a server to multiple groups

### DIFF
--- a/src/Deployer/Remote/RemoteGroup.php
+++ b/src/Deployer/Remote/RemoteGroup.php
@@ -15,7 +15,7 @@ class RemoteGroup implements RemoteInterface
 
     public function add($group, RemoteInterface $remote)
     {
-        $this->remotes[] = array($group, $remote);
+        $this->remotes[] = array((array)$group, $remote);
     }
 
     public function group($group)
@@ -32,7 +32,7 @@ class RemoteGroup implements RemoteInterface
     {
         foreach ($this->remotes as $list) {
             list($group, $remote) = $list;
-            if($group === $isGroup) {
+            if (in_array($isGroup, $group)) {
                 return true;
             }
         }
@@ -78,7 +78,7 @@ class RemoteGroup implements RemoteInterface
             foreach ($this->remotes as $list) {
                 list($group, $remote) = $list;
 
-                if ($group === $this->group) {
+                if (in_array($this->group, $group)) {
                     $remotes[] = $remote;
                 }
             }

--- a/src/Deployer/Tool.php
+++ b/src/Deployer/Tool.php
@@ -108,8 +108,9 @@ class Tool
 
     public function connect($server, $user, $password, $group = null)
     {
-        $this->writeln(sprintf("Connecting to <info>%s%s</info>", $server, $group ? " ($group)" : ""));
-        if (null === $group) {
+        $group = (array)$group;
+        $this->writeln(sprintf("Connecting to <info>%s%s</info>", $server, $group ? " (". implode(', ', $group) .")" : ""));
+        if (!count($group)) {
             $this->remote = $this->remoteFactory->create($server, $user, $password);
         } else {
             if (null === $this->remote) {

--- a/test/Deployer/Remote/RemoteGroupTest.php
+++ b/test/Deployer/Remote/RemoteGroupTest.php
@@ -34,6 +34,36 @@ class RemoteGroupTest extends \PHPUnit_Framework_TestCase
         $remote->execute('command');
     }
 
+    public function testRemoteMultiGroupCalls()
+    {
+        $remote = new RemoteGroup();
+
+        $mock = $this->getMock('Deployer\Remote\RemoteInterface');
+        $mock->expects($this->exactly(3))
+            ->method('cd')
+            ->with('/path');
+
+        $mock->expects($this->exactly(2))
+            ->method('uploadFile')
+            ->with('/from', '/to');
+
+        $mock->expects($this->exactly(1))
+            ->method('execute');
+
+        $remote->add('1', $mock);
+        $remote->add(array('1', '2'), $mock);
+        $remote->add(array('1', '2', '3'), $mock);
+
+        $remote->group('1');
+        $remote->cd('/path');
+
+        $remote->group('2');
+        $remote->uploadFile('/from', '/to');
+
+        $remote->group('3');
+        $remote->execute('command');
+    }
+
     public function testRemoteGroupSubsection()
     {
         $remote = new RemoteGroup();
@@ -69,6 +99,20 @@ class RemoteGroupTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($remote->isGroupExist('one'));
         $this->assertFalse($remote->isGroupExist('two'));
+    }
+
+
+    public function testIsGroupExistWithMulti()
+    {
+        $remote = new RemoteGroup();
+
+        $mock = $this->getMock('Deployer\Remote\RemoteInterface');
+
+        $remote->add(array('one', 'two'), $mock);
+
+        $this->assertTrue($remote->isGroupExist('one'));
+        $this->assertTrue($remote->isGroupExist('two'));
+        $this->assertFalse($remote->isGroupExist('three'));
     }
 }
  


### PR DESCRIPTION
Hello,

With this PR you can assign a server to multiple groups

exemple:

``` php

connect('ssh.host1.com', 'user', 'password', array('one', 'two'));
connect('ssh.host2.com', 'user', 'password', 'two');

group('two', function() {
    ...
});
```
