### PR TITLE
Implemented tests and fixed default timeout value to not soo huge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.idea/
 /nbproject/
 *.phar
+/.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: required
+
 php:
   - 5.4
   - 5.5
@@ -13,10 +15,10 @@ matrix:
     - php: hhvm
 
 install:
+  - eval `ssh-agent -s`
+  - test/travis/setup-secure-shell.sh
   - composer self-update
   - composer install --no-interaction --prefer-source
 
 script:
   - phpunit
-  
-sudo: false

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -46,7 +46,7 @@ class PhpSecLib implements ServerInterface
     public function connect()
     {
         $serverConfig = $this->getConfiguration();
-        $this->sftp = new SFTP($serverConfig->getHost(), $serverConfig->getPort(), PHP_INT_MAX);
+        $this->sftp = new SFTP($serverConfig->getHost(), $serverConfig->getPort(), 3600);
 
         switch ($serverConfig->getAuthenticationMethod()) {
             case Configuration::AUTH_BY_PASSWORD:

--- a/test/recipe/Helper/RecipeTester.php
+++ b/test/recipe/Helper/RecipeTester.php
@@ -9,6 +9,8 @@ namespace Deployer\Helper;
 
 use Deployer\Console\Application;
 use Deployer\Deployer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 abstract class RecipeTester extends \PHPUnit_Framework_TestCase
@@ -51,12 +53,17 @@ abstract class RecipeTester extends \PHPUnit_Framework_TestCase
         $this->deployer = new Deployer($console, $input, $output);
 
         // Load recipe
-        localServer('localhost')
-            ->env('deploy_path', self::$deployPath);
+        $this->setUpServer();
         $this->loadRecipe();
 
         // Init Deployer
         $this->deployer->addConsoleCommands();
+    }
+
+    protected function setUpServer()
+    {
+        localServer('localhost')
+            ->env('deploy_path', self::$deployPath);
     }
 
 

--- a/test/recipe/RemoteServerTest.php
+++ b/test/recipe/RemoteServerTest.php
@@ -1,0 +1,101 @@
+<?php
+/* (c) Dmitry Balabka <dmitry.balabka@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use \Deployer\Helper\RecipeTester;
+
+class RemoteServerTest extends RecipeTester
+{
+    const IP_REG_EXP = '#^::1#';
+
+    /**
+     * @var \Deployer\Type\Result
+     */
+    private $result;
+
+    protected function setUpServer()
+    {
+        $username = getenv('DEPLOYER_USERNAME') ?: 'deployer';
+        $password = getenv('DEPLOYER_PASSWORD') ?: 'deployer_password';
+        server('remote_auth_by_password', 'localhost', 22)
+            ->env('deploy_path', self::$deployPath)
+            ->user($username)
+            ->password($password);
+        server('remote_auth_by_identity_file', 'localhost', 22)
+            ->env('deploy_path', self::$deployPath)
+            ->user($username)
+            ->identityFile();
+        server('remote_auth_by_pem_file', 'localhost', 22)
+            ->env('deploy_path', self::$deployPath)
+            ->user($username)
+            ->pemFile('~/.ssh/id_rsa.pem');
+        server('remote_auth_by_agent', 'localhost', 22)
+            ->env('deploy_path', self::$deployPath)
+            ->user($username)
+            ->forwardAgent();
+    }
+
+    protected function loadRecipe()
+    {
+        require __DIR__ . '/../../recipe/common.php';
+
+        task('deploy:timeout_test', function () {
+            $this->result = run('sleep 11 && echo $SSH_CLIENT');
+        });
+        task('deploy:ssh_test', function () {
+            $this->result = run('echo $SSH_CLIENT');
+        });
+        task('deploy:agent_test', function () {
+            $this->result = run('ssh -T deployer@localhost \'echo $SSH_CLIENT\'');
+        });
+    }
+
+    public function testAuthByPassword()
+    {
+        if (false !== getenv('SCRUTINIZER')) {
+            $this->markTestSkipped('Test skipped on scrutinizer environment');
+        }
+        $this->exec('deploy:ssh_test', ['stage' => 'remote_auth_by_password']);
+        $this->assertRegExp(self::IP_REG_EXP, $this->result->getOutput());
+    }
+
+    public function testAuthByIdentityFile()
+    {
+        if (false !== getenv('SCRUTINIZER')) {
+            $this->markTestSkipped('Test skipped on scrutinizer environment');
+        }
+        $this->exec('deploy:ssh_test', ['stage' => 'remote_auth_by_identity_file']);
+        $this->assertRegExp(self::IP_REG_EXP, $this->result->getOutput());
+    }
+
+    public function testAuthByPemFile()
+    {
+        if (false !== getenv('SCRUTINIZER')) {
+            $this->markTestSkipped('Test skipped on scrutinizer environment');
+        }
+        $this->markTestIncomplete('Will be implemented later');
+        $this->exec('deploy:ssh_test', ['stage' => 'remote_auth_by_pem_file']);
+        $this->assertRegExp(self::IP_REG_EXP, $this->result->getOutput());
+    }
+
+    public function testAuthByAgent()
+    {
+        if (false !== getenv('SCRUTINIZER')) {
+            $this->markTestSkipped('Test skipped on scrutinizer environment');
+        }
+        $this->exec('deploy:agent_test', ['stage' => 'remote_auth_by_agent']);
+        $this->assertRegExp(self::IP_REG_EXP, $this->result->getOutput());
+    }
+
+    public function testTimeout()
+    {
+        if (false !== getenv('SCRUTINIZER')) {
+            $this->markTestSkipped('Test skipped on scrutinizer environment');
+        }
+        $this->exec('deploy:timeout_test', ['stage' => 'remote_auth_by_agent']);
+        $this->assertRegExp(self::IP_REG_EXP, $this->result->getOutput());
+    }
+}

