### PR TITLE
Clone recursive and fix cleanup

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -176,7 +176,7 @@ task('deploy:symlink', function () {
  * Cleanup old releases
  */
 task('cleanup', function () {
-    $releases = env()->getReleases();
+    $releases = env()->getReleasesByTime();
 
     $keep = get('keep_releases', 3);
 

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -130,6 +130,21 @@ class Environment
             return !empty($release);
         });
     }
+    
+    /**
+     * Let ls sort by time
+     * No need to rsort
+     */
+    public function getReleasesByTime()
+    {
+        $releases = $this->server->run("cd {$this->getConfig()->getPath()} && ls -t releases");
+        $releases = explode("\n", $releases);
+
+        return array_filter($releases, function ($release) {
+            $release = trim($release);
+            return !empty($release);
+        });
+    }
 
     /**
      * @param string $workingPath


### PR DESCRIPTION
- i have a submodule in my git repository, it's not really common but i needed a recursive clone. maybe a nice feature to have for the update_code task
- there was a bug in the cleanup task, wrong orderning of the releases directory caused this.
  now there is a new function (didn't want to break older code) which let the ls command sort by time
