### PR TITLE
Added some modifications into the global functions, and fixed a spelling mistake

### DIFF
--- a/build
+++ b/build
@@ -64,4 +64,4 @@ $phar->setStub($stub);
 $phar->stopBuffering();
 unset($phar);
 
-echo "$pharName created successful.\n";
+echo "$pharName was created successfully.\n";

--- a/src/functions.php
+++ b/src/functions.php
@@ -425,6 +425,15 @@ function get($key)
 }
 
 /**
+ * @param string $key
+ * @return boolean
+ */
+function has($key)
+{
+    return Deployer::get()->parameters->has($key);
+}
+
+/**
  * @param string $message
  * @param string|null $default
  * @return string

--- a/src/functions.php
+++ b/src/functions.php
@@ -51,10 +51,6 @@ function server($name, $host = null, $port = 22)
     $deployer->servers->set($name, $server);
     $deployer->environments->set($name, $env);
 
-    // Setting environment variables about the server automatically
-    $env->set('name', $name);
-    $env->set('host', $host);
-
     return new Builder($config, $env);
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -35,12 +35,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @param int $port
  * @return Builder
  */
-function server($name, $domain = null, $port = 22)
+function server($name, $host = null, $port = 22)
 {
     $deployer = Deployer::get();
 
     $env = new Environment();
-    $config = new Configuration($name, $domain, $port);
+    $config = new Configuration($name, $host, $port);
 
     if ($deployer->parameters->has('ssh_type') && $deployer->parameters->get('ssh_type') === 'ext-ssh2') {
         $server = new Remote\SshExtension($config);
@@ -50,6 +50,10 @@ function server($name, $domain = null, $port = 22)
 
     $deployer->servers->set($name, $server);
     $deployer->environments->set($name, $env);
+
+    // Setting environment variables about the server automatically
+    $env->set('name', $server);
+    $env->set('host', $host);
 
     return new Builder($config, $env);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -52,7 +52,7 @@ function server($name, $host = null, $port = 22)
     $deployer->environments->set($name, $env);
 
     // Setting environment variables about the server automatically
-    $env->set('name', $server);
+    $env->set('name', $name);
     $env->set('host', $host);
 
     return new Builder($config, $env);

--- a/src/functions.php
+++ b/src/functions.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @param string $name
- * @param string|null $domain
+ * @param string|null $host
  * @param int $port
  * @return Builder
  */


### PR DESCRIPTION
 - Fixed the success sentence, which was outputted when a new phar build was finished,
 - Added automatic environment variable registration to the `server` function ("host" and "name" variables),
 - Added a `has` function, so that the existence of a parameter can be checked.

I'm awaiting your opinions.