### PR TITLE
Temporary fixes problem with command execution timeout

### DIFF
--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -46,7 +46,7 @@ class PhpSecLib implements ServerInterface
     public function connect()
     {
         $serverConfig = $this->getConfiguration();
-        $this->sftp = new SFTP($serverConfig->getHost(), $serverConfig->getPort());
+        $this->sftp = new SFTP($serverConfig->getHost(), $serverConfig->getPort(), PHP_INT_MAX);
 
         switch ($serverConfig->getAuthenticationMethod()) {
             case Configuration::AUTH_BY_PASSWORD:


### PR DESCRIPTION
It temporary fixes problem that described in phpseclib/phpseclib#775.
For example `composer install` may be stoped on the middle of progress if it takes more than 10 sec.