### PR TITLE
Drop support PHP 5.5 and add test on PHP 7.1 to TravisCI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,7 +13,7 @@ filter:
 
 build:
   environment:
-    php: '5.5.25'
+    php: '5.6.26'
   tests:
     override:
       -

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: 7.1
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 sudo: required
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "bin/dep"
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "elfet/pure": "~2.0",
         "symfony/finder": "~2.6|~3.0",
         "symfony/console": "~2.6|~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c441c416a25f59bc5fb53697c8cd1796",
-    "content-hash": "14c3d0d0f6513ae479a79788fb7d7df8",
+    "hash": "148b026377d84830a33bf8ae493daf83",
+    "content-hash": "a873302c7d8827c6c1dab71c38b44ee7",
     "packages": [
         {
             "name": "deployer/phar-update",
@@ -530,16 +530,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb"
+                "reference": "41f85e9c2582b3f6d1b7d20395fb40c687ad5370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
-                "reference": "3d265f7c079f5b37d33475f996d7a383c5fc8aeb",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/41f85e9c2582b3f6d1b7d20395fb40c687ad5370",
+                "reference": "41f85e9c2582b3f6d1b7d20395fb40c687ad5370",
                 "shasum": ""
             },
             "require": {
@@ -618,7 +618,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2016-05-13 01:15:21"
+            "time": "2016-08-18 18:49:14"
         },
         {
             "name": "pimple/pimple",
@@ -2956,7 +2956,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.0"
+        "php": ">=5.6.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | #745 

- Drop support PHP 5.5
- Add test on PHP 7.1 to TravisCI


