### PR TITLE
Local process: add option to configure timeout with process_timeout

### DIFF
--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -26,10 +26,12 @@ class Local implements ServerInterface
      */
     public function run($command)
     {
+        $timeout = env()->get('process_timeout', self::TIMEOUT);
+
         $process = new Process($command);
         $process
-            ->setTimeout(self::TIMEOUT)
-            ->setIdleTimeout(self::TIMEOUT)
+            ->setTimeout($timeout)
+            ->setIdleTimeout($timeout)
             ->mustRun();
 
         return $process->getOutput();


### PR DESCRIPTION
Unfortunately there is no way to change process timeout for commands running on local server. Method `runLocally` has that option.