### PR TITLE
Fix assets installation in Symfony 3

### DIFF
--- a/recipe/symfony3.php
+++ b/recipe/symfony3.php
@@ -10,6 +10,20 @@ require_once __DIR__ . '/symfony.php';
 /**
  * Symfony 3 Configuration
  */
+ 
+/**
+ * Dump all assets to the filesystem
+ * 
+ * This overrides the Symfony 2 assetic:dump command
+ * in favor of the new assets:install command.
+ */
+task('deploy:assetic:dump', function () {
+    if (!get('dump_assets')) {
+        return;
+    }
+
+    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assets:install --env={{env}} --no-debug {{release_path}}/web');
+})->desc('Dump assets');
 
 // Symfony shared dirs
 set('shared_dirs', ['var/logs', 'var/sessions']);

--- a/recipe/symfony3.php
+++ b/recipe/symfony3.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/symfony.php';
  
 /**
  * Dump all assets to the filesystem
- * 
+ *
  * This overrides the Symfony 2 assetic:dump command
  * in favor of the new assets:install command.
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

The `assetic:dump` command does not exist in Symfony 3. The `assetic` namespace has been replaced by `assets`. The new command to install assets is `assets:install`. 

This PR overrides the `deploy:assetic:dump` command so it works in Symfony 3. Ideally, the `deploy:assetic:dump` command would be renamed to something like `deploy:assets:install` in the main deploy task. However, this would mean overriding the entire list of tasks.