### PR TITLE
Fixed usage of composer.phar, when used as env/composer

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -53,7 +53,7 @@ env('bin/composer', function () {
 
     if (empty($composer)) {
         run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | php");
-        $composer = '{{bin/php}} composer.phar';
+        $composer = '{{bin/php}} {{release_path}}/composer.phar';
     }
 
     return $composer;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | https://github.com/deployphp/deployer/issues/615

