### PR TITLE
Fixed SSH upload method bug

### DIFF
--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -131,7 +131,7 @@ class SshExtension implements ServerInterface
             $this->directories[$dir] = true;
         }
 
-        if (!$this->session->getSftp()->send($local, $remote)) {
+        if ($this->session->getSftp()->send($local, $remote) === false) {
             throw new \RuntimeException('Can not upload file.');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? |No
| Fixed tickets | N/A

The `Ssh\Sftp\send` method return `false` on failure. The `!$this->session->getSftp()->send($local, $remote)` check will throw and exception if the file is empty (0 bytes sent).
