### PR TITLE
#527 Remove shared file .env on laravel recipe

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -17,9 +17,6 @@ set('shared_dirs', [
     'storage/logs',
 ]);
 
-// Laravel 5 shared file
-set('shared_files', ['.env']);
-
 // Laravel writable dirs
 set('writable_dirs', ['bootstrap/cache', 'storage']);
 


### PR DESCRIPTION
#527 Remove shared file .env on laravel recipe

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes?
| Deprecations? | no
| Fixed tickets | #527

It will break deployments that use .env for configuration, but this is really discouraged by dotenv 