### PR TITLE
Task: syntactic suger for onlyOn method

### DIFF
--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -126,12 +126,12 @@ class Task
     }
 
     /**
-     * @param array $servers
+     * @param array|string $servers
      * @return $this
      */
-    public function onlyOn($servers)
+    public function onlyOn($servers = [])
     {
-        $this->onlyOn = array_flip($servers);
+        $this->onlyOn = array_flip(is_array($servers) ? $servers : func_get_args());
         return $this;
     }
 

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -37,6 +37,13 @@ class TaskTest extends \PHPUnit_Framework_TestCase
 
         $task->onlyOn([]);
         $this->assertTrue($task->runOnServer('server'));
+
+        $task->onlyOn('server');
+        $this->assertEquals(['server' => 0], $task->getOnlyOn());
+        $this->assertTrue($task->runOnServer('server'));
+
+        $task->onlyOn();
+        $this->assertTrue($task->runOnServer('server'));
         
         $task->setPrivate();
         $this->assertTrue($task->isPrivate());


### PR DESCRIPTION
Just little bit of syntactic sugar. What do you think?

**String at onlyOn method**
[That](https://github.com/deployphp/deployer/issues/408#issuecomment-125478786) example from #408 didn't work and [here](https://github.com/deployphp/deployer/issues/355#issuecomment-112614911) it was suggested to use strings too. But the method internally works with arrays, so it should either accept both arrays and strings or I think that there should be an `array` type hint.