### PR TITLE
Added simple check if the shell on remote server is POSIX-compliant.

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -54,6 +54,15 @@ task('rollback', function () {
  * Preparing server for deployment.
  */
 task('deploy:prepare', function () {
+    // Simple IF to check if shell is POSIX-compliant
+   try {
+       run('if [ ! -d {{deploy_path}} ]; then echo ""; fi');
+   }
+   catch(\RuntimeException $e){
+       throw new \RuntimeException('Shell on your server is not POSIX-compliant. Please change to sh, bash or similar. '
+           .PHP_EOL.'Usually, you can change your shell to bash by running: chsh -s /bin/bash');
+   }
+
     // Create releases dir.
     run("cd {{deploy_path}} && if [ ! -d releases ]; then mkdir releases; fi");
 


### PR DESCRIPTION
As described in issue #248 - the commands for deployment can fail with mysterious errors when remote server is running a non-POSIX shell (like tcsh, common on BSD systems). 
Added a simple check with expression - if it fails, user will see more friendly message explaining to switch to sh/bash/similar.