### PR TITLE
Change output for cloning repository

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -77,7 +77,7 @@ task('deploy:release', function () {
  */
 task('deploy:update_code', function () {
     $repository = get('repository');
-    run("git clone --recursive -q $repository {release_path}");
+    run("git clone --recursive -q $repository {release_path} 2>&1");
     run("chmod -R g+w {release_path}");
 })->desc('Updating code');
 


### PR DESCRIPTION
Changed output when cloning repository, because of initialization of submodule. Git always output some text, and this is actually considered as error. Update provide possibility to deploy repository with submodules.