### PR TITLE
Fix bug of pull request #276: add feature protected env params

### DIFF
--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -71,20 +71,15 @@ class Environment
      */
     private function checkIfNameIsProtected($name)
     {
-        $nameArray = strpos($name, '.') !== false ? explode('.', $name) : [$name];
-
-        // Checks every level for protection
-        foreach ($nameArray as $subName) {
-            $dotName = !isset($dotName) ? $subName : "$dotName.$subName";
-            if (in_array($dotName, $this->protectedNames)) {
-                throw new \RuntimeException("The parameter `$name` cannot be set, because " . ($name === $dotName ? "it's" : "`$dotName` is" ) . " protected.");
-            }
-        }
-
-        // Even if not one of $name's levels is protected, protected env params
-        // under it could still exist, so let's check for those too.
+        $length = strlen($name);
+        
         foreach ($this->protectedNames as $protectedName) {
-            if (strpos($protectedName, $name) !== false) {
+            $len = strlen($protectedName);
+            if ($name === $protectedName) {
+                throw new \RuntimeException("The parameter `$name` cannot be set, because it's protected.");
+            } elseif ($len < $length && '.' === $name[$len] && 0 === strpos($name, $protectedName)) {
+                throw new \RuntimeException("The parameter `$name` cannot be set, because `$protectedName` is protected.");
+            } elseif ($len > $length && '.' === $protectedName[$length] && 0 === strpos($protectedName, $name)) {
                 throw new \RuntimeException("The parameter `$name` could not be set, because a protected parameter named `$protectedName` already exists.");
             }
         }

--- a/src/Type/DotArray.php
+++ b/src/Type/DotArray.php
@@ -149,10 +149,7 @@ class DotArray implements \ArrayAccess
             $scope = &$scope[$parts[$i]];
         }
         if (is_array($value)) {
-            $tmp = new static();
-            foreach ($value as $k => $v) {
-                $tmp->offsetSet($k, $v);
-            }
+            $tmp = new static($value);
             $scope[$parts[$i]] = $tmp->toArray();
         } else {
             $scope[$parts[$i]] = $value;

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -114,6 +114,10 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $env->set('not_protected', []);
         $env->setAsProtected('not_protected.protected', 'value');
 
+        // Ok
+        $env->setAsProtected('protected', 'value');
+        $env->setAsProtected('not', 'value');
+
         // Since `not_protected.protected` is a protected parameter, overwriting
         // the whole `not_protected` parameter is not allowed.
         $env->setAsProtected('not_protected', 'value');


### PR DESCRIPTION
This pull request is fixing bug of pull request #276 .
> Note: This code using 
```php
if($len < $length && '.' === $name[$len] && 0 === strpos($name, $protectedName)) {
```
> it's performance better than 
```php
if(0 === strpos($name, $protectedName . '.')) {
```