### PR TITLE
Allow to ignore platform requirements

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -199,9 +199,14 @@ task('deploy:vendors', function () {
             run("if [ -d $(echo $vendorsDir) ]; then cp -r $vendorsDir $releasePath; fi");
         }
     }
+    
+    $options = '--no-dev --verbose --prefer-dist --optimize-autoloader --no-progress';
+    $ignorePlatformReqs = get('ignore_platform_reqs', 'false');
+    if ('true' === $ignorePlatformReqs) {
+        $options .= ' --ignore-platform-reqs';
+    }
 
-    run("SYMFONY_ENV=$prod php composer.phar install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress");
-
+    run("SYMFONY_ENV=$prod php composer.phar install $options");
 })->desc('Installing vendors');
 
 


### PR DESCRIPTION
## Configuration

Use it by adding `set('ignore_platform_reqs', 'true');` inside `deploy.php`
## Usage

See https://github.com/composer/composer/issues/1468
tl;dr;
It's usefull to ignore platform requirements when you use container with volumes or want to install them with hhvm
