### PR TITLE
Add env parsing to upload

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -339,7 +339,7 @@ function upload($local, $remote)
 {
     $server = Context::get()->getServer();
     $local = env()->parse($local);
-    $remove = env()->parse($remote);
+    $remote = env()->parse($remote);
 
     if (is_file($local)) {
         writeln("Upload file <info>$local</info> to <info>$remote</info>");

--- a/src/functions.php
+++ b/src/functions.php
@@ -338,6 +338,8 @@ function runLocally($command, $timeout = 60)
 function upload($local, $remote)
 {
     $server = Context::get()->getServer();
+    $local = env()->parse($local);
+    $remove = env()->parse($remote);
 
     if (is_file($local)) {
         writeln("Upload file <info>$local</info> to <info>$remote</info>");


### PR DESCRIPTION
I think it is a good thing to get the local / remote to be parsed through the env parser, so its possible to do things like

````php
task('copy:param:file', function() {
    upload('.deploy/parameters.{{env}}.yml', '{{release_path}}/app/config/parameters.yml');
});
````

Right now I have created my own upload function, which "extends" the upload function

````php
function MyUpload($local, $remote)
{
    $local = env()->parse($local);
    $remote = env()->parse($remote);
    upload($local, $remote);
}
````