### PR TITLE
Return $result if getStdError() returns an empty string.

### DIFF
--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -74,12 +74,12 @@ class PhpSecLib implements ServerInterface
                 break;
 
             case Configuration::AUTH_BY_AGENT:
-                
+
                 $key = new Agent();
                 $result = $this->sftp->login($serverConfig->getUser(), $key);
-                
+
                 break;
-            
+
             default:
                 throw new RuntimeException('You need to specify authentication method.');
         }
@@ -109,7 +109,8 @@ class PhpSecLib implements ServerInterface
         $result = $this->sftp->exec($command);
 
         if ($this->sftp->getExitStatus() !== 0) {
-            throw new \RuntimeException($this->sftp->getStdError());
+            $output = $this->sftp->getStdError() ?: $result;
+            throw new \RuntimeException($output);
         }
 
         return $result;


### PR DESCRIPTION
This is done to support applications which return a non-zero exit status but do not output error messages to stderr.