### PR TITLE
Added way to execute tasks only for certain stages

### DIFF
--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -9,6 +9,7 @@ namespace Deployer\Executor;
 
 use Deployer\Console\Output\OutputWatcher;
 use Deployer\Console\Output\VerbosityString;
+use Deployer\Server\Environment;
 use Deployer\Task\Context;
 use Pure\Server;
 use Pure\Storage\ArrayStorage;
@@ -44,6 +45,11 @@ class ParallelExecutor implements ExecutorInterface
      * @var \Deployer\Server\ServerInterface[]
      */
     private $servers;
+
+    /**
+     * @var \Deployer\Server\Environment[]
+     */
+    private $environments;
 
     /**
      * @var \Symfony\Component\Console\Input\InputInterface
@@ -128,6 +134,7 @@ class ParallelExecutor implements ExecutorInterface
     {
         $this->tasks = $tasks;
         $this->servers = $servers;
+        $this->environments = $environments;
         $this->input = $input;
         $this->output = new OutputWatcher($output);
         $this->informer = new Informer($this->output);
@@ -286,6 +293,12 @@ class ParallelExecutor implements ExecutorInterface
 
                     foreach ($this->servers as $serverName => $server) {
                         if ($task->runOnServer($serverName)) {
+                            $env = isset($this->environments[$serverName]) ? $this->environments[$serverName] : $this->environments[$serverName] = new Environment();
+
+                            if (!empty($task->getOnlyFor()) && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                                continue;
+                            }
+
                             $this->informer->onServer($serverName);
                             $this->tasksToDo[$serverName] = $taskName;
                         }

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -295,7 +295,7 @@ class ParallelExecutor implements ExecutorInterface
                         if ($task->runOnServer($serverName)) {
                             $env = isset($this->environments[$serverName]) ? $this->environments[$serverName] : $this->environments[$serverName] = new Environment();
 
-                            if (count($task->getOnlyFor()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                            if (count($task->getOnlyForStage()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
                                 continue;
                             }
 

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -295,7 +295,7 @@ class ParallelExecutor implements ExecutorInterface
                         if ($task->runOnServer($serverName)) {
                             $env = isset($this->environments[$serverName]) ? $this->environments[$serverName] : $this->environments[$serverName] = new Environment();
 
-                            if (!empty($task->getOnlyFor()) && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                            if (count($task->getOnlyFor()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
                                 continue;
                             }
 

--- a/src/Executor/SeriesExecutor.php
+++ b/src/Executor/SeriesExecutor.php
@@ -33,6 +33,10 @@ class SeriesExecutor implements ExecutorInterface
                     if ($task->runOnServer($serverName)) {
                         $env = isset($environments[$serverName]) ? $environments[$serverName] : $environments[$serverName] = new Environment();
 
+                        if (!empty($task->getOnlyFor()) && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                            continue;
+                        }
+
                         $informer->onServer($serverName);
 
                         try {

--- a/src/Executor/SeriesExecutor.php
+++ b/src/Executor/SeriesExecutor.php
@@ -33,7 +33,7 @@ class SeriesExecutor implements ExecutorInterface
                     if ($task->runOnServer($serverName)) {
                         $env = isset($environments[$serverName]) ? $environments[$serverName] : $environments[$serverName] = new Environment();
 
-                        if (!empty($task->getOnlyFor()) && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                        if (count($task->getOnlyFor()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
                             continue;
                         }
 

--- a/src/Executor/SeriesExecutor.php
+++ b/src/Executor/SeriesExecutor.php
@@ -33,7 +33,7 @@ class SeriesExecutor implements ExecutorInterface
                     if ($task->runOnServer($serverName)) {
                         $env = isset($environments[$serverName]) ? $environments[$serverName] : $environments[$serverName] = new Environment();
 
-                        if (count($task->getOnlyFor()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
+                        if (count($task->getOnlyForStage()) > 0 && (!$env->has('stages') || !$task->runForStages($env->get('stages')))) {
                             continue;
                         }
 

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -179,7 +179,7 @@ class Task
         if (empty($this->onlyFor)) {
             return true;
         } else {
-            return !empty(array_intersect($stages, array_keys($this->onlyFor)));
+            return count(array_intersect($stages, array_keys($this->onlyFor))) > 0;
         }
     }
 

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -33,6 +33,12 @@ class Task
     private $once = false;
 
     /**
+     * List of stages in which this task should be executed.
+     * @var array  Key contains stage names.
+     */
+    private $onlyFor = [];
+
+    /**
      * List of servers names there this task should be executed.
      * @var array  Key contains server names.
      */
