### PR TITLE
fix task once

### DIFF
--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -286,7 +286,7 @@ class ParallelExecutor implements ExecutorInterface
                 $this->informer->startTask($taskName);
 
                 if ($task->isOnce()) {
-                    $task->run(new Context(null, null, $this->input, $this->output));
+                    $task->run(new Context(null, new Environment(), $this->input, $this->output));
                     $this->informer->endTask();
                 } else {
                     $this->tasksToDo = [];

--- a/src/Executor/SeriesExecutor.php
+++ b/src/Executor/SeriesExecutor.php
@@ -27,7 +27,7 @@ class SeriesExecutor implements ExecutorInterface
             $informer->startTask($task->getName());
 
             if ($task->isOnce()) {
-                $task->run(new Context(null, null, $input, $output));
+                $task->run(new Context(null, new Environment(), $input, $output));
             } else {
                 foreach ($servers as $serverName => $server) {
                     if ($task->runOnServer($serverName)) {

--- a/test/fixture/recipe.php
+++ b/test/fixture/recipe.php
@@ -23,3 +23,8 @@ task('test', [
     'test:hello',
     'test:onlyForStage'
 ]);
+
+task('test:hello', function () {
+    runLocally('echo "hello"');
+    writeln('Hello world!');
+})->once();

--- a/test/src/Executor/ParallelExecutorTest.php
+++ b/test/src/Executor/ParallelExecutorTest.php
@@ -31,6 +31,9 @@ class ParallelExecutorTest extends RecipeTester
         define('DEPLOYER_BIN', __DIR__ . '/../../../bin/dep');
     }
 
+    /**
+     * @group executor
+     */
     public function testParallel()
     {
         $display = $this->exec('test', ['--parallel' => true, '--file' => $this->recipeFile]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

deploy.php
```php
task('deployer:start', function () {
    if(runLocally('if [ -f start.txt ]; then echo "true"; fi')->toBool())
    {
        throw new \RuntimeException('deployer already started');
    }
    runLocally('touch start.txt');
})->desc('Deployer start')
    ->once()
    ->setPrivate();

task('deployer:end', function () {
    runLocally('rm -rf start.txt');
})->desc('Deployer end')
    ->once()
    ->setPrivate();
```

result : 
PHP Fatal error:  Uncaught Error: Call to a member function parse() on null in /.../vendor/deployer/deployer/src/functions.php:316

functions.php
```php
function runLocally($command, $timeout = 60)
{
    $command = env()->parse($command);
```

```php
function env($name = null, $value = null)
{
    if (false === Context::get()) {
        Environment::setDefault($name, $value);
    } else {
        if (null === $name && null === $value) {
            return Context::get()->getEnvironment();
```
Context::get()->getEnvironment() is null

fix :
SeriesExecutor.php line 29
```php
if ($task->isOnce()) {
    $task->run(new Context(null, null, $input, $output));
```
->
```php
if ($task->isOnce()) {
    $task->run(new Context(null, new Environment(), $input, $output));
```

ParallerlExecutor.php line 288
```php
if ($task->isOnce()) {
    $task->run(new Context(null, null, $this->input, $this->output));
```
->
```php
if ($task->isOnce()) {
    $task->run(new Context(null, new Environment(), $this->input, $this->output));
```