### PR TITLE
Add cd (change directory) and within (run commands within a directory and revert to the previous workingPath)

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -141,6 +141,40 @@ function after($it, $that)
 }
 
 /**
+ * Change the current working directory.
+ *
+ * @param string $path
+ */
+function cd($path)
+{
+    env('working_path', $path);
+}
+
+/**
+ * Execute a callback within a specific directory and revert back to the initial working directory.
+ *
+ * @param string $path
+ * @param callable $callback
+ */
+function within($path, $callback)
+{
+    $lastWorkingPath = workingPath();
+    env()->set('working_path', $path);
+    $callback();
+    env()->set('working_path', $lastWorkingPath);
+}
+
+/**
+ * Return the current working path.
+ *
+ * @return string
+ */
+function workingPath()
+{
+    return env()->get('working_path', env()->get(Environment::DEPLOY_PATH));
+}
+
+/**
  * Run command on server.
  *
  * @param string $command
@@ -149,7 +183,10 @@ function after($it, $that)
 function run($command)
 {
     $server = Context::get()->getServer();
-    $command = Context::get()->getEnvironment()->parse($command);
+    $command = env()->parse($command);
+    $workingPath = workingPath();
+
+    $command = "cd $workingPath && $command";
 
     if (isVeryVerbose()) {
         writeln("<comment>Run</comment>: $command");


### PR DESCRIPTION
Here's my take on the `cd` function. I've also added a `within` function which allows the user to provide a callback:

```php
<?php

task('test', function() {
	cd('my_dir');
	within('{some_dir}', function() {
		run('some command');
	});
	// back in my_dir
});
```

After the `within` function is called, the environment is reverted to the previous working path.

This current implementation only support going to an absolute path. We may consider changing the implementation to support relative navigation if that is something people would want (I don't think that is the case though).

Reference: #177.