### PR TITLE
Update deploy:writable_dirs: When running WITHOUT sudo, exec setfacl once only

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -242,12 +242,15 @@ task('deploy:writable', function () {
                         run("$sudo setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
                         run("$sudo setfacl -dR -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
                     } else {
-                        // If run without sudo, check each dir
+                        // When running without sudo, exception may be thrown
+                        // if executing setfacl on files created by http user (in directory that has been setfacl before).
+                        // These directories/files should be skipped.
+                        // Now, we will check each directory for ACL and only setfacl for which has not been set before.
                         $writeableDirs = get('writable_dirs');
                         foreach ($writeableDirs as $dir) {
                             // Check if ACL has been set or not
                             $hasfacl = run("getfacl -p $dir | grep $httpUser | wc -l")->toString();
-                            // Set ACL for dir if it has not been set before
+                            // Set ACL for directory if it has not been set before
                             if (!$hasfacl) {
                                 run("setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
                                 run("setfacl -dR -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -249,7 +249,7 @@ task('deploy:writable', function () {
                         $writeableDirs = get('writable_dirs');
                         foreach ($writeableDirs as $dir) {
                             // Check if ACL has been set or not
-                            $hasfacl = run("getfacl -p $dir | grep $httpUser | wc -l")->toString();
+                            $hasfacl = run("getfacl -p $dir | grep \"^user:$httpUser:.*w\" | wc -l")->toString();
                             // Set ACL for directory if it has not been set before
                             if (!$hasfacl) {
                                 run("setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");


### PR DESCRIPTION
When run deploy:writable_dirs WITHOUT sudo, exception maybe thrown if setfacl run on files created by http user (in directory that has been setfacl before). These directories/files should be skipped.

Ref: https://github.com/deployphp/deployer/issues/433#issuecomment-133388894