### PR TITLE
Task: add runAlwaysOn option

### DIFF
--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -285,6 +285,10 @@ class ParallelExecutor implements ExecutorInterface
                     $this->tasksToDo = [];
 
                     foreach ($this->servers as $serverName => $server) {
+                        if (($runnerServerName = $task->getRunAlwaysOn()) && isset($this->servers[$runnerServerName])) {
+                            $serverName = $runnerServerName;
+                        }
+
                         if ($task->runOnServer($serverName)) {
                             $this->informer->onServer($serverName);
                             $this->tasksToDo[$serverName] = $taskName;

--- a/src/Executor/SeriesExecutor.php
+++ b/src/Executor/SeriesExecutor.php
@@ -30,6 +30,11 @@ class SeriesExecutor implements ExecutorInterface
                 $task->run(new Context(null, null, $input, $output));
             } else {
                 foreach ($servers as $serverName => $server) {
+                    if (($runnerServerName = $task->getRunAlwaysOn()) && isset($servers[$runnerServerName])) {
+                        $serverName = $runnerServerName;
+                        $server = $servers[$runnerServerName];
+                    }
+
                     if ($task->runOnServer($serverName)) {
                         $env = isset($environments[$serverName]) ? $environments[$serverName] : $environments[$serverName] = new Environment();
 

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -39,6 +39,12 @@ class Task
     private $onlyOn = [];
 
     /**
+     * Name of server on which this task will always run
+     * @var string
+     */
+    private $runAlwaysOn;
+
+    /**
      * Make task internal and not visible in CLI.
      * @var bool
      */
@@ -155,6 +161,24 @@ class Task
         } else {
             return array_key_exists($serverName, $this->onlyOn);
         }
+    }
+
+    /**
+     * @param string $serverName
+     * @return $this
+     */
+    public function runAlwaysOn($serverName)
+    {
+        $this->runAlwaysOn = $serverName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRunAlwaysOn()
+    {
+        return $this->runAlwaysOn;
     }
 
     /**

--- a/test/src/Executor/SeriesExecutorTest.php
+++ b/test/src/Executor/SeriesExecutorTest.php
@@ -10,6 +10,7 @@ namespace Deployer\Executor;
 use Deployer\Helper\DeployerHelper;
 use Deployer\Server\Environment;
 use Deployer\Server\Local;
+use Deployer\Task\Context;
 use Deployer\Task\Task;
 
 class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
@@ -21,7 +22,7 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
         $this->initialize();
 
         $mock = $this->getMockBuilder('stdClass')
-            ->setMethods(['task', 'once', 'only'])
+            ->setMethods(['task', 'once', 'only', 'always'])
             ->getMock();
 
         $mock->expects($this->exactly(2))
@@ -30,6 +31,8 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
             ->method('once');
         $mock->expects($this->once())
             ->method('only');
+        $mock->expects($this->exactly(2))
+            ->method('always');
 
         $task = new Task('task', function () use ($mock) {
             $mock->task();
@@ -45,7 +48,12 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
         });
         $taskOnly->onlyOn(['one']);
 
-        $tasks = [$task, $taskOne, $taskOnly];
+        $taskAlways = new Task('always', function () use ($mock) {
+            $mock->always();
+        });
+        $taskAlways->runAlwaysOn('two');
+
+        $tasks = [$task, $taskOne, $taskOnly, $taskAlways];
 
         $environments = [
             'one' => new Environment(),


### PR DESCRIPTION
Adds new option `runAlwaysOn` to task, based on #408. 

**Configuration:**

```php
localServer('production');
localServer('test1');
localServer('test2');

task('database:sync', function() {
    write('syncing database from '. env('server.name'));
})->runAlwaysOn('production');
```

**Test:**

```
$ dep test production
output: syncing database from production

$ dep test test1
output: syncing database from production

$ dep test test2
output: syncing database from production
```

Now it doesn't matter on which server you want to run some task, it will just always run on the defined one. That can be easily used for example for syncing database from production to other servers (independently). 

**Todo:**

* Is `runAlwaysOn` good name?
* Is it possible to somehow test at which server current task runs? `env('server.name')` can't be used
* I don't know how to test `ParallelExecutor`. At least not yet