### PR TITLE
Use mirrored git repository for faster results

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -131,7 +131,6 @@ task('deploy:update_code', function () {
         $at = "$branch";
     }
 
-    $releases = env('releases_list');
     if (run("if [ ! -f {{deploy_path}}/repo/HEAD ]; then echo \"1\"; fi")->toString()) {
         run("git clone --mirror $repository {{deploy_path}}/repo");
     } else {

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -21,14 +21,14 @@ env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
 env('git_cache', function () { //whether to use git cache - faster cloning by borrowing objects from existing clones.
-  $gitVersion = run('git version');
-  $regs = [];
-  if (preg_match('/((\d+\.?)+)/', $gitVersion, $regs)) {
-      $version = $regs[1];
-  } else {
-      $version = "1.0.0";
-  }
-  return version_compare($version, '2.3', '>=');
+    $gitVersion = run('git version');
+    $regs = [];
+    if (preg_match('/((\d+\.?)+)/', $gitVersion, $regs)) {
+        $version = $regs[1];
+    } else {
+        $version = "1.0.0";
+    }
+    return version_compare($version, '2.3', '>=');
 });
 
 /**
@@ -82,7 +82,7 @@ task('deploy:prepare', function () {
 
         throw $e;
     }
-    
+
     run('if [ ! -d {{deploy_path}} ]; then echo ""; fi');
 
     // Create releases dir.
@@ -128,7 +128,7 @@ task('deploy:update_code', function () {
     $branch = env('branch');
     $gitCache = env('git_cache');
     $depth = $gitCache ? '' : '--depth 1';
-    
+
     if (input()->hasOption('tag')) {
         $tag = input()->getOption('tag');
     }
@@ -141,17 +141,17 @@ task('deploy:update_code', function () {
     }
 
     $releases = env('releases_list');
-    
+
     if ($gitCache && isset($releases[1])) {
         try {
             run("git clone $at --recursive -q --reference {{deploy_path}}/releases/{$releases[1]} --dissociate $repository  {{release_path}} 2>&1");
         } catch (RuntimeException $exc) {
             // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
-        run("git clone $at --recursive -q $repository {{release_path}} 2>&1");
+            run("git clone $at --recursive -q $repository {{release_path}} 2>&1");
         }
     } else {
         // if we're using git cache this would be identical to above code in catch - full clone. If not, it would create shallow clone.
-      run("git clone $at $depth --recursive -q $repository {{release_path}} 2>&1");
+        run("git clone $at $depth --recursive -q $repository {{release_path}} 2>&1");
     }
 
 })->desc('Updating code');


### PR DESCRIPTION
The problem: big repositories takes too long to copy, even with the --reference. This solution will not copy, fetch any git objects, but uses only one mirror, updates it and then creates an archive to the release path.
    
The original idea is coming from Capistrano:
https://github.com/capistrano/capistrano/blob/ad61d9288a2567faa5ae37e7fa74b1c1947e592d/lib/capistrano/git.rb