### PR TITLE
Don't stop the deploy process when zero migrations

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -90,7 +90,7 @@ task('deploy:cache:warmup', function () {
  * Migrate database
  */
 task('database:migrate', function () {
-    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction');
+    run('{{bin/php}} {{release_path}}/' . trim(get('bin_dir'), '/') . '/console doctrine:migrations:migrate --env={{env}} --no-debug --no-interaction --allow-no-migration');
 })->desc('Migrate database');
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | ?
| Deprecations? | No
| Fixed tickets | N/A


When i want to keep a "database:migrate" on my deploy file and when I have no migration in DoctrineMigrations Folder, cause break of the deploy.
