### PR TITLE
Run deploy:writable again after cache warmup

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -126,6 +126,7 @@ task('deploy', [
     'deploy:vendors',
     'deploy:assetic:dump',
     'deploy:cache:warmup',
+    'deploy:writable',
     'deploy:symlink',
     'cleanup',
 ])->desc('Deploy your project');

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -121,7 +121,6 @@ task('deploy', [
     'deploy:update_code',
     'deploy:create_cache_dir',
     'deploy:shared',
-    'deploy:writable',
     'deploy:assets',
     'deploy:vendors',
     'deploy:assetic:dump',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #575 

As described in ticket #575 the cache is not writable after the deployment of symfony if the deployment-user is not the httpd-user. Therefore we would make the cache-directory writable again after the
cache-warmup.  This is necessary because symfony may not do that and the deploy user should know who is able to write into the cache.  You can finally define this by using `set('writable_dirs', […])` and
`set('http_user', '…')`.