### PR TITLE
Automatic registration of server env vars

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -28,11 +28,11 @@ class Builder
         $this->config = $config;
         $this->env = $env;
 
-        $env->set('server', [
+        $env->setAsProtected('server', [
             'name' => $config->getName(),
             'host' => $config->getHost(),
             'port' => $config->getPort(),
-        ], true);
+        ]);
     }
 
     /**

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -27,6 +27,12 @@ class Builder
     {
         $this->config = $config;
         $this->env = $env;
+
+        $env->set('server', [
+            'name' => $config->getName(),
+            'host' => $config->getHost(),
+            'port' => $config->getPort(),
+        ]);
     }
 
     /**
@@ -110,10 +116,10 @@ class Builder
         $this->config->setPemFile($pemFile);
         return $this;
     }
-    
+
     /**
      * Using forward agent to authentication
-     * 
+     *
      * @return $this
      */
     public function forwardAgent()

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -32,7 +32,7 @@ class Builder
             'name' => $config->getName(),
             'host' => $config->getHost(),
             'port' => $config->getPort(),
-        ]);
+        ], true);
     }
 
     /**

--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -25,7 +25,14 @@ class Environment
      * @var \Deployer\Type\DotArray
      */
     private $values = null;
-    
+
+    /**
+     * Values represented by their keys here are protected, and cannot be
+     * changed by calling the `set` method.
+     * @var array
+     */
+    private $protectedValueKeys = [];
+
     /**
      * Constructor
      */
@@ -37,10 +44,19 @@ class Environment
     /**
      * @param string $name
      * @param bool|int|string|array $value
+     * @param bool $isProtected
      */
-    public function set($name, $value)
+    public function set($name, $value, $isProtected = false)
     {
+        if (in_array($name, $this->protectedValueKeys)) {
+            throw new \RuntimeException("The environment parameter `$name` has already been set, and is protected from changes.");
+        }
+
         $this->values[$name] = $value;
+
+        if ($isProtected === true) {
+            $this->protectedValueKeys[] = $name;
+        }
     }
 
     /**

--- a/test/src/Server/BuilderTest.php
+++ b/test/src/Server/BuilderTest.php
@@ -112,7 +112,31 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();
         $env = $this->getMock('Deployer\Server\Environment');
-        $env->expects($this->once())
+
+        // Configuring stubs
+        $config
+            ->method('getName')
+            ->will($this->returnValue('test-name'));
+        $config
+            ->method('getHost')
+            ->will($this->returnValue('test-host'));
+        $config
+            ->method('getPort')
+            ->will($this->returnValue(22));
+
+        // The Builder class should create the server env variable.
+        $env->expects($this->at(0))
+            ->method('set')
+            ->with('server', [
+                'name' => 'test-name',
+                'host' => 'test-host',
+                'port' => 22,
+            ])
+            ->will($this->returnSelf());
+
+        // The `env` method of the Builder class should internally call the
+        // Environment's `set` method.
+        $env->expects($this->at(1))
             ->method('set')
             ->with('name', 'value')
             ->will($this->returnSelf());
@@ -120,7 +144,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $b = new Builder($config, $env);
         $b->env('name', 'value');
     }
-    
+
     public function testForwardAgent()
     {
         $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -4,7 +4,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace Deployer\Server;
 
 class EnvironmentTest extends \PHPUnit_Framework_TestCase
@@ -30,7 +30,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $env->set('string', 'value');
         $env->set('array', [1, 'two']);
         $env->set('parse', 'is {{int}}');
-        
+
         $this->assertEquals(42, $env->get('int'));
         $this->assertEquals('value', $env->get('string'));
         $this->assertEquals([1, 'two'], $env->get('array'));
@@ -44,5 +44,15 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('RuntimeException', 'Environment parameter `so` does not exists.');
         $env->get('so');
+    }
+
+    public function testProtectedParameters()
+    {
+        $env = new Environment();
+
+        $env->set('protected', 'protected-value', true);
+
+        $this->setExpectedException('\RuntimeException', 'The environment parameter `protected` has already been set, and is protected from changes.');
+        $env->set('protected', 'some-other-value');
     }
 }


### PR DESCRIPTION
I implemented the solution we aggreed upon in issue #270.
The problem is, that it breaks an existing test, and I can't figure out why.

Can someone help me out with this?
(If this issue is resolved I'll add tests for the new functionality too.)

Here's the output of phpunit:

```bash
PHPUnit 4.6.6 by Sebastian Bergmann and contributors.

Configuration read from /home/zeecoder/work/deployer/phpunit.xml

............................................F.................... 65 / 74 ( 87%)
.........

Time: 2.13 seconds, Memory: 12.75Mb

There was 1 failure:

1) Deployer\Server\BuilderTest::testEnv
Expectation failed for method name is equal to <string:set> when invoked 1 time(s)
Parameter 0 for invocation Deployer\Server\Environment::set('server', Array (...)) does not match expected value.
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'name'
+'server'

/home/zeecoder/work/deployer/src/Server/Builder.php:36
/home/zeecoder/work/deployer/test/src/Server/BuilderTest.php:120
/usr/share/php/PHPUnit/TextUI/Command.php:186
/usr/share/php/PHPUnit/TextUI/Command.php:138

FAILURES!
Tests: 74, Assertions: 208, Failures: 1.
```