### PR TITLE
Add support for Silverstripe CMS

### DIFF
--- a/recipe/silverstripe.php
+++ b/recipe/silverstripe.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/common.php';
+
+/**
+ * Silverstripe configuration
+ */
+
+// Silverstripe shared dirs
+set('shared_dirs', [
+    'assets'
+]);
+
+// Silverstripe writable dirs
+set('writable_dirs', ['assets']);
+
+/**
+ * Helper tasks
+ */
+task('silverstripe:build', function () {
+    return run('{{bin/php}} {{release_path}}/framework/cli-script.php /dev/build');
+})->desc('Run /dev/build');
+
+task('silverstripe:buildflush', function () {
+    return run('{{bin/php}} {{release_path}}/framework/cli-script.php /dev/build flush=all');
+})->desc('Run /dev/build?flush=al');
+
+/**
+ * Main task
+ */
+task('deploy', [
+    'deploy:prepare',
+    'deploy:release',
+    'deploy:update_code',
+    'deploy:vendors',
+    'deploy:shared',
+    'deploy:writable',
+    'silverstripe:buildflush',
+    'deploy:symlink',
+    'cleanup',
+])->desc('Deploy your project');
+
+after('deploy', 'success');

--- a/recipe/silverstripe.php
+++ b/recipe/silverstripe.php
@@ -23,7 +23,7 @@ task('silverstripe:build', function () {
 
 task('silverstripe:buildflush', function () {
     return run('{{bin/php}} {{release_path}}/framework/cli-script.php /dev/build flush=all');
-})->desc('Run /dev/build?flush=al');
+})->desc('Run /dev/build?flush=all');
 
 /**
  * Main task


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A

This pr adds a recipe to support the [Silverstripe CMS](http://www.silverstripe.org/software/cms/) 
- Follows the [composer recipe](https://github.com/deployphp/deployer/blob/master/recipe/composer.php)
- Adds `assets` to `shared_dirs` and `writable_dirs`
- Additional helper tasks for [generating the database schema](https://docs.silverstripe.org/en/3.3/developer_guides/model/data_model_and_orm/#generating-the-database-schema) and flushing the [cache/template/config manifests](https://docs.silverstripe.org/en/3.3/developer_guides/execution_pipeline/flushable/)