### PR TITLE
Created a file .php_cs with default header comment.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,42 @@
+<?php
+
+use Symfony\CS\Config\Config;
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Finder\DefaultFinder;
+use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
+
+
+$header = <<<EOF
+(c) Anton Medvedev <anton@elfet.ru>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+EOF;
+
+HeaderCommentFixer::setHeader($header);
+
+$finder = DefaultFinder::create()
+    ->notName('LICENSE')
+    ->notName('README.md')
+    ->notName('UPGRADE.md')
+    ->notName('phpunit.xml*')
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+return Config::create()
+    ->fixers(array(
+//        '-yoda_conditions',
+        'align_double_arrow',
+        'header_comment',
+        'multiline_spaces_before_semicolon',
+        'no_blank_lines_before_namespace',
+        'ordered_use',
+//        'phpdoc_order',
+//        'phpdoc_var_to_type',
+//        'strict',
+//        'strict_param',
+//        'short_array_syntax',
+    ))
+    ->level(FixerInterface::SYMFONY_LEVEL)
+    ->setUsingCache(false)
+    ->finder($finder);


### PR DESCRIPTION
Before commit, we can run ``php-cs-fixer fix .`` and normalize all files of the project.
This can help on changes on header comment, doing this only in .php_cs.

Some fixers are commented because they need evaluation and testing to validate if not alter application behavior.

After accepted the PR, just run ``php-cs-fixer fix .`` on project root.