### PR TITLE
Updated shared dirs in laravel 5 recipe

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -13,7 +13,7 @@ set('shared_dirs', [
     'storage/framework/cache',
     'storage/framework/sessions',
     'storage/framework/views',
-    'storage/framework/logs',
+    'storage/logs',
 ]);
 
 // Laravel 5 shared file

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -8,7 +8,13 @@
 require_once __DIR__ . '/common.php';
 
 // Laravel shared dirs
-set('shared_dirs', ['storage']);
+set('shared_dirs', [
+    'storage/app',
+    'storage/framework/cache',
+    'storage/framework/sessions',
+    'storage/framework/views',
+    'storage/framework/logs',
+]);
 
 // Laravel 5 shared file
 set('shared_files', ['.env']);


### PR DESCRIPTION
This fixes a bug when laravel tries to get the full path of these directories but returns false because they don't exist.

This is caused in some cases like the [view config](https://github.com/laravel/laravel/blob/master/config/view.php#L31),  because `realpath()` is used.

If we don't create each shared folder during the deployment, realpath returns false because the dir doesn't exist and thus laravel tries to write to the root `/` directory.

- **Deployer version:** master branch
- **PHP version:** all php versions
- **Deployment target(s) OS:** hmm, all
