### PR TITLE
Allow to require deployer master through alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     ],
     "require": {
         "php": ">=5.4.0",
-
         "symfony/finder": "~2.5",
         "symfony/console": "~2.5",
         "elfet/php-ssh": "~1.0",
@@ -30,5 +29,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Add `"elfet/deployer": "~2.1.0@dev"` to composer in order to fetch master branch.

This also would remove a warning when requiring dev-master and validating the composer.json:

``` console
$ composer validate
./composer.json is valid, but with a few warnings
See http://getcomposer.org/doc/04-schema.md for details on the schema
require.elfet/deployer : unbound version constraints (dev-master@dev) should be avoided
```
