### PR TITLE
Make more correct RegExp in RemoteServerTest

### DIFF
--- a/test/recipe/RemoteServerTest.php
+++ b/test/recipe/RemoteServerTest.php
@@ -9,7 +9,7 @@ use \Deployer\Helper\RecipeTester;
 
 class RemoteServerTest extends RecipeTester
 {
-    const IP_REG_EXP = '#^((::1)|(127.0.0.1))#';
+    const IP_REG_EXP = '#^(?:::1|127\.0\.0\.1)#';
 
     /**
      * @var \Deployer\Type\Result


### PR DESCRIPTION
Problem with tests has been appeared because Travis has changed IPv6 to IPv4 (see
"IPv6 no longer present" section in https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future)