### PR TITLE
Implement SSH Agent Forwarding Feature

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -80,6 +80,17 @@ class Builder
         $this->config->setPemFile($pemFile);
         return $this;
     }
+    
+    /**
+     * Using forward agent to authentication
+     * 
+     * @return \Deployer\Server\Builder
+     */
+    public function forwardAgent()
+    {
+        $this->config->setAuthenticationMethod(Configuration::AUTH_BY_AGENT);
+        return $this;
+    }
 
     /**
      * @param string $name

--- a/src/Server/Configuration.php
+++ b/src/Server/Configuration.php
@@ -16,6 +16,8 @@ class Configuration
     const AUTH_BY_PUBLIC_KEY = 2;
 
     const AUTH_BY_PEM_FILE = 3;
+    
+    const AUTH_BY_AGENT = 4;
 
     /**
      * Type of authentication.

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -11,6 +11,7 @@ use Deployer\Server\Configuration;
 use Deployer\Server\ServerInterface;
 use phpseclib\Crypt\RSA;
 use phpseclib\Net\SFTP;
+use \phpseclib\System\SSH\Agent;
 
 class PhpSecLib implements ServerInterface
 {
@@ -71,6 +72,13 @@ class PhpSecLib implements ServerInterface
 
                 break;
 
+            case Configuration::AUTH_BY_AGENT:
+                
+                $key = new Agent();
+                $this->sftp->login($serverConfig->getUser(), $key);
+                
+                break;
+            
             default:
                 throw new \RuntimeException('You need to specify authentication method.');
         }

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -11,8 +11,8 @@ use Deployer\Server\Configuration;
 use Deployer\Server\ServerInterface;
 use phpseclib\Crypt\RSA;
 use phpseclib\Net\SFTP;
+use phpseclib\System\SSH\Agent;
 use RuntimeException;
-use \phpseclib\System\SSH\Agent;
 
 class PhpSecLib implements ServerInterface
 {
@@ -76,7 +76,7 @@ class PhpSecLib implements ServerInterface
             case Configuration::AUTH_BY_AGENT:
                 
                 $key = new Agent();
-                $this->sftp->login($serverConfig->getUser(), $key);
+                $result = $this->sftp->login($serverConfig->getUser(), $key);
                 
                 break;
             

--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -81,6 +81,10 @@ class SshExtension implements ServerInterface
             case Configuration::AUTH_BY_PEM_FILE:
 
                 throw new \RuntimeException('If you want to use pem file, switch to using PhpSecLib.');
+                
+            case Configuration::AUTH_BY_AGENT:
+
+                throw new \RuntimeException('If you want to use forward agent function, switch to using PhpSecLib.');
 
             default:
                 throw new \RuntimeException('You need to specify authentication method.');

--- a/test/src/Server/BuilderTest.php
+++ b/test/src/Server/BuilderTest.php
@@ -101,4 +101,17 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $b = new Builder($config, $env);
         $b->env('name', 'value');
     }
+    
+    public function testForwardAgent()
+    {
+        $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();
+        $config->expects($this->once())
+            ->method('setAuthenticationMethod')
+            ->with(Configuration::AUTH_BY_AGENT)
+            ->will($this->returnSelf());
+        $env = $this->getMock('Deployer\Server\Environment');
+
+        $b = new Builder($config, $env);
+        $b->forwardAgent();
+    }
 }


### PR DESCRIPTION
This pull request includes:
- Implement [SSH Agent Forwarding Feature #134 ](https://github.com/deployphp/deployer/issues/134)
- Unit test for `Builder::forwardAgent()` method   

How to use?
```php
<?php 
// file: deployer.php
server('deployer', 'domain.com', 22)
    ->forwardAgent();

```