### PR TITLE
Check the exit status of the command instead of stderr

### DIFF
--- a/src/Server/PhpSecLib.php
+++ b/src/Server/PhpSecLib.php
@@ -85,7 +85,7 @@ class PhpSecLib extends AbstractServer
 
         $result = $this->sftp->exec($command);
 
-        if ($this->sftp->getStdError()) {
+        if ($this->sftp->getExitStatus() !== 0) {
             throw new \RuntimeException($this->sftp->getStdError());
         }
 


### PR DESCRIPTION
Composer now outputs non-error messages to stderr. The `run` function should be check the exit status of the command, not the error output.