### PR TITLE
Atomic symlink swap

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -208,8 +208,7 @@ task('deploy:vendors', function () {
  */
 task('deploy:symlink', function () {
 
-    run("cd {deploy_path} && ln -sfn {release_path} current"); // `mv -f release current` does not work =(
-    run("cd {deploy_path} && rm release");
+    run("cd {deploy_path} && mv -Tf release current");
 
 })->desc('Creating symlink to release');
 


### PR DESCRIPTION
Creating symlink to release, the symlink swap is now a **non-atomic** operation.
To use "ln -fsn" is not bad, good enough. But '-n' option is non-standard and so is not recommended. Above all, it's not sure "ln -f" is atomic.
It's sure "mv" is an **atomic** operation.
**"mv -Tf"** - with '-T' option - may be the best bet.
