### PR TITLE
Fix restore working path after task deploy:writable

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -158,6 +158,7 @@ task('deploy:writable', function () {
     if (!empty($dirs)) {
 
         $httpUser = run("ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1")->toString();
+        $lastWorkingPath = workingPath();
 
         cd('{{release_path}}');
 
@@ -182,6 +183,8 @@ task('deploy:writable', function () {
         } else {
             run("$sudo chmod 777 $dirs");
         }
+        // restore working path
+        cd($lastWorkingPath);
     }
 
 })->desc('Make writable dirs');


### PR DESCRIPTION
After task `deploy:writable`, we should restore working path.