### PR TITLE
update contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,13 @@ In order for us to provide you with help as fast as possible, please make sure t
 All code contributions must go through a pull request and approved by a core developer before being merged.
 This is to ensure proper review of all the code.
 
-Fork the project, create a feature branch, and send a pull request.
+Fork the project, create a feature branch, and send a pull request (one pull request per feature).
 
 To ensure a consistent code base, you should make sure the code follows
 the [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md).
+
+Make sure each individual commit in your pull request is meaningful. 
+If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) 
+before submitting.
 
 If you would like to help take a look at the [list of issues](https://github.com/deployphp/deployer/issues).

--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ Contributing
 All code contributions must go through a pull request and approved by a core developer before being merged.
 This is to ensure proper review of all the code.
 
-Fork the project, create a feature branch, and send a pull request.
+Fork the project, create a feature branch, and send a pull request (one pull request per feature).
 
 To ensure a consistent code base, you should make sure the code follows
 the [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md).
+
+Make sure each individual commit in your pull request is meaningful. 
+If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) 
+before submitting.
 
 If you would like to help take a look at the [list of issues](https://github.com/deployphp/deployer/issues).
 


### PR DESCRIPTION
This project has many pull requests. I think it would be better if contributor squash multiple intermediate commits (while developing) before create pull request. To be best, one pull request only has one commit.