### PR TITLE
Clean ugly hack in output of an executing task

### DIFF
--- a/src/Console/Output/OutputWatcher.php
+++ b/src/Console/Output/OutputWatcher.php
@@ -35,14 +35,6 @@ class OutputWatcher implements OutputInterface
      */
     public function write($messages, $newline = false, $type = self::OUTPUT_NORMAL)
     {
-        // Next code prints arrow on task line if some output was inside task.
-        // This is ugly hack, and this part should be refactored later, but now i go segmentation fault.
-        static $isFirstTime = true;
-        if (!$this->wasWritten && !$isFirstTime) {
-            $this->output->write("\033[k\033[1A\r➤\n", false, $type);
-        }
-        $isFirstTime = false;
-
         $this->wasWritten = true;
         $this->output->write($messages, $newline, $type);
     }

--- a/src/Executor/Informer.php
+++ b/src/Executor/Informer.php
@@ -31,14 +31,7 @@ class Informer
     public function startTask($taskName)
     {
         if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-            if ($this->output->getVerbosity() == OutputInterface::VERBOSITY_NORMAL) {
-                $this->output->write("  ");
-            } else {
-                $this->output->write("➤ ");
-            }
-
-            $this->output->writeln("Executing task $taskName");
-
+            $this->output->writeln("➤ Executing task $taskName");
             $this->output->setWasWritten(false);
         }
     }


### PR DESCRIPTION
Removed ugly hack in OutputWatcher. No the arrow will be printed by beginning of the task and be overwritten with an check mark. I think this is ok, because it only speed up the old implementation with lees pain.

Old:
1. set space or arrow, depending on verbositiy
2. perform task
3. set arrow or check mark, depending of written lines

New:
1. set arrow
2. perform task
3. set check mark if no new lines were written

The result is actually the same.