### PR TITLE
[BUGFIX] : Use server date

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -93,7 +93,7 @@ env('release_path', function () {
  * Release
  */
 task('deploy:release', function () {
-    $release = date('YmdHis');
+    $release = run('date +%Y%m%d%H%M%S');
 
     $releasePath = "{{deploy_path}}/releases/$release";
 

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -58,7 +58,7 @@ task('deploy:assets', function () {
         return "{{release_path}}/$asset";
     }, get('assets')));
 
-    $time = date('Ymdhi.s');
+    $time = run('date +%Y%m%d%H%M.%S')
 
     run("find $assets -exec touch -t $time {} ';' &> /dev/null || true");
 })->desc('Normalize asset timestamps');


### PR DESCRIPTION
There is an issue with the release date : it's based on the client date.
It should be based on the server date.

How to reproduce:
- set your script to keep 2 releases
- set your server on UTC
- deploy twice from CircleCI (UTC)
- deploy once from a Europe/Berlin machine (or any other timezone as long as you more than 1 hour offset with UTC)

Releases:
- 20150612111941 : CircleCI (1st deployment) at 11:19:41
- 20150612113811 : CircleCI (2nd deployment) at 11:38:11
- 20150612093922 : Deployment from my machine at 11:39:22

The symlink task will symlink the latest release (20150612093922).
The cleanup will then remove the oldest release (20150612093922 too).

Only outdated releases will remain on the server : 20150612111941 and 20150612113811.

Using the server date ensures this situation does not happen.