### PR TITLE
Check for locally installed composer.phar

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -58,10 +58,19 @@ env('bin/composer', function () {
         $composer = run('which composer')->toString();
     }
 
-    if (empty($composer)) {
-        run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}");
-        $composer = '{{bin/php}} {{release_path}}/composer.phar';
+    if (!empty($composer)) {
+        return $composer;
     }
+
+    // check for a locally installed version of composer
+    $localFile = env()->parse('{{release_path}}/composer.phar');
+    if (is_file($localFile)) {
+        $composer = '{{bin/php}} {{release_path}}/composer.phar';
+        return $composer;
+    }
+
+    run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | php");
+    $composer = '{{bin/php}} {{release_path}}/composer.phar';
 
     return $composer;
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

If you already have a copy of composer.phar in {{release_path}} Deployer downloads a new copy instead of using the existing file.  This pull request adds a check so it will use that local copy.  