### PR TITLE
Possible override of runLocally task with timeout parameter optional.

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -207,12 +207,14 @@ function run($command)
 /**
  * Execute commands on local machine.
  * @param string $command Command to run locally.
+ * @param int $timeout (optional) Override process command timeout in seconds.
  * @return string Output of command.
  * @throws \RuntimeException
  */
-function runLocally($command)
+function runLocally($command, $timeout=60)
 {
     $process = new Symfony\Component\Process\Process($command);
+	$process->setTimeout( $timeout );
     $process->run();
 
     if (!$process->isSuccessful()) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -211,10 +211,10 @@ function run($command)
  * @return string Output of command.
  * @throws \RuntimeException
  */
-function runLocally($command, $timeout=60)
+function runLocally($command, $timeout = 60 )
 {
     $process = new Symfony\Component\Process\Process($command);
-	$process->setTimeout( $timeout );
+    $process->setTimeout( $timeout );
     $process->run();
 
     if (!$process->isSuccessful()) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -211,7 +211,7 @@ function run($command)
  * @return string Output of command.
  * @throws \RuntimeException
  */
-function runLocally($command, $timeout = 60 )
+function runLocally($command, $timeout = 60)
 {
     $process = new Symfony\Component\Process\Process($command);
     $process->setTimeout( $timeout );

--- a/src/functions.php
+++ b/src/functions.php
@@ -214,7 +214,7 @@ function run($command)
 function runLocally($command, $timeout = 60)
 {
     $process = new Symfony\Component\Process\Process($command);
-    $process->setTimeout( $timeout );
+    $process->setTimeout($timeout);
     $process->run();
 
     if (!$process->isSuccessful()) {


### PR DESCRIPTION
Regarding issue with timeout running local tasks that requires long execution.
This is a fix that allows the command to be attached with a timeout parameter optionally.