### PR TITLE
Added constant DEPLOYER for other autoload scripts to check

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -6,6 +6,8 @@
  * file that was distributed with this source code.
  */
 
+define("DEPLOYER", 1);
+
 $loaded = false;
 
 foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {

--- a/bin/dep
+++ b/bin/dep
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-define("DEPLOYER", 1);
+define('DEPLOYER', true);
 
 $loaded = false;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Using this to deploy Joomla. Have a few autoloading scripts for Joomla only checking if JEXEC is defined. This allows my autoloads to return if DEPLOYER is defined. 