### PR TITLE
Parse the target path given to cd to prevent recursive loop.

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -105,9 +105,9 @@ task('deploy:update_code', function () {
     } else if (!empty($branch)) {
         $at = "-b $branch";
     }
-    
+
     run("git clone $at --depth 1 --recursive -q $repository {release_path} 2>&1");
-    
+
 })->desc('Updating code');
 
 
@@ -155,14 +155,14 @@ task('deploy:writable', function () {
 
         $httpUser = run("ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1")->toString();
 
-        cd(env('release_path'));
+        cd('{release_path}');
 
         if (strpos(run("chmod 2>&1; true"), '+a') !== false) {
 
             if (!empty($httpUser)) {
                 run("$sudo chmod +a \"$httpUser allow delete,write,append,file_inherit,directory_inherit\" $dirs");
             }
-            
+
             run("$sudo chmod +a \"`whoami` allow delete,write,append,file_inherit,directory_inherit\" $dirs");
 
         } elseif (commandExist('setfacl')) {
@@ -171,7 +171,7 @@ task('deploy:writable', function () {
                 run("$sudo setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
                 run("$sudo setfacl -dR -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
             } else {
-                run("$sudo chmod 777 $dirs");    
+                run("$sudo chmod 777 $dirs");
             }
 
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -173,7 +173,7 @@ function option($name, $shortcut = null, $mode = null, $description = '', $defau
  */
 function cd($path)
 {
-    env('working_path', $path);
+    env('working_path', env()->parse($path));
 }
 
 /**


### PR DESCRIPTION
If cd was given {release_path} as target path, it would attempt to run a command to figure out what the value of {release_path} is, which, in the process, would also want to know the value of {release_path} and so on.

The fix simply parses the value as it is given, thus making the result static instead of a closure.