### PR TITLE
Feature task may be callable

### DIFF
--- a/recipe/cakephp.php
+++ b/recipe/cakephp.php
@@ -43,7 +43,7 @@ task('deploy:run_migrations', function () {
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/codeigniter.php
+++ b/recipe/codeigniter.php
@@ -18,7 +18,7 @@ set('writable_dirs', ['application/cache', 'application/logs']);
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/composer.php
+++ b/recipe/composer.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/common.php';
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/drupal7.php
+++ b/recipe/drupal7.php
@@ -9,7 +9,7 @@ namespace Deployer;
 
 require_once __DIR__ . '/common.php';
 
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/drupal8.php
+++ b/recipe/drupal8.php
@@ -9,7 +9,7 @@ namespace Deployer;
 
 require_once __DIR__ . '/common.php';
 
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/fuelphp.php
+++ b/recipe/fuelphp.php
@@ -17,7 +17,7 @@ set('shared_dirs', [
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -28,7 +28,7 @@ set('writable_dirs', ['bootstrap/cache', 'storage']);
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/magento.php
+++ b/recipe/magento.php
@@ -45,7 +45,7 @@ after('deploy:update_code', 'deploy:clear_version');
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -117,7 +117,7 @@ after('deploy:update_code', 'deploy:clear_controllers');
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/common.php';
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/yii.php
+++ b/recipe/yii.php
@@ -18,7 +18,7 @@ set('writable_dirs', ['runtime']);
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/yii2-app-advanced.php
+++ b/recipe/yii2-app-advanced.php
@@ -49,7 +49,7 @@ task('deploy:run_migrations', function () {
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/yii2-app-basic.php
+++ b/recipe/yii2-app-basic.php
@@ -26,7 +26,7 @@ task('deploy:run_migrations', function () {
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/recipe/zend_framework.php
+++ b/recipe/zend_framework.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/common.php';
 /**
  * Main task
  */
-task('deploy', [
+taskGroup('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -46,9 +46,9 @@ class Task
 
     /**
      * @param string $name Tasks name
-     * @param \Closure $callback Task code.
+     * @param callable $callback Task code.
      */
-    public function __construct($name, \Closure $callback)
+    public function __construct($name, callable $callback)
     {
         $this->name = $name;
         $this->callback = $callback;

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -103,17 +103,30 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
 
     public function testTask()
     {
+        // Task with closure
         task('task', function () {});
-
         $task = $this->deployer->tasks->get('task');
         $this->assertInstanceOf('Deployer\Task\Task', $task);
 
-        task('group', ['task']);
+        // TODO: Task with callable
+        $this->markTestIncomplete('Task with callable');
+
+        $this->setExpectedException('InvalidArgumentException', 'Task should be a callable.');
+        task('wrong', 'thing');
+    }
+
+    public function testTaskGroup()
+    {
+        task('task', function () {});
+        $task = $this->deployer->tasks->get('task');
+        $this->assertInstanceOf('Deployer\Task\Task', $task);
+
+        taskGroup('group', ['task']);
         $task = $this->deployer->tasks->get('group');
         $this->assertInstanceOf('Deployer\Task\GroupTask', $task);
 
-        $this->setExpectedException('InvalidArgumentException', 'Task should be an closure or array of other tasks.');
-        task('wrong', 'thing');
+        $this->setExpectedException('InvalidArgumentException', 'Task group should be an array of other tasks.');
+        taskGroup('wrong', 'thing');
     }
 
     public function testBefore()

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -108,8 +108,11 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $task = $this->deployer->tasks->get('task');
         $this->assertInstanceOf('Deployer\Task\Task', $task);
 
-        // TODO: Task with callable
-        $this->markTestIncomplete('Task with callable');
+        // Test create task with [$object, 'method']
+        $mock1 = $this->getMock('stdClass', ['callback']);
+        task('task1', [$mock1, 'callback']);
+        $task1 = $this->deployer->tasks->get('task1');
+        $this->assertInstanceOf('Deployer\Task\Task', $task1);
 
         $this->setExpectedException('InvalidArgumentException', 'Task should be a callable.');
         task('wrong', 'thing');

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -18,7 +18,7 @@ class TaskTest extends \PHPUnit_Framework_TestCase
         $task = new Task('task_name', function () use ($mock) {
             $mock->callback();
         });
-        
+
         $context = $this->getMockBuilder('Deployer\Task\Context')->disableOriginalConstructor()->getMock();
 
         $task->run($context);
@@ -44,13 +44,45 @@ class TaskTest extends \PHPUnit_Framework_TestCase
 
         $task->onlyOn();
         $this->assertTrue($task->runOnServer('server'));
-        
+
         $task->setPrivate();
         $this->assertTrue($task->isPrivate());
     }
 
     public function testInit()
     {
-        $this->markTestIncomplete('Test initial task with callable');
+        $context = $this->getMockBuilder('Deployer\Task\Context')->disableOriginalConstructor()->getMock();
+
+        // Test create task with [$object, 'method']
+        $mock1 = $this->getMock('stdClass', ['callback']);
+        $mock1->expects($this->once())->method('callback');
+        $task1 = new Task('task1', [$mock1, 'callback']);
+        $task1->run($context);
+
+        // Test create task with anonymous functions
+        $mock2 = $this->getMock('stdClass', ['callback']);
+        $mock2->expects($this->once())->method('callback');
+        $task2 = new Task('task2', function () use ($mock2) {
+            $mock2->callback();
+        });
+        $task2->run($context);
+
+        $this->assertEquals(0, StubTask::$runned);
+        $task3 = new Task('task3', new StubTask());
+        $task3->run($context);
+        $this->assertEquals(1, StubTask::$runned);
+    }
+}
+
+/**
+ * Stub class for task callable by __invoke()
+ */
+class StubTask
+{
+    public static $runned = 0;
+
+    public function __invoke()
+    {
+        self::$runned++;
     }
 }

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -48,4 +48,9 @@ class TaskTest extends \PHPUnit_Framework_TestCase
         $task->setPrivate();
         $this->assertTrue($task->isPrivate());
     }
+
+    public function testInit()
+    {
+        $this->markTestIncomplete('Test initial task with callable');
+    }
 }


### PR DESCRIPTION
Changed:
- Allowed define task by a callable
- Migrated using `taskGroup()` function to define a task group

```php
taskGroup('deploy', [
    'deploy:start',
    'deploy:end',
]);
```