### PR TITLE
Added file (--file and -f) option to deployer allowing to specify which deploy script to use

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -27,18 +27,39 @@ if (!$loaded) {
 // Recipe include path
 set_include_path(__DIR__ . '/../' . PATH_SEPARATOR . get_include_path());
 
+// Init App
+$app = new \Symfony\Component\Console\Application('Deployer', '2.0.0');
+$input = new \Symfony\Component\Console\Input\ArgvInput();
+$output = new \Symfony\Component\Console\Output\ConsoleOutput();
+
 // Init Deployer
 $deployer = new \Deployer\Deployer(
-    new \Symfony\Component\Console\Application('Deployer', '2.0.0'),
-    new \Symfony\Component\Console\Input\ArgvInput(),
-    new \Symfony\Component\Console\Output\ConsoleOutput()
+    $app,
+    $input,
+    $output
 );
 
-// Require current deploy.php script
-$deployFile = getcwd() . '/deploy.php';
+// Set file option for custom deploy script
+$app->getDefinition()->addOption(
+    new \Symfony\Component\Console\Input\InputOption(
+        'file',
+        'f',
+        \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL,
+        'The deployer script to use',
+        'deploy.php'
+    )
+);
 
-if (is_file($deployFile) && is_readable($deployFile)) {
+// Get the deploy script
+$input->bind($app->getDefinition());
+$optionFile = $input->getOption('file');
+$deployFile = realpath($optionFile);
+
+if (($deployFile !== false) && is_file($deployFile) && is_readable($deployFile)) {
     require $deployFile;
+} else if ($app->getDefinition()->getOption('file')->getDefault() !== $optionFile) {
+    // If the user specified a script and it doesn't exist then let them know
+    $output->writeln('<error>The deployer script ' . $optionFile . ' does not exist or is not readable</error>');
 }
 
 // Self-update command


### PR DESCRIPTION
Issue #67 

Will accept relative or absolute paths.

Example usage:
php bin/deploy --file=/home/alex/sites/deploy-scripts/wordpress.php deploy
php bin/deploy --file=deploy-scripts/anothersite.php deploy
php bin/deploy -fdeploy-scripts/wordpress.php deploy