@@ -136,13 +142,47 @@ class Task
     }
 
     /**
+     * Indicate for which stages this task should be run.
+     *
+     * @param array|string $stages
+     * @return $this
+     */
+    public function onlyFor($stages = [])
+    {
+        $this->onlyFor = array_flip(is_array($stages) ? $stages: func_get_args());
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function getOnlyOn()
     {
         return $this->onlyOn;
     }
-    
+
+    /**
+     * @return array
+     */
+    public function getOnlyFor()
+    {
+        return $this->onlyFor;
+    }
+
+    /**
+     * Decide to run or not to run for these stages.
+     * @param $stages
+     * @return bool
+     */
+    public function runForStages($stages)
+    {
+        if (empty($this->onlyFor)) {
+            return true;
+        } else {
+            return !empty(array_intersect($stages, array_keys($this->onlyFor)));
+        }
+    }
+
     /**
      * Decide to run or not to run on this server.
      * @param string $serverName

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -36,7 +36,7 @@ class Task
      * List of stages in which this task should be executed.
      * @var array  Key contains stage names.
      */
-    private $onlyFor = [];
+    private $onlyForStage = [];
 
     /**
      * List of servers names there this task should be executed.
@@ -147,9 +147,9 @@ class Task
      * @param array|string $stages
      * @return $this
      */
-    public function onlyFor($stages = [])
+    public function onlyForStage($stages = [])
     {
-        $this->onlyFor = array_flip(is_array($stages) ? $stages: func_get_args());
+        $this->onlyForStage = array_flip(is_array($stages) ? $stages: func_get_args());
         return $this;
     }
 
@@ -164,9 +164,9 @@ class Task
     /**
      * @return array
      */
-    public function getOnlyFor()
+    public function getOnlyForStage()
     {
-        return $this->onlyFor;
+        return $this->onlyForStage;
     }
 
     /**
@@ -176,10 +176,10 @@ class Task
      */
     public function runForStages($stages)
     {
-        if (empty($this->onlyFor)) {
+        if (empty($this->onlyForStage)) {
             return true;
         } else {
-            return count(array_intersect($stages, array_keys($this->onlyFor))) > 0;
+            return count(array_intersect($stages, array_keys($this->onlyForStage))) > 0;
         }
     }
 

--- a/test/fixture/recipe.php
+++ b/test/fixture/recipe.php
@@ -1,9 +1,25 @@
 <?php
 
+require __DIR__ . '/../../recipe/common.php';
+
 localServer('localhost');
 localServer('server1');
 localServer('server2');
+localServer('server3')
+    ->stage('production');
+localServer('server4')
+    ->stage('production');
 
-task('test', function () {
+task('test:hello', function () {
     writeln('Hello world!');
 });
+
+task('test:onlyFor', function () {
+    writeln('You should only see this for production');
+})
+    ->onlyFor('production');
+
+task('test', [
+    'test:hello',
+    'test:onlyFor'
+]);

--- a/test/fixture/recipe.php
+++ b/test/fixture/recipe.php
@@ -14,12 +14,12 @@ task('test:hello', function () {
     writeln('Hello world!');
 });
 
-task('test:onlyFor', function () {
+task('test:onlyForStage', function () {
     writeln('You should only see this for production');
 })
-    ->onlyFor('production');
+    ->onlyForStage('production');
 
 task('test', [
     'test:hello',
-    'test:onlyFor'
+    'test:onlyForStage'
 ]);

--- a/test/src/Executor/ParallelExecutorTest.php
+++ b/test/src/Executor/ParallelExecutorTest.php
@@ -26,12 +26,25 @@ class ParallelExecutorTest extends RecipeTester
         include $this->recipeFile = __DIR__ . '/../../fixture/recipe.php';
     }
 
-    public function testParallel()
+    public static function setUpBeforeClass()
     {
         define('DEPLOYER_BIN', __DIR__ . '/../../../bin/dep');
-        
+    }
+
+    public function testParallel()
+    {
         $display = $this->exec('test', ['--parallel' => true, '--file' => $this->recipeFile]);
 
         $this->assertContains('Ok', $display);
+        $this->assertNotContains('You should only see this for production', $display);
+    }
+
+    public function testParallelWithStage()
+    {
+        $display = $this->exec('test', ['--parallel' => true, '--file' => $this->recipeFile, 'stage' => 'production']);
+
+        $this->assertContains('Ok', $display);
+        $this->assertContains('[server3] You should only see this for production', $display);
+        $this->assertContains('[server4] You should only see this for production', $display);
     }
 }

--- a/test/src/Executor/SeriesExecutorTest.php
+++ b/test/src/Executor/SeriesExecutorTest.php
@@ -50,7 +50,7 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
         $taskOnlyStaging = new Task('onlyStaging', function () use ($mock) {
             $mock->onlyStaging();
         });
-        $taskOnlyStaging->onlyFor('staging');
+        $taskOnlyStaging->onlyForStage('staging');
 
         $tasks = [$task, $taskOne, $taskOnly, $taskOnlyStaging];
 

--- a/test/src/Executor/SeriesExecutorTest.php
+++ b/test/src/Executor/SeriesExecutorTest.php
@@ -21,7 +21,7 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
         $this->initialize();
 
         $mock = $this->getMockBuilder('stdClass')
-            ->setMethods(['task', 'once', 'only'])
+            ->setMethods(['task', 'once', 'only', 'onlyStaging'])
             ->getMock();
 
         $mock->expects($this->exactly(2))
@@ -30,6 +30,8 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
             ->method('once');
         $mock->expects($this->once())
             ->method('only');
+        $mock->expects($this->once())
+            ->method('onlyStaging');
 
         $task = new Task('task', function () use ($mock) {
             $mock->task();
@@ -45,12 +47,19 @@ class SeriesExecutorTest extends \PHPUnit_Framework_TestCase
         });
         $taskOnly->onlyOn(['one']);
 
-        $tasks = [$task, $taskOne, $taskOnly];
+        $taskOnlyStaging = new Task('onlyStaging', function () use ($mock) {
+            $mock->onlyStaging();
+        });
+        $taskOnlyStaging->onlyFor('staging');
+
+        $tasks = [$task, $taskOne, $taskOnly, $taskOnlyStaging];
 
         $environments = [
             'one' => new Environment(),
             'two' => new Environment(),
         ];
+        $environments['two']->set('stages', ['staging']);
+
         $servers = [
             'one' => new Local(),
             'two' => new Local(),

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -44,8 +44,23 @@ class TaskTest extends \PHPUnit_Framework_TestCase
 
         $task->onlyOn();
         $this->assertTrue($task->runOnServer('server'));
-        
+
         $task->setPrivate();
         $this->assertTrue($task->isPrivate());
+
+        $task->onlyFor(['staging', 'production']);
+        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyFor());
+        $this->assertTrue($task->runForStages(['staging']));
+        $this->assertTrue($task->runForStages(['production']));
+        $this->assertTrue($task->runForStages(['staging', 'production']));
+
+        $task->onlyFor('staging', 'production');
+        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyFor());
+        $this->assertTrue($task->runForStages(['staging']));
+        $this->assertTrue($task->runForStages(['production']));
+        $this->assertTrue($task->runForStages(['staging', 'production']));
+
+        $task->onlyFor();
+        $this->assertTrue($task->runForStages('anything'));
     }
 }

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -48,19 +48,19 @@ class TaskTest extends \PHPUnit_Framework_TestCase
         $task->setPrivate();
         $this->assertTrue($task->isPrivate());
 
-        $task->onlyFor(['staging', 'production']);
-        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyFor());
+        $task->onlyForStage(['staging', 'production']);
+        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyForStage());
         $this->assertTrue($task->runForStages(['staging']));
         $this->assertTrue($task->runForStages(['production']));
         $this->assertTrue($task->runForStages(['staging', 'production']));
 
