### PR TITLE
Change EventDispatcher versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/process": "~2.6|~3.0",
         "phpseclib/phpseclib": "~2.0",
         "deployer/phar-update": "^1.0",
-        "symfony/event-dispatcher": "^3.1",
+        "symfony/event-dispatcher": "~2.6|~3.0",
         "pimple/pimple": "~3.0",
         "monolog/monolog": "^1.21"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

We are using a project with Symfony 2.7 . The Deployer without namespaces cause conflict with the hamcrest/hamcrest-php library. The event dispatcher version is too strict with the `^3.1`.

