### PR TITLE
Allows to change timezone with UTC as a default

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -84,10 +84,10 @@ task('deploy:prepare', function () {
         throw $e;
     }
 
-	// Set the deployment timezone
-	if (!date_default_timezone_set(env('timezone'))) {
-		date_default_timezone_set('UTC');
-	}
+    // Set the deployment timezone
+    if (!date_default_timezone_set(env('timezone'))) {
+        date_default_timezone_set('UTC');
+    }
 
     run('if [ ! -d {{deploy_path}} ]; then echo ""; fi');
 

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -17,6 +17,7 @@ set('writable_use_sudo', true); // Using sudo in writable commands?
 /**
  * Environment vars
  */
+env('timezone', 'UTC');
 env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
@@ -82,7 +83,12 @@ task('deploy:prepare', function () {
 
         throw $e;
     }
-    
+
+	// Set the deployment timezone
+	if (!date_default_timezone_set(env('timezone'))) {
+		date_default_timezone_set('UTC');
+	}
+
     run('if [ ! -d {{deploy_path}} ]; then echo ""; fi');
 
     // Create releases dir.
@@ -103,7 +109,7 @@ env('release_path', function () {
  * Release
  */
 task('deploy:release', function () {
-    $release = run('date +%Y%m%d%H%M%S');
+    $release = date('YmdHis');
 
     $releasePath = "{{deploy_path}}/releases/$release";
 

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -58,7 +58,7 @@ task('deploy:assets', function () {
         return "{{release_path}}/$asset";
     }, get('assets')));
 
-    $time = run('date +%Y%m%d%H%M.%S');
+    $time = date('Ymdhi.s');;
 
     run("find $assets -exec touch -t $time {} ';' &> /dev/null || true");
 })->desc('Normalize asset timestamps');


### PR DESCRIPTION
This PR aims to be a solution following various comments on https://github.com/deployphp/deployer/pull/338.

A revert of https://github.com/deployphp/deployer/commit/a760a9f17bf0ad3b28b9c5dfe3a29982266b00bf would reintroduce the bug previously explained.

The following PR provides a default timezone to UTC that can be overridden in the deployment script.
This provides thus a consistency between releases name on different servers, as the TZ on this server might all be different.

Also some documentation on http://deployer.org would be necessary.