### PR TITLE
Improve Collection class by feature of PHP 5.5+

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -22,7 +22,7 @@ class Collection implements CollectionInterface, \Countable
         if ($this->has($name)) {
             return $this->collection[$name];
         } else {
-            $class = explode('\\', get_class($this));
+            $class = explode('\\', static::class);
             $class = end($class);
             throw new \RuntimeException("Object `$name` does not exist in $class.");
         }

--- a/src/Server/EnvironmentCollection.php
+++ b/src/Server/EnvironmentCollection.php
@@ -11,12 +11,4 @@ use Deployer\Collection\Collection;
 
 class EnvironmentCollection extends Collection
 {
-    /**
-     * @param string $name
-     * @return Environment
-     */
-    public function get($name)
-    {
-        return parent::get($name);
-    }
 }

--- a/src/Server/ServerCollection.php
+++ b/src/Server/ServerCollection.php
@@ -11,12 +11,4 @@ use Deployer\Collection\Collection;
 
 class ServerCollection extends Collection
 {
-    /**
-     * @param string $name
-     * @return ServerInterface
-     */
-    public function get($name)
-    {
-        return parent::get($name);
-    }
 }

--- a/src/Task/Scenario/ScenarioCollection.php
+++ b/src/Task/Scenario/ScenarioCollection.php
@@ -12,12 +12,4 @@ use Deployer\Task\Scenario\Scenario;
 
 class ScenarioCollection extends Collection
 {
-    /**
-     * @param string $name
-     * @return Scenario
-     */
-    public function get($name)
-    {
-        return parent::get($name);
-    }
 }

--- a/src/Task/TaskCollection.php
+++ b/src/Task/TaskCollection.php
@@ -11,12 +11,4 @@ use Deployer\Collection\Collection;
 
 class TaskCollection extends Collection
 {
-    /**
-     * @param string $name
-     * @return Task
-     */
-    public function get($name)
-    {
-        return parent::get($name);
-    }
 }

--- a/test/recipe/CommonTest.php
+++ b/test/recipe/CommonTest.php
@@ -139,8 +139,8 @@ class CommonTest extends RecipeTester
      */
     public function testClean()
     {
-        set('clear_paths', ['current/app/README.md', 'current/app/tests']);
-        set('clear_use_sudo', false);
+        \Deployer\set('clear_paths', ['current/app/README.md', 'current/app/tests']);
+        \Deployer\set('clear_use_sudo', false);
 
         $this->exec('deploy:clean');
 

--- a/test/src/Collection/CollectionTest.php
+++ b/test/src/Collection/CollectionTest.php
@@ -8,7 +8,6 @@
 namespace Deployer\Collection;
 
 use Deployer\Server\EnvironmentCollection;
-use Deployer\Server\GroupCollection;
 use Deployer\Server\ServerCollection;
 use Deployer\Task\Scenario\ScenarioCollection;
 use Deployer\Task\TaskCollection;
@@ -52,10 +51,14 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider collections
      * @depends      testCollection
-     * @expectedException \RuntimeException
      */
     public function testException($collection)
     {
+        $class = explode('\\', get_class($collection));
+        $class = end($class);
+        $name  = 'unexpected';
+
+        $this->setExpectedException(\RuntimeException::class, "Object `$name` does not exist in $class.");
         $collection->get('unexpected');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This PR only improves Collection classes by using `static::class` constant instead of `get_class()` function.
