### PR TITLE
Fix custom php bin for composer install.

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -52,7 +52,7 @@ env('bin/composer', function () {
     }
 
     if (empty($composer)) {
-        run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | php");
+        run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}");
         $composer = '{{bin/php}} {{release_path}}/composer.phar';
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This PR fix missing custom php binary for composer installer.