### PR TITLE
Change specific requirement for env vars

### DIFF
--- a/src/Type/DotArray.php
+++ b/src/Type/DotArray.php
@@ -1,0 +1,166 @@
+<?php
+/* (c) Anton Medvedev <anton@elfet.ru>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Type;
+
+/**
+ * DotArray
+ * Allow access $array['abc.xyz'] same $array['abc']['xyz']
+ *
+ * Thank Glynn Forrest with https://github.com/glynnforrest/Crutches
+ *
+ * @author OanhNN <oanhnn@rikkeisoft.com>
+ * @version 1.0
+ */
+class DotArray implements \ArrayAccess
+{
+
+    /**
+     * Storage array
+     *
+     * @var array
+     */
+    protected $array = [];
+
+    /**
+     * Validate key
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function validateKey($key)
+    {
+        return (bool) preg_match('/^(\w|\.)+$/', $key);
+    }
+
+    /**
+     * Check has key
+     *
+     * @param string $key
+     * @return bool
+     * @throws \RuntimeException
+     */
+    public function hasKey($key)
+    {
+        if (!$this->validateKey($key)) {
+            throw new \RuntimeException("Key `$key` is invalid");
+        }
+
+        $parts = explode('.', $key);
+        $scope = &$this->array;
+        $count = count($parts) - 1;
+        for ($i = 0; $i < $count; $i++) {
+            if (!isset($scope[$parts[$i]])) {
+                return false;
+            }
+            $scope = &$scope[$parts[$i]];
+        }
+        
+        return array_key_exists($parts[$i], $scope);
+    }
+
+    /**
+     * Get all value as array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->array;
+    }
+
+    /**
+     * Check exist key . Like isset(), a value of null is considered not set.
+     * isset($array['abc.xyz']) same isset($array['abc']['xyz'])
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return null !== $this->offsetGet($key);
+    }
+
+    /**
+     * Get an array value
+     * $array['abc.xyz'] same $array['abc']['xyz']
+     *
+     * @param string $key
+     * @return mixed NULL will be returned if the key is not found.
+     * @throws \RuntimeException
+     */
+    public function offsetGet($key)
+    {
+        if (!$this->validateKey($key)) {
+            throw new \RuntimeException("Key `$key` is invalid");
+        }
+
+        $parts = explode('.', $key);
+        $scope = &$this->array;
+        $count = count($parts) - 1;
+        for ($i = 0; $i < $count; $i++) {
+            if (!isset($scope[$parts[$i]])) {
+                return null;
+            }
+            $scope = &$scope[$parts[$i]];
+        }
+        
+        return isset($scope[$parts[$i]]) ? $scope[$parts[$i]] : null;
+    }
+
+    /**
+     * Set an array value
+     * $array['abc.xyz'] = 'value' same $array['abc']['xyz'] = 'value'
+     *
+     * @param string $key
+     * @param mixed $value
+     * @throws \RuntimeException
+     */
+    public function offsetSet($key, $value)
+    {
+        if (!$this->validateKey($key)) {
+            throw new \RuntimeException("Key `$key` is invalid");
+        }
+
+        $parts = explode('.', $key);
+        //loop through each part, create it if not present.
+        $scope = &$this->array;
+        $count = count($parts) - 1;
+        for ($i = 0; $i < $count; $i++) {
+            if (!isset($scope[$parts[$i]])) {
+                $scope[$parts[$i]] = [];
+            }
+            $scope = &$scope[$parts[$i]];
+        }
+        $scope[$parts[$i]] = $value;
+    }
+
+    /**
+     * Unset an array value
+     * unset($array['abc.xyz']) same unset($array['abc']['xyz'])
+     * 
+     * @param string $key
+     */
+    public function offsetUnset($key)
+    {
+        if (!$this->validateKey($key)) {
+            throw new \RuntimeException("Key `$key` is invalid");
+        }
+
+        $parts = explode('.', $key);
+        $scope = &$this->array;
+        $count = count($parts) - 1;
+        for ($i = 0; $i < $count; $i++) {
+            if (!isset($scope[$parts[$i]])) {
+                return;
+            }
+            $scope = &$scope[$parts[$i]];
+        }
+        unset($scope[$parts[$i]]);
+    }
+
+}

--- a/test/src/Type/DotArrayTest.php
+++ b/test/src/Type/DotArrayTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/* (c) Anton Medvedev <anton@elfet.ru>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Type;
+
+use Deployer\Type\DotArray;
+
+/**
+ * DotArrayTest class
+ * 
+ * @author OanhNN <oanhnn@rikkeisoft.com>
+ * @version 1.0
+ */
+class DotArrayTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testDotArray()
+    {
+        $array     = [
+            'abc1'      => [
+                'xyz1' => 1,
+                'xyz2' => [1, 2, 3],
+            ],
+            'abc2.xyz1' => 2,
+            'abc2.xyz2' => [4, 5, 6],
+            'callable'  => function() {
+            echo 'hello world';
+        },
+            'abc.null' => null,
+        ];
+
+        $dotArray = new DotArray();
+        foreach ($array as $key => $value) {
+            $dotArray[$key] = $value;
+        }
+
+        foreach ($array as $key => $value) {
+            $this->assertSame($value, $dotArray[$key]);
+        }
+
+        $this->assertSame(isset($array['abc9.xyz']), isset($dotArray['abc9.xyz']));
+        $this->assertSame(isset($array['abc1']['xyz1']), isset($dotArray['abc1.xyz1']));
+        
+        $this->assertSame($dotArray['abc1']['xyz1'], $dotArray['abc1.xyz1']);
+        $this->assertSame($array['abc2.xyz1'], $dotArray['abc2']['xyz1']);
+
+        $this->assertSame(false, $dotArray->hasKey('abc1.null'));
+        $this->assertSame(true, $dotArray->hasKey('abc1.xyz2'));
+        $this->assertSame(true, $dotArray->hasKey('abc.null'));
+        
+        $this->assertSame(false, isset($dotArray['abc.null']));
+        $this->assertSame(false, isset($dotArray['abc']['null']));
+
+        $this->assertSame(['xyz1' => 2, 'xyz2' => [4, 5, 6]], $dotArray['abc2']);
+        
+        unset($dotArray['abc.null']);
+        $this->assertSame(false, isset($dotArray['abc']['null']));
+        $this->assertSame(false, $dotArray->hasKey('abc.null'));
+        
+        unset($dotArray['abc2']);
+        $this->assertSame(false, isset($dotArray['abc2']['xyz1']));
+        $this->assertSame(false, $dotArray->hasKey('abc2.xyz1'));
+    }
+
+}


### PR DESCRIPTION
In this PR: Change specific requirement for environment variables follow the discussion in #218 

1. Environment variable name will be checked and only allow a-z, A-Z, 0-9, underscore character ( `_` ) and dot character ( `.` ) .

2. If variable name having a dot character, variables could be used in the future to be a property of an array (`env()->set()`, `env()->get()`, `Environment::setDefault()`, `Environment::getDefault()` are implemented).
   ```php
env('abc.xyz', [1, 2, 3]);
var_export(env('abc'));
// output:
// array(
//     'xyz' => array(1, 2, 3)
// )
```

3. Environment variable parser for run command support below case:
```
{{ abcxyz }}  --> $env['abcxyz']
{{ abc_xyz }} --> $env['abc_xyz']
{{ abc.xyz }} --> $env['abc']['xyz']
```