### PR TITLE
Show which file is being uploaded when in debug mode

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -334,7 +334,7 @@ function runLocally($command, $timeout = 60)
     if (!$process->isSuccessful()) {
         throw new \RuntimeException($process->getErrorOutput());
     }
-    
+
     return new Result($process->getOutput());
 }
 
@@ -367,6 +367,10 @@ function upload($local, $remote)
 
         /** @var $file \Symfony\Component\Finder\SplFileInfo */
         foreach ($files as $file) {
+            if (isDebug()) {
+                writeln("Uploading <info>{$file->getRealPath()}</info>");
+            }
+            
             $server->upload(
                 $file->getRealPath(),
                 $remote . '/' . $file->getRelativePathname()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Currently, there's no way of actually seeing which files are being uploaded to the server. This PR adds the filename display of the file being uploaded when in debug mode (`-vvv`).

