### PR TITLE
Remove existing /current directory to prevent symlinks as subdirs

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -318,6 +318,9 @@ task('deploy:vendors', function () {
  * Create symlink to last release.
  */
 task('deploy:symlink', function () {
+    // Remove /current directory if it isn't a symlink (prevents symlinks in subdirectory)
+    run("if [ ! -L {{deploy_path}}/current ] && [ -d {{deploy_path}}/current ]; then rm -rf {{deploy_path}}/current; fi");
+
     run("cd {{deploy_path}} && ln -sfn {{release_path}} current"); // Atomic override symlink.
     run("cd {{deploy_path}} && rm release"); // Remove release link.
 })->desc('Creating symlink to release');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

We pre-configure our hosting environments with a skeleton "current" directory and, as it turns out, this caused Deployer to create the "current" symlinks as subdirectories, like follows:

```
$ ls -la current/
totaal 20
drwxrwxr-x 2 [...] [...] 4096 11 mrt 09:49 .
drwxr-xr-x 6 [...] [...] 4096 11 mrt 09:49 ..
lrwxrwxrwx 1 [...] [...]   72 11 mrt 09:33 20160311083328 -> [...]/releases/20160311083328
lrwxrwxrwx 1 [...] [...]   72 11 mrt 09:36 20160311083556 -> [...]/releases/20160311083556
lrwxrwxrwx 1 [...] [...]   72 11 mrt 09:49 20160311084947 -> [...]/releases/20160311084947
```

This PR ensures that an existing "current" directory (not a symlink) is removed prior to creating the symlink.
