### PR TITLE
Added host() and port() to Builder

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -44,6 +44,28 @@ class Builder
     }
 
     /**
+     * Define server host
+     * @param int $host
+     * @return $this
+     */
+    public function host($host)
+    {
+        $this->config->setHost($host);
+        return $this;
+    }
+
+    /**
+     * Define server port
+     * @param int $port
+     * @return $this
+     */
+    public function port($port)
+    {
+        $this->config->setPort($port);
+        return $this;
+    }
+
+    /**
      * If you use an ssh config file you can user it.
      * @param string $file Config file path
      * @return $this

--- a/src/functions.php
+++ b/src/functions.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @param int $port
  * @return Builder
  */
-function server($name, $domain, $port = 22)
+function server($name, $domain = null, $port = 22)
 {
     $deployer = Deployer::get();
 

--- a/test/src/Server/BuilderTest.php
+++ b/test/src/Server/BuilderTest.php
@@ -30,6 +30,24 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $b->user('user', 'password');
     }
 
+    public function testHostAndPort()
+    {
+        $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();
+        $config->expects($this->once())
+            ->method('setHost')
+            ->with('localhost')
+            ->will($this->returnSelf());
+        $config->expects($this->once())
+            ->method('setPort')
+            ->with(22)
+            ->will($this->returnSelf());
+        $env = $this->getMock('Deployer\Server\Environment');
+
+        $b = new Builder($config, $env);
+        $b->host('localhost');
+        $b->port(22);
+    }
+
     public function testConfig()
     {
         $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This is just a proposal because i prefer more fluent like that:

```php
server('name')
    ->host('ec2-52-171-208-37.my-server.com')
    ->port('9876')
    ->path('/home/dir/dir')
    ->user('user')
    ->pubKey('~/.ssh/name.pub', '~/.ssh/name');
```

instead of:

```php
server('name', 'ec2-52-171-208-37.my-server.com', '9876')
    ->path('/home/dir/dir')
    ->user('user')
    ->pubKey('~/.ssh/name.pub', '~/.ssh/name');
```