-        $task->onlyFor('staging', 'production');
-        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyFor());
+        $task->onlyForStage('staging', 'production');
+        $this->assertEquals(['staging' => 0, 'production' => 1], $task->getOnlyForStage());
         $this->assertTrue($task->runForStages(['staging']));
         $this->assertTrue($task->runForStages(['production']));
         $this->assertTrue($task->runForStages(['staging', 'production']));
 
-        $task->onlyFor();
+        $task->onlyForStage();
         $this->assertTrue($task->runForStages('anything'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | N/A

I have a use case where my `servers.yml` file is not a static list of servers. I have more than one production webserver, and the server information is pulled down from AWS and written to `servers.yml` each time I do a deployment. The number of production servers could increase or decrease based on needs, so I don't want to have to update the deployment script every time that happens.

This means I can't just do:

```php
task('task_name', function () {
})
    ->onlyOn('production1', 'production2', 'etc...');
```

However, I know that I always want to run that task on Production, regardless of how many Production servers I have. That is the purpose of this pull request. Instead, I can do:

```php
task('task_name', function () {
})
    ->onlyFor('production');
```

Then, no matter how many production servers I have, or what they are named, this task will only execute for production.

Some things to note:
1. If a task has `->onlyFor(...)` set, then it will _not run_ if the current server environment does not have a stage set.
2. You can specify multiple stages using `->onlyFor('production', 'staging')` for tasks that can run in more than one stage, but not necessarily all of them.