### PR TITLE
Enabling 2-factor with private key + password

### DIFF
--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -154,6 +154,25 @@ class Builder
     }
 
     /**
+     * Authenticate with public key + password (2-factor)
+     *
+     * @param string $publicKeyFile
+     * @param string $privateKeyFile
+     * @param string $passPhrase
+     * @param string $password
+     *
+     * @return Builder
+     */
+    public function identityFileAndPassword($publicKeyFile = '~/.ssh/id_rsa.pub', $privateKeyFile = '~/.ssh/id_rsa', $passPhrase = '', $password = null)
+    {
+        $this->identityFile($publicKeyFile, $privateKeyFile, $passPhrase);
+        $this->password($password);
+        $this->config->setAuthenticationMethod(Configuration::AUTH_BY_IDENTITY_FILE_AND_PASSWORD);
+
+        return $this;
+    }
+
+    /**
      * Authenticate with pem file
      *
      * @param string $pemFile

--- a/src/Server/Configuration.php
+++ b/src/Server/Configuration.php
@@ -21,6 +21,7 @@ class Configuration
     const AUTH_BY_IDENTITY_FILE = 2;
     const AUTH_BY_PEM_FILE      = 3;
     const AUTH_BY_AGENT         = 4;
+    const AUTH_BY_IDENTITY_FILE_AND_PASSWORD    = 5;
 
     /**
      * Type of authentication.

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -81,6 +81,16 @@ class PhpSecLib implements ServerInterface
 
                 break;
 
+            case Configuration::AUTH_BY_IDENTITY_FILE_AND_PASSWORD:
+
+                $key = new RSA();
+                $key->setPassword($serverConfig->getPassPhrase());
+                $key->loadKey(file_get_contents($serverConfig->getPrivateKey()));
+
+                $result = $this->sftp->login($serverConfig->getUser(), $key, $serverConfig->getPassword());
+
+                break;
+
             default:
                 throw new RuntimeException('You need to specify authentication method.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | 638

The underlying SFTP library allows for multiple authentication methods, so I've added a new setting AUTH_BY_IDENTITY_FILE_AND_PASSWORD.  I would imagine a better way to handle this would be to queue up each authentication method in an array and pass them as the arguments for the sftp->login() call, but I felt that I had too much potential to create breakage - so instead I created an additional method.

To use:

``` php
server('staging', 'example.com', 22)
    ->user('username')
    ->identityFileAndPassword() // Arguments are the 3 identityFile() arguments + the password() argument.  It will assume those defaults if nothing is passed.
    ->stage('staging')
    ->env('branch', 'staging')
    ->env('deploy_path', '/var/www/html/staging');
```
