### PR TITLE
Adding new variable "cleanup_use_sudo"

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -14,6 +14,7 @@ set('shared_files', []);
 set('copy_dirs', []);
 set('writable_dirs', []);
 set('writable_use_sudo', true); // Using sudo in writable commands?
+set('cleanup_use_sudo', true); // Using sudo in cleanup commands?
 set('http_user', null);
 
 /**
@@ -354,6 +355,7 @@ task('current', function () {
  * Cleanup old releases.
  */
 task('cleanup', function () {
+    $sudo = get('cleanup_use_sudo') ? 'sudo' : '';
     $releases = env('releases_list');
 
     $keep = get('keep_releases');
@@ -364,11 +366,11 @@ task('cleanup', function () {
     }
 
     foreach ($releases as $release) {
-        run("rm -rf {{deploy_path}}/releases/$release");
+        run("$sudo rm -rf {{deploy_path}}/releases/$release");
     }
 
-    run("cd {{deploy_path}} && if [ -e release ]; then rm release; fi");
-    run("cd {{deploy_path}} && if [ -h release ]; then rm release; fi");
+    run("cd {{deploy_path}} && if [ -e release ]; then $sudo rm release; fi");
+    run("cd {{deploy_path}} && if [ -h release ]; then $sudo rm release; fi");
 
 })->desc('Cleaning up old releases');
 


### PR DESCRIPTION
We faced this in the past where we needed to run the cleanup command as sudo as all our releases are owned by a different user than the one which we use for deployment.