### PR TITLE
Fixed command configuration

### DIFF
--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -39,7 +39,13 @@ class TaskCommand extends Command
         parent::__construct($name);
         $this->setDescription($description);
         $this->deployer = $deployer;
+    }
 
+    /**
+     * Configures the command
+     */
+    protected function configure()
+    {
         $this->addOption(
             'server',
             null,


### PR DESCRIPTION
The symfony console has a `configure`-method which should be used to configure the command.