### PR TITLE
Add Blade views composer directory to shared_dirs for Laravel

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/common.php';
 // for older versions, please read the documentation https://github.com/deployphp/docs
 
 // Laravel shared dirs
-set('shared_dirs', ['storage']);
+set('shared_dirs', ['storage', 'storage/framework/views']);
 
 // Laravel 5 shared file
 set('shared_files', ['.env']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Laravel 5.2 cannot create the compiled view if directory does not exist. Without this, you get the following exception:

`file_put_contents(/56ccf3c0f1a96367aabe0a532b30e5bdea56cfcd.php): failed to open stream: Permission denied`
