### PR TITLE
Add helper tasks for laravel recipe

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -6,7 +6,8 @@
  */
 
 require_once __DIR__ . '/common.php';
-// This recipe support Laravel 5.1+, with orther version, please see document https://github.com/deployphp/docs
+// This recipe support Laravel 5.1+,
+// with orther version, please see document https://github.com/deployphp/docs
 
 // Laravel shared dirs
 set('shared_dirs', ['storage']);
@@ -59,6 +60,11 @@ task('artisan:config:cache', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan config:cache');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan config:cache');
+
+task('artisan:route:cache', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan route:cache');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan route:cache');
 
 /**
  * Task deploy:public_disk support the public disk.

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -7,7 +7,7 @@
 
 require_once __DIR__ . '/common.php';
 // This recipe support Laravel 5.1+,
-// with orther version, please see document https://github.com/deployphp/docs
+// with other version, please see document https://github.com/deployphp/docs
 
 // Laravel shared dirs
 set('shared_dirs', ['storage']);

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -23,6 +23,38 @@ set('shared_files', ['.env']);
 // Laravel writable dirs
 set('writable_dirs', ['bootstrap/cache', 'storage']);
 
+task('deploy:migrate', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate --force');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan migrate');
+
+task('deploy:migrate_rollback', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:rollback --force');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan migrate:rollback');
+
+task('deploy:migrate_status', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:status');
+    writeln('<info>' . $output . '</info>');
+})->desc('Show status of migration');
+
+/**
+ * Task deploy:public_disk support the public disk.
+ * To run this task automatically, please add below line to your deploy.php file
+ * <code>after('deploy:symlink', 'deploy:public_disk');</code>
+ * @see https://laravel.com/docs/5.2/filesystem#configuration
+ */
+task('deploy:public_disk', function () {
+    // Remove from source.
+    run('if [ -d $(echo {{release_path}}/public/storage) ]; then rm -rf {{release_path}}/public/storage; fi');
+
+    // Create shared dir if it does not exist.
+    run('mkdir -p {{deploy_path}}/shared/storage/app/public');
+
+    // Symlink shared dir to release dir
+    run('ln -nfs {{deploy_path}}/shared/storage/app/public {{release_path}}/public/storage');
+})->desc('Make symlink for public disk');
+
 /**
  * Main task
  */

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -23,20 +23,35 @@ set('shared_files', ['.env']);
 // Laravel writable dirs
 set('writable_dirs', ['bootstrap/cache', 'storage']);
 
-task('deploy:migrate', function () {
+task('artisan:migrate', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate --force');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan migrate');
 
-task('deploy:migrate_rollback', function () {
+task('artisan:migrate:rollback', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:rollback --force');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan migrate:rollback');
 
-task('deploy:migrate_status', function () {
+task('artisan:migrate:status', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:status');
     writeln('<info>' . $output . '</info>');
-})->desc('Show status of migration');
+})->desc('Execute artisan migrate:status');
+
+task('artisan:db:seed', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan db:seed --force');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan db:seed');
+
+task('artisan:cache:clear', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan cache:clear');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan cache:clear');
+
+task('artisan:config:cache', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan config:cache');
+    writeln('<info>' . $output . '</info>');
+})->desc('Execute artisan config:cache');
 
 /**
  * Task deploy:public_disk support the public disk.

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -17,6 +17,19 @@ set('shared_files', ['.env']);
 // Laravel writable dirs
 set('writable_dirs', ['bootstrap/cache', 'storage']);
 
+/**
+ * Helper tasks
+ */
+task('artisan:up', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan up');
+    writeln('<info>'.$output.'</info>');
+})->desc('Disable maintenance mode');
+
+task('artisan:down', function () {
+    $output = run('{{bin/php}} {{deploy_path}}/current/artisan down');
+    writeln('<error>'.$output.'</error>');
+})->desc('Enable maintenance mode');
+
 task('artisan:migrate', function () {
     $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate --force');
     writeln('<info>' . $output . '</info>');
@@ -65,19 +78,6 @@ task('deploy:public_disk', function () {
 })->desc('Make symlink for public disk');
 
 /**
- * Helper tasks
- */
-task('artisan:up', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan up');
-    writeln('<info>'.$output.'</info>');
-})->desc('Disable maintenance mode');
-
-task('artisan:down', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan down');
-    writeln('<error>'.$output.'</error>');
-})->desc('Enable maintenance mode');
-
-/**
  * Main task
  */
 task('deploy', [
@@ -89,6 +89,8 @@ task('deploy', [
     'deploy:writable',
     'deploy:symlink',
     'cleanup',
+    'artisan:cache:clear',
+    'artisan:config:cache',
 ])->desc('Deploy your project');
 
 after('deploy', 'success');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #541 #619 

Added helper tasks:
- `artisan:migrate` => `artisan migrate --force`
- `artisan:migrate:rollback` => `artisan migrate:rollback --force`
- `artisan:migrate:status` => `artisan migrate:status`
- `artisan:db:seed` => `artisan db:seed --force`
- `artisan:cache:clear` => `artisan cache:clear`
- `artisan:config:cache` => `artisan config:cache`
- `deploy:public_disk` => Create symlink `public/storage` to `storage/app/public`
