### PR TITLE
[WIP] Allow hiding of secrets in deployer log output

### DIFF
--- a/src/ShellCommand.php
+++ b/src/ShellCommand.php
@@ -1,0 +1,45 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer;
+
+use Deployer\Console\InitCommand;
+use Deployer\Console\WorkerCommand;
+use Deployer\Console\Application;
+use Deployer\Server;
+use Deployer\Stage\StageStrategy;
+use Deployer\Task;
+use Deployer\Collection;
+use Deployer\Console\TaskCommand;
+use Symfony\Component\Console;
+
+class ShellCommand
+{
+    private $command;
+
+    public function __construct($command)
+    {
+        $this->command = $command;
+    }
+
+    public function getForRunning()
+    {
+        $command = str_replace("<secret>", "", $this->command);
+        $command = str_replace("</secret>", "", $command);
+        return $command;
+    }
+
+    public function __toString()
+    {
+        return $this->getForRunning();
+    }
+
+    public function getForPrinting()
+    {
+        return preg_replace('|<secret>.*</secret>|s', "[SECRET HIDDEN]", $this->command);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,6 +7,8 @@
 namespace Deployer;
 
 use Deployer\Builder\BuilderInterface;
+
+use Deployer\ShellCommand;
 use Deployer\Server\Local;
 use Deployer\Server\Remote;
 use Deployer\Server\Builder;
@@ -249,7 +251,11 @@ function workingPath()
 function run($command)
 {
     $server = Context::get()->getServer();
-    $command = Context::get()->getEnvironment()->parse($command);
+
+    $command = new ShellCommand(
+        Context::get()->getEnvironment()->parse($command)
+    );
+
     $workingPath = workingPath();
 
     if (!empty($workingPath)) {
@@ -257,7 +263,7 @@ function run($command)
     }
 
     if (isVeryVerbose()) {
-        writeln("<fg=red>></fg=red> $command");
+        writeln("<fg=red>></fg=red> {$command->getForPrinting()}");
     }
 
     $output = $server->run($command);
@@ -280,10 +286,12 @@ function run($command)
  */
 function runLocally($command, $timeout = 60)
 {
-    $command = Context::get()->getEnvironment()->parse($command);
+    $command = new ShellCommand(
+        Context::get()->getEnvironment()->parse($command)
+    );
 
     if (isVeryVerbose()) {
-        writeln("<comment>Run locally</comment>: $command");
+        writeln("<comment>Run locally</comment>: {$command->getForPrinting()}");
     }
 
     $process = new Process($command);

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -173,6 +173,35 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('hello', (string)$output);
     }
 
+    public function testRunLocallyWithSecret()
+    {
+        $this->_output->expects($this->once())
+                   ->method("writeln")
+                   ->with($this->equalTo('<comment>Run locally</comment>: echo "[SECRET HIDDEN]"'));
+
+        $this->_output->method('getVerbosity')
+                      ->willReturn(\Symfony\Component\Console\Output\Output::VERBOSITY_DEBUG);
+
+        $output = runLocally('echo "<secret>asecret</secret>"');
+        $this->assertEquals('asecret', (string)$output);
+    }
+
+    public function testRunWithSecret()
+    {
+        $this->_output->expects($this->once())
+                   ->method("writeln")
+                   ->with($this->equalTo('<fg=red>></fg=red> echo "[SECRET HIDDEN]"'));
+
+        $this->_output->method('getVerbosity')
+                      ->willReturn(\Symfony\Component\Console\Output\Output::VERBOSITY_DEBUG);
+
+        $this->_server->expects($this->once())
+                      ->method("run")
+                      ->with($this->equalTo('echo "asecret"'));
+
+        $output = run('echo "<secret>asecret</secret>"');
+    }
+
     public function testUpload()
     {
         $this->_server

--- a/test/src/ShellCommandTest.php
+++ b/test/src/ShellCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+namespace Deployer;
+
+class ShellCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->command = new ShellCommand("echo '<secret>important\nsecret</secret>' > /dev/null");
+        $this->emptySecretCommand = new ShellCommand("echo '<secret></secret>' > /dev/null");
+    }
+
+    public function testGetForRunning()
+    {
+        $this->assertEquals(
+            "echo 'important\nsecret' > /dev/null",
+            $this->command->getForRunning()
+        );
+    }
+
+    public function testToString()
+    {
+        $this->assertEquals(
+            "echo 'important\nsecret' > /dev/null",
+            (string) $this->command
+        );
+    }
+
+    public function testGetForPrinting()
+    {
+        $this->assertEquals(
+            "echo '[SECRET HIDDEN]' > /dev/null",
+            $this->command->getForPrinting()
+        );
+    }
+
+    public function testGetForRunningEmptySecret()
+    {
+        $this->assertEquals(
+            "echo '' > /dev/null",
+            $this->emptySecretCommand->getForRunning()
+        );
+    }
+
+    public function testGetForPrintingEmptySecret()
+    {
+        $this->assertEquals(
+            "echo '[SECRET HIDDEN]' > /dev/null",
+            $this->emptySecretCommand->getForPrinting()
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes
| BC breaks?    |  No
| Deprecations? |  No
| Fixed tickets | N/A 

I'm currently building a continuous deployment system using GitLab CI and deployer. Being able to deploy from within GitLab CI requires me to provide it with some secrets, such as the password of the server I'm going to deploy to (since that shouldn't be part of the git repository). I can create such secrets in GitLab, and they will not be visible to common users, which is good. 

For being able to check deployment failures in the build logs, I'm always running the deployment with `-vv`. As a result, when running a command which contains a secret, it is echoed to the build log in plain text. I need to avoid this, since build logs are visible to all users that can see the repository in GitLab. 

Because of this I've introduced the `[secret]foobar[/secret]` syntax, which will omit everything between the "tags" when printed to the console, but will still run the correct command when used with `run` or `runLocally`. 

Is this something that you (the maintainers) could see being merged into deployer? :)

PS: Thinking about it, I should've probably used `<secret></secret>` instead to conform with Symfony Console. I'll fix that, along with any other feedback there might be.

- [x] Change syntax to `<secret>`
- [ ] Figure out where to put the `ShellCommand` class (root namespace doesn't seem nice)
- [ ] Clean up `use`s in `ShellCommand.php`
- [x] Figure out why tests are not failing for me locally
