### PR TITLE
Flag for assetic:dump task #419

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -22,6 +22,8 @@ set('writable_dirs', ['app/cache', 'app/logs']);
 
 // Assets
 set('assets', ['web/css', 'web/images', 'web/js']);
+// Default true - BC for Symfony < 3.0
+set('dump_assets', true);
 
 // Environment vars
 env('env_vars', 'SYMFONY_ENV=prod');
@@ -68,6 +70,9 @@ task('deploy:assets', function () {
  * Dump all assets to the filesystem
  */
 task('deploy:assetic:dump', function () {
+    if (!get('dump_assets')) {
+        return;
+    }
 
     run('php {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assetic:dump --env={{env}} --no-debug');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #419

Default is set to true - current configuration does not need to be changed.
If you do not use AsseticBundle just switch flag to false:

```php
set('dump_assets', true);
```