### PR TITLE
Remove php 7 from failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm
 
 install:
@@ -30,4 +29,3 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-  


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
Php 7 is stable so it should be removed from failures