### PR TITLE
Ref #346 - faster git cloning

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -20,6 +20,18 @@ set('writable_use_sudo', true); // Using sudo in writable commands?
 env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
+env('git_cache', function(){ //whether to use git cache - fester cloning by borrowing objects from existing clones.
+  $gitVersion = run('git version');
+  $regs = [];
+  echo $gitVersion;
+  if (preg_match('/((\d+\.?)+)/', $gitVersion, $regs)) {
+    $version = $regs[1];
+  } else {
+    $version = "1.0.0";
+  }
+  $compare = version_compare($version, '2.3', '>=');
+  return $compare;
+});
 
 /**
  * Default arguments and options.
@@ -116,6 +128,7 @@ task('deploy:release', function () {
 task('deploy:update_code', function () {
     $repository = get('repository');
     $branch = env('branch');
+    $gitCache = env('git_cache');
     if (input()->hasOption('tag')) {
         $tag = input()->getOption('tag');
     }
@@ -127,7 +140,18 @@ task('deploy:update_code', function () {
         $at = "-b $branch";
     }
 
-    run("git clone $at --depth 1 --recursive -q $repository {{release_path}} 2>&1");
+    $releases = env('releases_list');
+    
+    if($gitCache && isset($releases[1])){
+      try {
+       run("git clone $at --recursive -q --reference {{deploy_path}}/releases/{$releases[1]} --dissociate $repository  {{release_path}} 2>&1");  
+      } catch (RuntimeException $exc) {
+        // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
+        run("git clone $at --recursive -q $repository {{release_path}} 2>&1"); 
+      }
+    } else{
+      run("git clone $at --depth 1 --recursive -q $repository {{release_path}} 2>&1"); 
+    }
 
 })->desc('Updating code');
 


### PR DESCRIPTION
This enables faster git cloning by using options `--reference` and `--dissociate`.

By default if git on server is newer or equal to 2.3, git cache is enabled. However if user sees any drawbacks to using git cache and would rather use shallow clones, he is allowed to do so by simply setting env variable `git_cache` to `false`.

This work is based on deployphp/recipes#12 for same behaviour on local machine.