### PR TITLE
Change syntax for env vars

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -36,16 +36,16 @@ env('env', 'prod');
  */
 task('deploy:create_cache_dir', function () {
     // Set cache dir
-    env('cache_dir', '{release_path}/app/cache');
+    env('cache_dir', '{{release_path}}/app/cache');
 
     // Remove cache dir if it exist
-    run('if [ -d "{cache_dir}" ]; then rm -rf {cache_dir}; fi');
+    run('if [ -d "{{cache_dir}}" ]; then rm -rf {{cache_dir}}; fi');
 
     // Create cache dir
-    run('mkdir -p {cache_dir}');
+    run('mkdir -p {{cache_dir}}');
 
     // Set rights
-    run("chmod -R g+w {cache_dir}");
+    run("chmod -R g+w {{cache_dir}}");
 })->desc('Create cache dir');
 
 
@@ -54,7 +54,7 @@ task('deploy:create_cache_dir', function () {
  */
 task('deploy:assets', function () {
     $assets = implode(' ', array_map(function ($asset) {
-        return "{release_path}/$asset";
+        return "{{release_path}}/$asset";
     }, get('assets')));
 
     $time = date('Ymdhi.s');
@@ -68,7 +68,7 @@ task('deploy:assets', function () {
  */
 task('deploy:assetic:dump', function () {
 
-    run("php {release_path}/app/console assetic:dump --env={env} --no-debug");
+    run("php {{release_path}}/app/console assetic:dump --env={{env}} --no-debug");
 
 })->desc('Dump assets');
 
@@ -78,7 +78,7 @@ task('deploy:assetic:dump', function () {
  */
 task('deploy:cache:warmup', function () {
 
-    run('php {release_path}/app/console cache:warmup  --env={env} --no-debug');
+    run('php {{release_path}}/app/console cache:warmup  --env={{env}} --no-debug');
 
 })->desc('Warm up cache');
 
@@ -88,7 +88,7 @@ task('deploy:cache:warmup', function () {
  */
 task('database:migrate', function () {
 
-    run("php {release_path}/app/console doctrine:migrations:migrate --env={env} --no-debug --no-interaction");
+    run("php {{release_path}}/app/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction");
 
 })->desc('Migrate database');
 
@@ -98,7 +98,7 @@ task('database:migrate', function () {
  */
 task('deploy:clear_controllers', function () {
 
-    run("rm -f {release_path}/web/app_*.php");
+    run("rm -f {{release_path}}/web/app_*.php");
 
 })->setPrivate();
 

--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -88,13 +88,21 @@ class Environment
     public function parse($value)
     {
         if (is_string($value)) {
-            if (preg_match_all('/\{(.+?)\}/', $value, $matches)) {
-                foreach ($matches[1] as $name) {
-                    $value = str_replace('{' . $name . '}', $this->get($name), $value);
-                }
-            }
+            $value = preg_replace_callback('/\{\{\s*(\w+)\s*\}\}/', [$this, 'parseCallback'], $value);
         }
 
         return $value;
     }
+
+    /**
+     * Replace env values callback for parse
+     *
+     * @param array $matches
+     * @return mixed
+     */
+    private function parseCallback($matches)
+    {
+        return isset($matches[1]) ? $this->get($matches[1]) : null;
+    }
+
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -456,7 +456,7 @@ function isDebug()
 
 /**
  * Return current server env or set default values or get env value.
- * When set env value you can write over values line "{name}".
+ * When set env value you can write over values line "{{name}}".
  *
  * @param string|null $name
  * @param mixed $value

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -20,7 +20,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $env->set('int', 42);
         $env->set('string', 'value');
         $env->set('array', [1, 'two']);
-        $env->set('parse', 'is {int}');
+        $env->set('parse', 'is {{int}}');
         
         $this->assertEquals(42, $env->get('int'));
         $this->assertEquals('value', $env->get('string'));


### PR DESCRIPTION
In this Pull request, I will implement feature of issue #211 
Change syntax for env vars to {{ ... }} and support allow whitespaces ( {{deploy_path}} and {{ deploy_path }} return same value).

Sorry by create other pull request.
This pull request is rebase of PR #218 