### PR TITLE
Allow the use of * wildcard in shared files

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -182,14 +182,16 @@ task('deploy:shared', function () {
         // Remove from source
         run("if [ -f $(echo {{release_path}}/$file) ]; then rm -rf {{release_path}}/$file; fi");
 
-        // Create dir of shared file
-        run("mkdir -p $sharedPath/" . dirname($file));
+        $dirName = dirname($file);
 
-        // Touch shared
-        run("touch $sharedPath/$file");
+        // Create dir of shared file
+        run("mkdir -p $sharedPath/$dirName");
+
+        // Create destination dir
+        run("mkdir -p {{release_path}}/$dirName");
 
         // Symlink shared dir to release dir
-        run("ln -nfs $sharedPath/$file {{release_path}}/$file");
+        run("cd {{release_path}}/$dirName && shopt -s failglob && ln -nfs $sharedPath/$file -t . && shopt -u failglob");
     }
 })->desc('Creating symlinks for shared files');
 


### PR DESCRIPTION
This change allows to use of the `*` wildcard for the shared files. For example it could be useful in Zend Framework 2 where you have a lot of configuration files ending with `.local.php`, so you'd like to use `*.local.php`.

Maybe it's not the best solution. Feel free to consider it as an idea.

I removed the `touch` command because if there are no files of the requested format in the shared folder, then a file like `*.local.php` would actually be created and linked in the application folder