### PR TITLE
Refactoring/Cleanup/Fixes for Symfony-related Recipes

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -18,13 +18,21 @@ set('http_user', null);
 set('clear_paths', []);         // Relative path from deploy_path
 set('clear_use_sudo', true);    // Using sudo in clean commands?
 
+
+/**
+ * Composer options
+ */
+env('composer_action', 'install');
+env('composer_options', '{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
+
+
 /**
  * Environment vars
  */
 env('timezone', 'UTC');
 env('branch', ''); // Branch to deploy.
-env('env_vars', ''); // For Composer installation. Like SYMFONY_ENV=prod
-env('composer_options', 'install --no-dev --verbose --prefer-dist --optimize-autoloader --no-progress --no-interaction');
+env('env_vars', ''); // Variable assignment before cmds (for example, SYMFONY_ENV={{env}})
+
 env('git_cache', function () { //whether to use git cache - faster cloning by borrowing objects from existing clones.
     $gitVersion = run('{{bin/git}} version');
     $regs       = [];
@@ -43,6 +51,7 @@ env('release_name', function () {
 
     return date('YmdHis');
 }); // name of folder in releases
+
 
 /**
  * Custom bins.
@@ -73,6 +82,7 @@ env('bin/composer', function () {
 argument('stage', \Symfony\Component\Console\Input\InputArgument::OPTIONAL, 'Run tasks only on this server or group of servers.');
 option('tag', null, \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL, 'Tag to deploy.');
 option('revision', null, \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL, 'Revision to deploy.');
+
 
 /**
  * Rollback to previous release.
@@ -336,10 +346,7 @@ task('deploy:writable', function () {
  * Installing vendors tasks.
  */
 task('deploy:vendors', function () {
-    $composer = env('bin/composer');
-    $envVars = env('env_vars') ? 'export ' . env('env_vars') . ' &&' : '';
-
-    run("cd {{release_path}} && $envVars $composer {{composer_options}}");
+    run('cd {{release_path}} && {{env_vars}} {{bin/composer}} {{composer_options}}');
 })->desc('Installing vendors');
 
 

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -7,9 +7,13 @@
 
 require_once __DIR__ . '/common.php';
 
+
 /**
  * Symfony Configuration
  */
+
+// Symfony build env
+env('env', 'prod');
 
 // Symfony shared dirs
 set('shared_dirs', ['app/logs']);
@@ -22,16 +26,28 @@ set('writable_dirs', ['app/cache', 'app/logs']);
 
 // Assets
 set('assets', ['web/css', 'web/images', 'web/js']);
-// Default true - BC for Symfony < 3.0
-set('dump_assets', true);
+
+// Requires non symfony-core package `kriswallsmith/assetic` to be installed
+set('dump_assets', false);
 
 // Environment vars
-env('env_vars', 'SYMFONY_ENV=prod');
-env('env', 'prod');
+env('env_vars', 'SYMFONY_ENV={{env}}');
 
 // Adding support for the Symfony3 directory structure
 set('bin_dir', 'app');
 set('var_dir', 'app');
+
+// Symfony console bin
+env('bin/console', function () {
+    return sprintf('{{release_path}}/%s/console', trim(get('bin_dir'), '/'));
+});
+
+// Symfony console opts
+env('console_options', function () {
+    $options = '--no-interaction --env={{env}}';
+
+    return env('env') !== 'prod' ? $options : sprintf('%s --no-debug', $options);
+});
 
 
 /**
@@ -60,21 +76,25 @@ task('deploy:assets', function () {
         return "{{release_path}}/$asset";
     }, get('assets')));
 
-    $time = date('Ymdhi.s');
-
-    run("find $assets -exec touch -t $time {} ';' &> /dev/null || true");
+    run(sprintf('find %s -exec touch -t %s {} \';\' &> /dev/null || true', $assets, date('Ymdhi.s')));
 })->desc('Normalize asset timestamps');
+
+
+/**
+ * Install assets from public dir of bundles
+ */
+task('deploy:assets:install', function () {
+    run('{{env_vars}} {{bin/php}} {{bin/console}} assets:install {{console_options}} {{release_path}}/web');
+})->desc('Install bundle assets');
 
 
 /**
  * Dump all assets to the filesystem
  */
 task('deploy:assetic:dump', function () {
-    if (!get('dump_assets')) {
-        return;
+    if (get('dump_assets')) {
+        run('{{env_vars}} {{bin/php}} {{bin/console}} assetic:dump {{console_options}}');
     }
-
-    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assetic:dump --env={{env}} --no-debug');
 })->desc('Dump assets');
 
 
@@ -82,7 +102,7 @@ task('deploy:assetic:dump', function () {
  * Warm up cache
  */
 task('deploy:cache:warmup', function () {
-    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console cache:warmup  --env={{env}} --no-debug');
+    run('{{env_vars}} {{bin/php}} {{bin/console}} cache:warmup {{console_options}}');
 })->desc('Warm up cache');
 
 
@@ -90,7 +110,7 @@ task('deploy:cache:warmup', function () {
  * Migrate database
  */
 task('database:migrate', function () {
-    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction');
+    run('{{env_vars}} {{bin/php}} {{bin/console}} doctrine:migrations:migrate {{console_options}}');
 })->desc('Migrate database');
 
 
@@ -98,10 +118,11 @@ task('database:migrate', function () {
  * Remove app_dev.php files
  */
 task('deploy:clear_controllers', function () {
-    run("rm -f {{release_path}}/web/app_*.php");
-    run("rm -f {{release_path}}/web/config.php");
+    run('rm -f {{release_path}}/web/app_*.php');
+    run('rm -f {{release_path}}/web/config.php');
 })->setPrivate();
 
+// Run after code is checked out
 after('deploy:update_code', 'deploy:clear_controllers');
 
 
@@ -116,6 +137,7 @@ task('deploy', [
     'deploy:shared',
     'deploy:assets',
     'deploy:vendors',
+    'deploy:assets:install',
     'deploy:assetic:dump',
     'deploy:cache:warmup',
     'deploy:writable',
@@ -123,4 +145,5 @@ task('deploy', [
     'cleanup',
 ])->desc('Deploy your project');
 
+// Display success message on completion
 after('deploy', 'success');

--- a/recipe/symfony3.php
+++ b/recipe/symfony3.php
@@ -10,20 +10,6 @@ require_once __DIR__ . '/symfony.php';
 /**
  * Symfony 3 Configuration
  */
- 
-/**
- * Dump all assets to the filesystem
- *
- * This overrides the Symfony 2 assetic:dump command
- * in favor of the new assets:install command.
- */
-task('deploy:assetic:dump', function () {
-    if (!get('dump_assets')) {
-        return;
-    }
-
-    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console assets:install --env={{env}} --no-debug {{release_path}}/web');
-})->desc('Dump assets');
 
 // Symfony shared dirs
 set('shared_dirs', ['var/logs', 'var/sessions']);
@@ -31,5 +17,6 @@ set('shared_dirs', ['var/logs', 'var/sessions']);
 // Symfony writable dirs
 set('writable_dirs', ['var/cache', 'var/logs', 'var/sessions']);
 
+// Symfony executable and variable directories
 set('bin_dir', 'bin');
 set('var_dir', 'var');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A

- Removed overridden `deploy:assetic:dump` task in `symfony3` recipe, as it implied this command was no longer valid and should be overridden with `deploy:assets:install` command. In reality, `deploy:assets:install` should exist in all symfony versions, as should `deploy:assetic:dump` (although this is arguable, as `deploy:assetic:dump` isn't a Symfony command, it is a kriswallsmith/assetic command). 
- Changed default for `deploy:assetic:dump` to `false` (via `dump_assets`) as this is not a core Symfony package and should not be assumed to be installed. It relies on kriswallsmith/assetic and symfony/assetic-bundle.
- Added `deploy:assets:install` task as this is a symfony-core command that is intended to be called prior to other asset compilation commands (such as `deploy:assetic:dump`). Its purpose to is to install any bundle assets (within `<bundleName>/Resource/public`) and put them in `web/bundles/<bundleName>`.
- `composer_action` created
- Fixed `SYMFONY_ENV` value in `env_vars` to correctly refer to the configured `env` value.
- Created `bin/console` to cleanup calls to Symfony console command (there was a ton of duplicated lines prior)
- created `console_options` so the options passed to `bin/console` reflect what should be passed per the configured environment (for example, the `--no-debug` options cannot be passed for any environment except for `prod` and will likely break hard when passed for `dev` environment)
- General cleanup...