### PR TITLE
Added support for setting http user for chmod

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -14,6 +14,7 @@ set('shared_files', []);
 set('copy_dirs', []);
 set('writable_dirs', []);
 set('writable_use_sudo', true); // Using sudo in writable commands?
+set('http_user', null);
 
 /**
  * Environment vars
@@ -223,10 +224,13 @@ task('deploy:shared', function () {
 task('deploy:writable', function () {
     $dirs = join(' ', get('writable_dirs'));
     $sudo = get('writable_use_sudo') ? 'sudo' : '';
+    $httpUser = get('http_user');
 
     if (!empty($dirs)) {
         try {
-            $httpUser = run("ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1")->toString();
+            if (null === $httpUser) {
+                $httpUser = run("ps aux | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\  -f1")->toString();
+            }
 
             cd('{{release_path}}');
 


### PR DESCRIPTION
This feature makes it possible to specify the user for `chmod` & `setfacl`. In my use case the PHP-FPM pool is using an dedicated user but Apache is served by www-data. Using `deploy:writable` all writable dirs would use the Apache user rather the pool user which causes permission issues when trying to set the file mode and owner.

You can now use the directive `set('http_user', 'username')` to set the user owning this files & directories.