### PR TITLE
Bugfix laravel recipe

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -20,12 +20,12 @@ set('writable_dirs', ['bootstrap/cache', 'storage']);
 /**
  * Helper tasks
  */
-task('deploy:up', function () {
+task('artisan:up', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan up');
     writeln('<info>'.$output.'</info>');
 })->desc('Disable maintenance mode');
 
-task('deploy:down', function () {
+task('artisan:down', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan down');
     writeln('<error>'.$output.'</error>');
 })->desc('Enable maintenance mode');
@@ -37,8 +37,8 @@ task('deploy', [
     'deploy:prepare',
     'deploy:release',
     'deploy:update_code',
-    'deploy:vendors',
     'deploy:shared',
+    'deploy:vendors',
     'deploy:writable',
     'deploy:symlink',
     'cleanup',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -9,19 +9,26 @@ require_once __DIR__ . '/common.php';
 // This recipe support Laravel 5.1+, with orther version, please see document https://github.com/deployphp/docs
 
 // Laravel shared dirs
-set('shared_dirs', [
-    'storage/app',
-    'storage/framework/cache',
-    'storage/framework/sessions',
-    'storage/framework/views',
-    'storage/logs',
-]);
+set('shared_dirs', ['storage']);
 
 // Laravel 5 shared file
 set('shared_files', ['.env']);
 
 // Laravel writable dirs
 set('writable_dirs', ['bootstrap/cache', 'storage']);
+
+/**
+ * Helper tasks
+ */
+task('deploy:up', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan up');
+    writeln('<info>'.$output.'</info>');
+})->desc('Disable maintenance mode');
+
+task('deploy:down', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan down');
+    writeln('<error>'.$output.'</error>');
+})->desc('Enable maintenance mode');
 
 /**
  * Main task
@@ -32,21 +39,9 @@ task('deploy', [
     'deploy:update_code',
     'deploy:vendors',
     'deploy:shared',
+    'deploy:writable',
     'deploy:symlink',
     'cleanup',
 ])->desc('Deploy your project');
 
 after('deploy', 'success');
-
-/**
- * Helper tasks
- */
-task('deploy:up', function () {
-    $output = run('php {{deploy_path}}/current/artisan up');
-    writeln('<info>'.$output.'</info>');
-})->desc('Disable maintenance mode');
-
-task('deploy:down', function () {
-    $output = run('php {{deploy_path}}/current/artisan down');
-    writeln('<error>'.$output.'</error>');
-})->desc('Enable maintenance mode');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #527 #572 

In this PR:
- Replace `php` by `{{bin/php}}`
- ~~Add helper tasks about migration and option `--force` can set by `env()`~~
- Resolved issues about shared directories and `.env` file
- Resolved issues about writable `storage` directory. Tested with `setfacl` on CentOS
- Changed order task deploy:shared and deploy:vendors in laravel recipe (See #619)
