### PR TITLE
Added the possibility of 'protected' env parameters. (+test).

### DIFF
--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -25,7 +25,14 @@ class Environment
      * @var \Deployer\Type\DotArray
      */
     private $values = null;
-    
+
+    /**
+     * Values represented by their keys here are protected, and cannot be
+     * changed by calling the `set` method.
+     * @var array
+     */
+    private $protectedValueKeys = [];
+
     /**
      * Constructor
      */
@@ -37,10 +44,19 @@ class Environment
     /**
      * @param string $name
      * @param bool|int|string|array $value
+     * @param bool $isProtected
      */
-    public function set($name, $value)
+    public function set($name, $value, $isProtected = false)
     {
+        if (in_array($name, $this->protectedValueKeys)) {
+            throw new \RuntimeException("The environment parameter `$name` has already been set, and is protected from changes.");
+        }
+
         $this->values[$name] = $value;
+
+        if ($isProtected === true) {
+            $this->protectedValueKeys[] = $name;
+        }
     }
 
     /**

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -4,7 +4,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace Deployer\Server;
 
 class EnvironmentTest extends \PHPUnit_Framework_TestCase
@@ -30,7 +30,7 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $env->set('string', 'value');
         $env->set('array', [1, 'two']);
         $env->set('parse', 'is {{int}}');
-        
+
         $this->assertEquals(42, $env->get('int'));
         $this->assertEquals('value', $env->get('string'));
         $this->assertEquals([1, 'two'], $env->get('array'));
@@ -44,5 +44,15 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('RuntimeException', 'Environment parameter `so` does not exists.');
         $env->get('so');
+    }
+
+    public function testProtectedParameters()
+    {
+        $env = new Environment();
+
+        $env->set('protected', 'protected-value', true);
+
+        $this->setExpectedException('\RuntimeException', 'The environment parameter `protected` has already been set, and is protected from changes.');
+        $env->set('protected', 'some-other-value');
     }
 }


### PR DESCRIPTION
We didn't talk about this, but I think this feature is a natural addition.

Basic env parameters - especially ones that could be mentioned in the docs - should be protected from future changes, since many 3rd party and custom tasks can rely on these values.

Consider the env parameters set by the Builder (#272).
If a 3rd party task later desides to set the "server" env var, there's nothing to stop him in doing so.

Now if a developer just include that task in his deployment process without digging in the code and checking every detail, it can cause side-effects, since after that task runs, any following task that relies on the "server" env var will fail in some way.

At this point, the developer can easily misjudge the situation and believe that the depoyer code itself is buggy, while in reality the 3rd party task is the one causing unwanted side-effects.

If this pull request gets accepted, I'll create another one, which sets the aforementioned "server" env parameter as protected.