### PR TITLE
Fix bug #555 and clean output

### DIFF
--- a/src/Console/Output/OutputWatcher.php
+++ b/src/Console/Output/OutputWatcher.php
@@ -35,14 +35,6 @@ class OutputWatcher implements OutputInterface
      */
     public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL)
     {
-        // Next code prints arrow on task line if some output was inside task.
-        // This is ugly hack, and this part should be refactored later, but now i go segmentation fault.
-        static $isFirstTime = true;
-        if (!$this->wasWritten && !$isFirstTime) {
-            $this->output->write("\033[k\033[1A\r➤\n", false, $type);
-        }
-        $isFirstTime = false;
-
         $this->wasWritten = true;
         $this->output->write($messages, $newline, $type);
     }

--- a/src/Executor/Informer.php
+++ b/src/Executor/Informer.php
@@ -49,7 +49,7 @@ class Informer
     public function endTask()
     {
         if ($this->output->getVerbosity() == OutputInterface::VERBOSITY_NORMAL && !$this->output->getWasWritten()) {
-            $this->output->write("\033[k\033[1A\r<info>✔</info>\n");
+            $this->output->writeln("\r\033[K\033[1A\r<info>✔</info>");
         } else {
             $this->output->writeln("<info>✔</info> Ok");
         }

--- a/src/Executor/Informer.php
+++ b/src/Executor/Informer.php
@@ -31,14 +31,7 @@ class Informer
     public function startTask($taskName)
     {
         if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-            if ($this->output->getVerbosity() == OutputInterface::VERBOSITY_NORMAL) {
-                $this->output->write("  ");
-            } else {
-                $this->output->write("➤ ");
-            }
-
-            $this->output->writeln("Executing task $taskName");
-
+            $this->output->writeln("➤ Executing task $taskName");
             $this->output->setWasWritten(false);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #555

The bug #555 was caused by using a wrong escape-sequence for the
terminal.  Instead of using \e[K it has used \e[k which actually has no
meaning and only bloats some noise on the terminal (except on OSX where
the noise is catched and hidden from the user). To see this behaviour
you need a real linux client for example a VM and you have to use it's
own terminal – not the OSX-terminal via ssh or something like that. Than
type the following example to see the behavior:

    echo -e "aaaaaaaaa\r\033[k"
    echo -e "bbbbbbbbb\r\033[K"

Furthermore the cursor is now set to the beginning of the line first to
really clean the line and not just something starting from a random
position.