### PR TITLE
Don't use /current in Laravel recipe

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -22,47 +22,47 @@ set('writable_dirs', ['bootstrap/cache', 'storage']);
  * Helper tasks
  */
 task('artisan:up', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan up');
-    writeln('<info>'.$output.'</info>');
+    $output = run('if [ -d {{deploy_path}}/current ]; then {{bin/php}} {{deploy_path}}/current/artisan up; fi');
+    writeln('<info>' . $output . '</info>');
 })->desc('Disable maintenance mode');
 
 task('artisan:down', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan down');
-    writeln('<error>'.$output.'</error>');
+    $output = run('if [ -d {{deploy_path}}/current ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi');
+    writeln('<error>' . $output . '</error>');
 })->desc('Enable maintenance mode');
 
 task('artisan:migrate', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate --force');
+    $output = run('{{bin/php}} {{release_path}}/artisan migrate --force');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan migrate');
 
 task('artisan:migrate:rollback', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:rollback --force');
+    $output = run('{{bin/php}} {{release_path}}/artisan migrate:rollback --force');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan migrate:rollback');
 
 task('artisan:migrate:status', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan migrate:status');
+    $output = run('{{bin/php}} {{release_path}}/artisan migrate:status');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan migrate:status');
 
 task('artisan:db:seed', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan db:seed --force');
+    $output = run('{{bin/php}} {{release_path}}/artisan db:seed --force');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan db:seed');
 
 task('artisan:cache:clear', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan cache:clear');
+    $output = run('{{bin/php}} {{release_path}}/artisan cache:clear');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan cache:clear');
 
 task('artisan:config:cache', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan config:cache');
+    $output = run('{{bin/php}} {{release_path}}/artisan config:cache');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan config:cache');
 
 task('artisan:route:cache', function () {
-    $output = run('{{bin/php}} {{deploy_path}}/current/artisan route:cache');
+    $output = run('{{bin/php}} {{release_path}}/artisan route:cache');
     writeln('<info>' . $output . '</info>');
 })->desc('Execute artisan route:cache');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A or xx

The Laravel recipe assumes the existence of the `current` directory, but this is not the case on the very first release:

```
[RuntimeException]
  Could not open input file: foo/current/artisan
```

This PR fixes this issue by using `{{release_path}}` and using an inline `if -d` for the`artisan:up` and `artisan:down` tasks.