### PR TITLE
Add initial support for custom php and php-cli binary.

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -37,6 +37,9 @@ env('git_cache', function () { //whether to use git cache - faster cloning by bo
     return version_compare($version, '2.3', '>=');
 });
 env('release_name', date('YmdHis')); // name of folder in releases
+env('php_bin', function () {
+    return run('which php');
+});
 
 /**
  * Default arguments and options.
@@ -313,7 +316,7 @@ task('deploy:vendors', function () {
     
     if (! commandExist($composer)) {
         run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | php");
-        $composer = 'php composer.phar';
+        $composer = '{{php_bin}} composer.phar';
     }
 
     $composerEnvVars = env('env_vars') ? 'export ' . env('env_vars') . ' &&' : '';

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -26,6 +26,9 @@ env('timezone', 'UTC');
 env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
+env('composer_require_cli', function () {
+    return false;
+});
 env('git_cache', function () { //whether to use git cache - faster cloning by borrowing objects from existing clones.
     $gitVersion = run('git version');
     $regs       = [];
@@ -316,7 +319,7 @@ task('deploy:vendors', function () {
     
     if (! commandExist($composer)) {
         run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | php");
-        $composer = '{{php_bin}} composer.phar';
+        $composer = sprintf('{{php_bin}}%s composer.phar', env('composer_require_cli') ? '-cli' : '');
     }
 
     $composerEnvVars = env('env_vars') ? 'export ' . env('env_vars') . ' &&' : '';

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -42,11 +42,11 @@ after('deploy', 'success');
  * Helper tasks
  */
 task('deploy:up', function () {
-    $output = run('php {{deploy_path}}/current/artisan up');
+    $output = run('{{php_bin}} {{deploy_path}}/current/artisan up');
     writeln('<info>'.$output.'</info>');
 })->desc('Disable maintenance mode');
 
 task('deploy:down', function () {
-    $output = run('php {{deploy_path}}/current/artisan down');
+    $output = run('{{php_bin}} {{deploy_path}}/current/artisan down');
     writeln('<error>'.$output.'</error>');
 })->desc('Enable maintenance mode');

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -74,7 +74,7 @@ task('deploy:assetic:dump', function () {
         return;
     }
 
-    run('php {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assetic:dump --env={{env}} --no-debug');
+    run('{{php_bin}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assetic:dump --env={{env}} --no-debug');
 
 })->desc('Dump assets');
 
@@ -84,7 +84,7 @@ task('deploy:assetic:dump', function () {
  */
 task('deploy:cache:warmup', function () {
 
-    run('php {{release_path}}/' . trim(get('bin_dir'), '/') . '/console cache:warmup  --env={{env}} --no-debug');
+    run('{{php_bin}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console cache:warmup  --env={{env}} --no-debug');
 
 })->desc('Warm up cache');
 
@@ -94,7 +94,7 @@ task('deploy:cache:warmup', function () {
  */
 task('database:migrate', function () {
 
-    run('php {{release_path}}/' . trim(get('bin_dir'), '/') . '/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction');
+    run('{{php_bin}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction');
 
 })->desc('Migrate database');
 

--- a/recipe/yii2-app-advanced.php
+++ b/recipe/yii2-app-advanced.php
@@ -35,14 +35,14 @@ set('shared_files', [
  * Initialization
  */
 task('deploy:init', function () {
-    run('php {{release_path}}/init --env=Production --overwrite=n');
+    run('{{php_bin}} {{release_path}}/init --env=Production --overwrite=n');
 })->desc('Initialization');
 
 /**
  * Run migrations
  */
 task('deploy:run_migrations', function () {
-    run('php {{release_path}}/yii migrate up --interactive=0');
+    run('{{php_bin}} {{release_path}}/yii migrate up --interactive=0');
 })->desc('Run migrations');
 
 /**

--- a/recipe/yii2-app-basic.php
+++ b/recipe/yii2-app-basic.php
@@ -19,7 +19,7 @@ set('shared_dirs', ['runtime']);
  * Run migrations
  */
 task('deploy:run_migrations', function () {
-    run('php {{release_path}}/yii migrate up --interactive=0');
+    run('{{php_bin}} {{release_path}}/yii migrate up --interactive=0');
 })->desc('Run migrations');
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #586 

This add initial support for configure a custom php for each server.

Some servers, need use php-cli to install vendors. This PR use a new env var (<code>composer_require_cli</code>) to handle that too
