### PR TITLE
Fix deleting old releases, if deploy_path is a symlink

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -357,7 +357,7 @@ task('deploy:symlink', function () {
  */
 env('releases_list', function () {
     // find will list only dirs in releases/
-    $list = run('find {{deploy_path}}/releases -maxdepth 1 -mindepth 1 -type d')->toArray();
+    $list = run('find {{deploy_path}}/releases/ -maxdepth 1 -mindepth 1 -type d')->toArray();
 
     // filter out anything that does not look like a release
     foreach ($list as $key => $item) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No (?)
| Deprecations? | No
| Fixed tickets | 

When the {{deploy_path}} is a symlink, find won't find any directories within it. To solve this, the trailing slash is required. This behaviour is explained here: https://chris-lamb.co.uk/posts/find-trailing-slashes-and-symbolic-links-directories