### PR TITLE
Fix phpseclib api

### DIFF
--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -59,7 +59,7 @@ class PhpSecLib implements ServerInterface
 
                 $key = new RSA();
                 $key->setPassword($serverConfig->getPassPhrase());
-                $key->loadKey(file_get_contents($serverConfig->getPrivateKey()));
+                $key->load(file_get_contents($serverConfig->getPrivateKey()));
 
                 $result = $this->sftp->login($serverConfig->getUser(), $key);
 
@@ -68,7 +68,7 @@ class PhpSecLib implements ServerInterface
             case Configuration::AUTH_BY_PEM_FILE:
 
                 $key = new RSA();
-                $key->loadKey(file_get_contents($serverConfig->getPemFile()));
+                $key->load(file_get_contents($serverConfig->getPemFile()));
                 $result = $this->sftp->login($serverConfig->getUser(), $key);
 
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

- The method loadKey() was renamed load()
- See: https://github.com/phpseclib/phpseclib/commit/b4cf10fc94590b8164c2c9ff31e5e0cfe34eab9d#diff-b4b2acaebb5e3d125481ec5da11baff5