### PR TITLE
Avoid -R for setfacl and use find instead

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -291,8 +291,8 @@ task('deploy:writable', function () {
             } elseif (commandExist('setfacl')) {
                 if (!empty($httpUser)) {
                     if (!empty($sudo)) {
-                        run("$sudo setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
-                        run("$sudo setfacl -dR -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs");
+                        run("$sudo find $dirs | $sudo xargs setfacl -m u:\"$httpUser\":rwX -m u:`whoami`:rwX");
+                        run("$sudo find $dirs | $sudo xargs setfacl -d -m u:\"$httpUser\":rwX -m u:`whoami`:rwX");
                     } else {
                         // When running without sudo, exception may be thrown
                         // if executing setfacl on files created by http user (in directory that has been setfacl before).
@@ -304,8 +304,8 @@ task('deploy:writable', function () {
                             $hasfacl = run("getfacl -p $dir | grep \"^user:$httpUser:.*w\" | wc -l")->toString();
                             // Set ACL for directory if it has not been set before
                             if (!$hasfacl) {
-                                run("setfacl -R -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
-                                run("setfacl -dR -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
+                                run("find $dirs | xargs setfacl -m u:\"$httpUser\":rwX -m u:`whoami`:rwX");
+                                run("find $dirs | xargs setfacl -d -m u:\"$httpUser\":rwX -m u:`whoami`:rwX");
                             }
                         }
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #683 

`setfacl` may has no `-R` option on non-GNU systems therefore we want to avoid this plattform-specific option and use a more general solution instead. This solution is build on `find` and `xargs` because these tools can emulate the whole behaviour smoothly and are widely available.