--- a/test/travis/setup-secure-shell.sh
+++ b/test/travis/setup-secure-shell.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+set -x
+
+export DEPLOYER_USERNAME='deployer'
+export DEPLOYER_PASSWORD='deployer_password'
+
+# Create deployer user and home directory
+sudo useradd --create-home --base-dir /home "$DEPLOYER_USERNAME"
+
+# Set deployer user password
+echo "$DEPLOYER_USERNAME:$DEPLOYER_PASSWORD" | sudo chpasswd
+
+# Create a 1024 bit RSA SSH key pair without passphrase for the travis user
+ssh-keygen -t rsa -b 1024 -f "$HOME/.ssh/id_rsa" -q -N ""
+ssh-keygen -f "$HOME/.ssh/id_rsa.pub" -e -m pem > "$HOME/.ssh/id_rsa.pem"
+
+# Add the generated private key to SSH agent of travis user
+ssh-add "$HOME/.ssh/id_rsa"
+
+# Allow the private key of the travis user to log in as deployer user
+sudo mkdir -p "/home/$DEPLOYER_USERNAME/.ssh/"
+sudo cp "$HOME/.ssh/id_rsa.pub" "/home/$DEPLOYER_USERNAME/.ssh/authorized_keys"
+sudo ssh-keyscan -t rsa localhost > "/tmp/known_hosts"
+sudo cp "/tmp/known_hosts" "/home/$DEPLOYER_USERNAME/.ssh/known_hosts"
+sudo chown "$DEPLOYER_USERNAME:$DEPLOYER_USERNAME" "/home/$DEPLOYER_USERNAME/.ssh/" -R


### PR DESCRIPTION
It fixes wrong huge default value for timeout that was introduced in #429
- [x] be sure that Travis tests works fine

IMPORTANT! To prepare ssh tests, I have to use `sudo: required` that means that all tests will run on old Travis infrastructure not [container-base](http://docs.travis-ci.com/user/workers/container-based-infrastructure/)