### PR TITLE
Added possibility to add arguments/options

### DIFF
--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -103,6 +103,43 @@ class Deployer
     }
 
     /**
+     * Adds a global argument
+     *
+     * @param string $name
+     * @param array  $config
+     */
+    public function addArgument($name, $config)
+    {
+        $argument = new Console\Input\InputArgument(
+            $name,
+            $config['mode'],
+            $config['description'],
+            $config['default']
+        );
+
+        $this->console->getDefinition()->addArgument($argument);
+    }
+
+    /**
+     * Adds a global option
+     *
+     * @param string $name
+     * @param array  $config
+     */
+    public function addOption($name, $config)
+    {
+        $option = new Console\Input\InputOption(
+            $name,
+            $config['shortcut'],
+            $config['mode'],
+            $config['description'],
+            $config['default']
+        );
+
+        $this->console->getDefinition()->addOption($option);
+    }
+
+    /**
      * @return Console\Input\InputInterface
      */
     public function getInput()

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -108,8 +108,14 @@ class Deployer
      * @param string $name
      * @param array  $config
      */
-    public function addArgument($name, $config)
+    public function addArgument($name, array $config)
     {
+        $config = array_merge(array(
+            'mode'        => null,
+            'description' => '',
+            'default'     => null
+        ), $config);
+
         $argument = new Console\Input\InputArgument(
             $name,
             $config['mode'],
@@ -126,8 +132,15 @@ class Deployer
      * @param string $name
      * @param array  $config
      */
-    public function addOption($name, $config)
+    public function addOption($name, array $config)
     {
+        $config = array_merge(array(
+            'shortcut'    => null,
+            'mode'        => null,
+            'description' => '',
+            'default'     => null
+        ), $config);
+
         $option = new Console\Input\InputOption(
             $name,
             $config['shortcut'],

--- a/src/functions.php
+++ b/src/functions.php
@@ -420,3 +420,37 @@ function env($name = null, $value = null)
         return null;
     }
 }
+
+/**
+ * Adds a global argument
+ *
+ * @param string $name
+ * @param array  $argument
+ *
+ * @return mixed
+ */
+function argument($name, array $argument = null)
+{
+    if (null === $argument) {
+        return Deployer::get()->getInput()->getArgument($name);
+    } else {
+        Deployer::get()->addArgument($name, $argument);
+    }
+}
+
+/**
+ * Adds a global option
+ *
+ * @param string $name
+ * @param array  $option
+ *
+ * @return mixed
+ */
+function option($name, array $option = null)
+{
+    if (null === $option) {
+        return Deployer::get()->getInput()->getOption($name);
+    } else {
+        Deployer::get()->addOption($name, $option);
+    }
+}

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -9,6 +9,8 @@ namespace Deployer;
 
 use Deployer\Task\Context;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class FunctionsTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,29 +27,29 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->console = new Application();
-        
+
         $input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
         $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $server = $this->getMockBuilder('Deployer\Server\ServerInterface')->disableOriginalConstructor()->getMock();
         $env = $this->getMockBuilder('Deployer\Server\Environment')->disableOriginalConstructor()->getMock();
-        
+
         $this->deployer = new Deployer($this->console, $input, $output);
     }
 
     protected function tearDown()
     {
         unset($this->deployer);
-        
+
         $this->deployer = null;
     }
 
     public function testServer()
     {
         server('main', 'domain.com', 22);
-        
+
         $server = $this->deployer->servers->get('main');
         $env = $this->deployer->environments->get('main');
-        
+
         $this->assertInstanceOf('Deployer\Server\ServerInterface', $server);
         $this->assertInstanceOf('Deployer\Server\Environment', $env);
     }
@@ -74,26 +76,52 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException', 'Task should be an closure or array of other tasks.');
         task('wrong', 'thing');
     }
-    
+
     public function testBefore()
     {
         task('main', function () {});
         task('before', function () {});
         before('main', 'before');
-        
+
         $mainScenario = $this->deployer->scenarios->get('main');
         $this->assertInstanceOf('Deployer\Task\Scenario\Scenario', $mainScenario);
         $this->assertEquals(['before', 'main'], $mainScenario->getTasks());
     }
-    
+
     public function testAfter()
     {
         task('main', function () {});
         task('after', function () {});
         after('main', 'after');
-        
+
         $mainScenario = $this->deployer->scenarios->get('main');
         $this->assertInstanceOf('Deployer\Task\Scenario\Scenario', $mainScenario);
         $this->assertEquals(['main', 'after'], $mainScenario->getTasks());
+    }
+
+    public function testArgument()
+    {
+        argument('argument', array(
+            'mode' => InputArgument::OPTIONAL,
+            'description' => 'This is the description',
+            'default' => 'This is the default value'
+        ));
+
+        $arguments = $this->console->getDefinition()->getArguments();
+        $this->assertArrayHasKey('argument', $arguments);
+        $this->assertEquals('This is the default value', $arguments['argument']->getDefault());
+    }
+
+    public function testOption()
+    {
+        option('option', array(
+            'mode' => InputOption::VALUE_REQUIRED,
+            'description' => 'This is the description',
+            'default' => 'This is the default value'
+        ));
+
+        $options = $this->console->getDefinition()->getOptions();
+        $this->assertArrayHasKey('option', $options);
+        $this->assertEquals('This is the default value', $options['option']->getDefault());
     }
 }


### PR DESCRIPTION
We felt the need to add some arguments/options to the console command during our development of our recipes. Maybe others need this functionality, too. This would allow you to do something like this:

In a recipe:
```php
option('tag', array(
    'description' => 'Tag to checkout during `git clone`'
));
```

When deploying:
```bash
deployer.phar --server=prod --tag=v1.0
```

/cc @mabrahamde