### PR TITLE
Fix environment variable replacement in "download" function

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -386,6 +386,9 @@ function upload($local, $remote)
 function download($local, $remote)
 {
     $server = Context::get()->getServer();
+    $local = env()->parse($local);
+    $remote = env()->parse($remote);
+
     $server->download($local, $remote);
 }
 

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -50,7 +50,10 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->_input = $this->getMock('Symfony\Component\Console\Input\InputInterface');
         $this->_output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $this->_server = $this->getMockBuilder('Deployer\Server\ServerInterface')->disableOriginalConstructor()->getMock();
+
         $this->_env = new Environment();
+        $this->_env->set("local_path", __DIR__ . '/../fixture/app');
+        $this->_env->set("remote_path", "/home/www");
 
         $this->deployer = new Deployer($this->console, $this->_input, $this->_output);
         Context::push(new Context($this->_server, $this->_env, $this->_input, $this->_output));
@@ -149,7 +152,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     public function testUpload()
     {
         $this->_server
-            ->expects($this->any())
+            ->expects($this->atLeastOnce())
             ->method('upload')
             ->with(
                 $this->callback(function ($local) {
@@ -160,9 +163,9 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
                 }));
 
         // Directory
-        upload(__DIR__ . '/../fixture/app', '/home/www');
+        upload('{{local_path}}', '{{remote_path}}');
 
         // File
-        upload(__DIR__ . '/../fixture/app/README.md', '/home/www/README.md');
+        upload('{{local_path}}/README.md', '{{remote_path}}/README.md');
     }
 }

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -168,4 +168,31 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         // File
         upload('{{local_path}}/README.md', '{{remote_path}}/README.md');
     }
+
+    public function testDownloadFile()
+    {
+        $this->_server
+            ->expects($this->once())
+            ->method('download')
+            ->with(
+                $this->_env->get("local_path") . "/README.md",
+                $this->_env->get("remote_path") . "/README.md"
+            );
+
+        download('{{local_path}}/README.md', '{{remote_path}}/README.md');
+    }
+
+    public function testDownloadDirectory()
+    {
+        $this->_server
+            ->expects($this->once())
+            ->method('download')
+            ->with(
+                $this->_env->get("local_path"),
+                $this->_env->get("remote_path")
+            );
+
+
+        download('{{local_path}}', '{{remote_path}}');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none, afaik

I've also modified the test for `upload` so that it verifies environment variable replacement.