### PR TITLE
Format release name according to timezone.

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -35,7 +35,9 @@ env('git_cache', function () { //whether to use git cache - faster cloning by bo
     }
     return version_compare($version, '2.3', '>=');
 });
-env('release_name', date('YmdHis')); // name of folder in releases
+env('release_name', (new DateTime())
+    ->setTimeZone(new DateTimeZone(get('timezone')))
+    ->format('YmdHis')); // name of folder in releases
 
 /**
  * Custom bins.

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -17,11 +17,11 @@ set('writable_use_sudo', true); // Using sudo in writable commands?
 set('http_user', null);
 set('clear_paths', []);         // Relative path from deploy_path
 set('clear_use_sudo', true);    // Using sudo in clean commands?
+set('timezone', 'UTC'); // Timezone used in release folder name
 
 /**
  * Environment vars
  */
-env('timezone', 'UTC');
 env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
@@ -36,7 +36,7 @@ env('git_cache', function () { //whether to use git cache - faster cloning by bo
     return version_compare($version, '2.3', '>=');
 });
 env('release_name', (new DateTime())
-    ->setTimeZone(new DateTimeZone(env('timezone')))
+    ->setTimeZone(new DateTimeZone(get('timezone')))
     ->format('YmdHis')); // name of folder in releases
 
 /**

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -17,11 +17,11 @@ set('writable_use_sudo', true); // Using sudo in writable commands?
 set('http_user', null);
 set('clear_paths', []);         // Relative path from deploy_path
 set('clear_use_sudo', true);    // Using sudo in clean commands?
-set('timezone', 'UTC'); // Timezone used in release folder name
 
 /**
  * Environment vars
  */
+env('timezone', 'UTC');
 env('branch', ''); // Branch to deploy.
 env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
 env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
@@ -35,9 +35,13 @@ env('git_cache', function () { //whether to use git cache - faster cloning by bo
     }
     return version_compare($version, '2.3', '>=');
 });
-env('release_name', (new DateTime())
-    ->setTimeZone(new DateTimeZone(get('timezone')))
-    ->format('YmdHis')); // name of folder in releases
+env('release_name', function () {
+    // Use env-defined timezone, default to 'UTC' if invalid
+    if (!date_default_timezone_set(env('timezone'))) {
+        date_default_timezone_set('UTC');
+    }
+    return date('YmdHis');
+}); // name of folder in releases
 
 /**
  * Custom bins.

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -36,7 +36,7 @@ env('git_cache', function () { //whether to use git cache - faster cloning by bo
     return version_compare($version, '2.3', '>=');
 });
 env('release_name', (new DateTime())
-    ->setTimeZone(new DateTimeZone(get('timezone')))
+    ->setTimeZone(new DateTimeZone(env('timezone')))
     ->format('YmdHis')); // name of folder in releases
 
 /**
@@ -119,11 +119,6 @@ task('deploy:prepare', function () {
         write($formatter->formatBlock($errorMessage, 'error', true));
 
         throw $e;
-    }
-
-    // Set the deployment timezone
-    if (!date_default_timezone_set(env('timezone'))) {
-        date_default_timezone_set('UTC');
     }
 
     run('if [ ! -d {{deploy_path}} ]; then mkdir -p {{deploy_path}}; fi');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | _Potentially_
| Deprecations? | No
| Fixed tickets | [649](https://github.com/deployphp/deployer/issues/649)

The `timezone` environment variable was not used when generating release folder name, which could cause the build to break.

This *can* however be considered a breaking change, because users from a timezone that is ahead of UTC, who move towards consistently using UTC instead of their own timezone, _and_ who already deployed enough releases in the last few hours, might see their release folder instantly removed on deploy.