### PR TITLE
Set local process timeout to a higher value

### DIFF
--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -11,7 +11,7 @@ use Symfony\Component\Process\Process;
 
 class Local implements ServerInterface
 {
-    const TIMEOUT      = 300;
+    const TIMEOUT = 300;
 
     /**
      * {@inheritdoc}

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -11,6 +11,8 @@ use Symfony\Component\Process\Process;
 
 class Local implements ServerInterface
 {
+    const TIMEOUT      = 300;
+
     /**
      * {@inheritdoc}
      */
@@ -25,7 +27,10 @@ class Local implements ServerInterface
     public function run($command)
     {
         $process = new Process($command);
-        $process->mustRun();
+        $process
+            ->setTimeout(self::TIMEOUT)
+            ->setIdleTimeout(self::TIMEOUT)
+            ->mustRun();
 
         return $process->getOutput();
     }


### PR DESCRIPTION
Tasks like `composer install` can take really long. However in `Symfony\Component\Process` the method `run()` uses a default timeout of 60 seconds. Sometimes this value is too low. 

In #146 we discussed just to set a higher timeout value.