### PR TITLE
Feature/forward composer auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.phar
 /.vagrant
 deploy.php
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     - php: 7.1
 
 env:
+  global:
+    - COMPOSER_DISABLE_XDEBUG_WARN=1
   matrix:
     - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS="--prefer-stable"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,17 +10,21 @@
 >
     <testsuites>
         <testsuite name="Source">
-            <directory>test/src/</directory>
+            <directory>test/src</directory>
         </testsuite>
         <testsuite name="Recipes">
-            <directory>test/recipe/</directory>
+            <directory>test/recipe</directory>
         </testsuite>
     </testsuites>
     <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">src</directory>
+            <directory suffix=".php">recipe</directory>
+        </whitelist>
         <blacklist>
-            <directory suffix=".php">vendor/</directory>
-            <directory>bin/</directory>
-            <directory>src/Resources/</directory>
+            <directory suffix=".php">vendor</directory>
+            <directory>bin</directory>
+            <directory>src/Resources</directory>
         </blacklist>
     </filter>
 </phpunit>

--- a/src/Bootstrap/BootstrapByConfigFile.php
+++ b/src/Bootstrap/BootstrapByConfigFile.php
@@ -49,7 +49,7 @@ class BootstrapByConfigFile
      * @var BuilderInterface[] $clusterBuilders
      */
     public $clusterBuilders = [];
-    
+
     /**
      * @var BuilderInterface[] $serverBuilders
      */
@@ -89,7 +89,7 @@ class BootstrapByConfigFile
             unset($config['forward_agent']);
         }
 
-        if ($config->hasKey('forward_composer_auth')) {
+        if ($config->has('forward_composer_auth')) {
             $builder->forwardComposerAuth();
             unset($config['forward_composer_auth']);
         }

--- a/src/Bootstrap/BootstrapByConfigFile.php
+++ b/src/Bootstrap/BootstrapByConfigFile.php
@@ -89,6 +89,11 @@ class BootstrapByConfigFile
             unset($config['forward_agent']);
         }
 
+        if ($config->hasKey('forward_composer_auth')) {
+            $builder->forwardComposerAuth();
+            unset($config['forward_composer_auth']);
+        }
+
         foreach (['user', 'password', 'stage', 'pem_file'] as $key) {
             if ($config->has($key)) {
                 $method = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));

--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -58,6 +58,13 @@ interface BuilderInterface
     public function forwardAgent();
 
     /**
+     * Using forward composer auth to environment.
+     *
+     * @return BuilderInterface
+     */
+    public function forwardComposerAuth();
+
+    /**
      * @param string|array $stages
      * @return BuilderInterface
      */

--- a/src/Cluster/ClusterBuilder.php
+++ b/src/Cluster/ClusterBuilder.php
@@ -102,6 +102,17 @@ class ClusterBuilder implements BuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function forwardComposerAuth()
+    {
+        foreach ($this->nodes as $node) {
+            $node->builder->forwardComposerAuth();
+        }
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function set($name, $env)
     {
         foreach ($this->nodes as $node) {

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -196,7 +196,7 @@ class Builder implements BuilderInterface
             $composerAuth = json_decode($environment);
         }
 
-        if (empty($composerAuth)){
+        if (empty($composerAuth)) {
             $filename = self::getComposerHomeDir() . DIRECTORY_SEPARATOR . 'auth.json';
             if (file_exists(realpath($filename))) {
                 $composerAuth = json_decode(file_get_contents($filename));

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -179,6 +179,101 @@ class Builder implements BuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function forwardComposerAuth()
+    {
+        $this->config->setComposerAuth($this->getComposerAuth());
+
+        return $this;
+    }
+
+
+    protected static function getComposerAuth()
+    {
+        $composerAuth = '';
+
+        $environment = getenv('COMPOSER_AUTH');
+        if ($environment) {
+            $composerAuth = json_decode($environment);
+        }
+
+        if (empty($composerAuth)){
+            $filename = self::getComposerHomeDir() . DIRECTORY_SEPARATOR . 'auth.json';
+            if (file_exists(realpath($filename))) {
+                $composerAuth = json_decode(file_get_contents($filename));
+            }
+        }
+
+        if (!empty($composerAuth)) {
+            return json_encode($composerAuth);
+        }
+        return '';
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return string
+     */
+    protected static function getComposerHomeDir()
+    {
+        $home = getenv('COMPOSER_HOME');
+        if ($home) {
+            return $home;
+        }
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            if (!getenv('APPDATA')) {
+                throw new \RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to run correctly');
+            }
+
+            return rtrim(strtr(getenv('APPDATA'), '\\', '/'), '/') . '/Composer';
+        }
+
+        $userDir = self::getUserDir();
+        if (is_dir($userDir . '/.composer')) {
+            return $userDir . '/.composer';
+        }
+
+        if (self::useXdg()) {
+            // XDG Base Directory Specifications
+            $xdgConfig = getenv('XDG_CONFIG_HOME') ?: $userDir . '/.config';
+
+            return $xdgConfig . '/composer';
+        }
+
+        return $userDir . '/.composer';
+    }
+
+    /**
+     * @return bool
+     */
+    private static function useXdg()
+    {
+        foreach (array_keys($_SERVER) as $key) {
+            if (substr($key, 0, 4) === 'XDG_') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return string
+     */
+    private static function getUserDir()
+    {
+        $home = getenv('HOME');
+        if (!$home) {
+            throw new \RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to run correctly');
+        }
+
+        return rtrim(strtr($home, '\\', '/'), '/');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function set($name, $value)
     {
         $this->env->set($name, $value);

--- a/src/Server/Builder.php
+++ b/src/Server/Builder.php
@@ -10,6 +10,7 @@ namespace Deployer\Server;
 use Deployer\Builder\BuilderInterface;
 use Deployer\Server\Password\AskPasswordGetter;
 use Deployer\Server\Password\PasswordGetterInterface;
+use Deployer\Util\Composer;
 
 /**
  * Build server configuration
@@ -181,94 +182,9 @@ class Builder implements BuilderInterface
      */
     public function forwardComposerAuth()
     {
-        $this->config->setComposerAuth($this->getComposerAuth());
+        $this->config->setComposerAuth(Composer::getComposerAuth());
 
         return $this;
-    }
-
-
-    protected static function getComposerAuth()
-    {
-        $composerAuth = '';
-
-        $environment = getenv('COMPOSER_AUTH');
-        if ($environment) {
-            $composerAuth = json_decode($environment);
-        }
-
-        if (empty($composerAuth)) {
-            $filename = self::getComposerHomeDir() . DIRECTORY_SEPARATOR . 'auth.json';
-            if (file_exists(realpath($filename))) {
-                $composerAuth = json_decode(file_get_contents($filename));
-            }
-        }
-
-        if (!empty($composerAuth)) {
-            return json_encode($composerAuth);
-        }
-        return '';
-    }
-
-    /**
-     * @throws \RuntimeException
-     * @return string
-     */
-    protected static function getComposerHomeDir()
-    {
-        $home = getenv('COMPOSER_HOME');
-        if ($home) {
-            return $home;
-        }
-
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            if (!getenv('APPDATA')) {
-                throw new \RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to run correctly');
-            }
-
-            return rtrim(strtr(getenv('APPDATA'), '\\', '/'), '/') . '/Composer';
-        }
-
-        $userDir = self::getUserDir();
-        if (is_dir($userDir . '/.composer')) {
-            return $userDir . '/.composer';
-        }
-
-        if (self::useXdg()) {
-            // XDG Base Directory Specifications
-            $xdgConfig = getenv('XDG_CONFIG_HOME') ?: $userDir . '/.config';
-
-            return $xdgConfig . '/composer';
-        }
-
-        return $userDir . '/.composer';
-    }
-
-    /**
-     * @return bool
-     */
-    private static function useXdg()
-    {
-        foreach (array_keys($_SERVER) as $key) {
-            if (substr($key, 0, 4) === 'XDG_') {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @throws \RuntimeException
-     * @return string
-     */
-    private static function getUserDir()
-    {
-        $home = getenv('HOME');
-        if (!$home) {
-            throw new \RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to run correctly');
-        }
-
-        return rtrim(strtr($home, '\\', '/'), '/');
     }
 
     /**

--- a/src/Server/Configuration.php
+++ b/src/Server/Configuration.php
@@ -110,6 +110,13 @@ class Configuration
 
 
     /**
+     * Used to forward composer auth
+     *
+     * @var bool
+     */
+    private $composerAuth = null;
+
+    /**
      * Construct
      *
      * @param string $name
@@ -383,6 +390,18 @@ class Configuration
     public function setPemFile($pemFile)
     {
         $this->pemFile = $this->parseHome($pemFile);
+
+        return $this;
+    }
+
+    public function getComposerAuth()
+    {
+        return $this->composerAuth;
+    }
+
+    public function setComposerAuth($composerAuth)
+    {
+        $this->composerAuth = $composerAuth;
 
         return $this;
     }

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -50,9 +50,9 @@ class Local implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command, array $env = [])
+    public function run($command)
     {
-        return $this->mustRun($command, null, $env);
+        return $this->mustRun($command);
     }
 
     /**
@@ -60,10 +60,9 @@ class Local implements ServerInterface
      * @param callable $callback
      * @return string
      */
-    public function mustRun($command, $callback = null, array $env = [])
+    public function mustRun($command, $callback = null)
     {
-        $env = array_merge($_ENV, $env);
-        $process = new Process($command, null, $env);
+        $process = new Process($command);
         $process
             ->setTimeout(self::TIMEOUT)
             ->setIdleTimeout(self::TIMEOUT)

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -9,14 +9,9 @@ namespace Deployer\Server;
 
 use Symfony\Component\Process\Process;
 
-class Local implements ServerInterface
+class Local extends ServerBase
 {
     const TIMEOUT = 300;
-
-    /**
-     * @var Configuration
-     */
-    private $configuration;
 
     /**
      * Local constructor.
@@ -27,16 +22,7 @@ class Local implements ServerInterface
         if ($config === null) {
             $config = new Configuration('localhost', 'localhost');
         }
-
-        $this->configuration = $config;
-    }
-
-    /**
-     * @return Configuration
-     */
-    public function getConfiguration()
-    {
-        return $this->configuration;
+        parent::__construct($config);
     }
 
     /**
@@ -62,6 +48,8 @@ class Local implements ServerInterface
      */
     public function mustRun($command, $callback = null)
     {
+        $command = $this->parseCommand($command);
+
         $process = new Process($command);
         $process
             ->setTimeout(self::TIMEOUT)

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -62,6 +62,7 @@ class Local implements ServerInterface
      */
     public function mustRun($command, $callback = null, array $env = [])
     {
+        $env = array_merge($_ENV, $env);
         $process = new Process($command, null, $env);
         $process
             ->setTimeout(self::TIMEOUT)

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -50,9 +50,9 @@ class Local implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command)
+    public function run($command, array $env = [])
     {
-        return $this->mustRun($command);
+        return $this->mustRun($command, null, $env);
     }
 
     /**
@@ -60,9 +60,9 @@ class Local implements ServerInterface
      * @param callable $callback
      * @return string
      */
-    public function mustRun($command, $callback = null)
+    public function mustRun($command, $callback = null, array $env = [])
     {
-        $process = new Process($command);
+        $process = new Process($command, null, $env);
         $process
             ->setTimeout(self::TIMEOUT)
             ->setIdleTimeout(self::TIMEOUT)

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -49,7 +49,7 @@ class NativeSsh implements ServerInterface
 
         $composerAuth = $this->getConfiguration()->getComposerAuth();
         if (!empty($composerAuth)) {
-           $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
         }
 
         $exports = '';

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -8,24 +8,11 @@
 namespace Deployer\Server\Remote;
 
 use Deployer\Server\Configuration;
-use Deployer\Server\ServerInterface;
+use Deployer\Server\ServerBase;
 use Symfony\Component\Process\Process;
 
-class NativeSsh implements ServerInterface
+class NativeSsh extends ServerBase
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    /**
-     * @param Configuration $configuration
-     */
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -39,6 +26,8 @@ class NativeSsh implements ServerInterface
      */
     public function run($command)
     {
+        $command = $this->parseCommand($command);
+
         $serverConfig = $this->getConfiguration();
         $sshOptions = [
             '-A',
@@ -126,13 +115,5 @@ class NativeSsh implements ServerInterface
             ->mustRun();
 
         return $process->getOutput();
-    }
-
-    /**
-     * @return Configuration
-     */
-    public function getConfiguration()
-    {
-        return $this->configuration;
     }
 }

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -37,26 +37,14 @@ class NativeSsh implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command, array $env = [])
+    public function run($command)
     {
         $serverConfig = $this->getConfiguration();
         $sshOptions = [
             '-A',
             '-q',
-            '-o UserKnownHostsFile=/dev/null',
-            '-o StrictHostKeyChecking=no'
+            '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
         ];
-
-        $composerAuth = $this->getConfiguration()->getComposerAuth();
-        if (!empty($composerAuth)) {
-            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
-        }
-
-        $exports = '';
-        foreach ($env as $key => $value) {
-            $exports = sprintf('export %s=%s;', $key, $value);
-        }
-        $command = $exports . $command;
 
         $username = $serverConfig->getUser() ? $serverConfig->getUser() : null;
         if (!empty($username)) {

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -8,19 +8,14 @@
 namespace Deployer\Server\Remote;
 
 use Deployer\Server\Configuration;
-use Deployer\Server\ServerInterface;
+use Deployer\Server\ServerBase;
 use phpseclib\Crypt\RSA;
 use phpseclib\Net\SFTP;
 use phpseclib\System\SSH\Agent;
 use RuntimeException;
 
-class PhpSecLib implements ServerInterface
+class PhpSecLib extends ServerBase
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
     /**
      * @var SFTP
      */
@@ -31,14 +26,6 @@ class PhpSecLib implements ServerInterface
      * @var array
      */
     private $directories = [];
-
-    /**
-     * @param Configuration $configuration
-     */
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
 
     /**
      * {@inheritdoc}
@@ -115,6 +102,8 @@ class PhpSecLib implements ServerInterface
      */
     public function run($command)
     {
+        $command = $this->parseCommand($command);
+
         $this->checkConnection();
 
         $result = $this->sftp->exec($command);
@@ -157,13 +146,5 @@ class PhpSecLib implements ServerInterface
         if (!$this->sftp->get($remote, $local)) {
             throw new \RuntimeException(implode($this->sftp->getSFTPErrors(), "\n"));
         }
-    }
-
-    /**
-     * @return Configuration
-     */
-    public function getConfiguration()
-    {
-        return $this->configuration;
     }
 }

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -113,20 +113,9 @@ class PhpSecLib implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command, array $env = [])
+    public function run($command)
     {
         $this->checkConnection();
-
-        $composerAuth = $this->getConfiguration()->getComposerAuth();
-        if (!empty($composerAuth)) {
-            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
-        }
-
-        $exports = '';
-        foreach ($env as $key => $value) {
-            $exports = sprintf('export %s=%s;', $key, $value);
-        }
-        $command = $exports . $command;
 
         $result = $this->sftp->exec($command);
 

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -113,9 +113,20 @@ class PhpSecLib implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command)
+    public function run($command, array $env = [])
     {
         $this->checkConnection();
+
+        $composerAuth = $this->getConfiguration()->getComposerAuth();
+        if (!empty($composerAuth)) {
+           $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+        }
+
+        $exports = '';
+        foreach ($env as $key => $value) {
+            $exports = sprintf('export %s=%s;', $key, $value);
+        }
+        $command = $exports . $command;
 
         $result = $this->sftp->exec($command);
 

--- a/src/Server/Remote/PhpSecLib.php
+++ b/src/Server/Remote/PhpSecLib.php
@@ -119,7 +119,7 @@ class PhpSecLib implements ServerInterface
 
         $composerAuth = $this->getConfiguration()->getComposerAuth();
         if (!empty($composerAuth)) {
-           $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
         }
 
         $exports = '';

--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -7,17 +7,12 @@
 
 namespace Deployer\Server\Remote;
 
-use Deployer\Server\ServerInterface;
+use Deployer\Server\ServerBase;
 use Deployer\Server\Configuration;
 use Ssh;
 
-class SshExtension implements ServerInterface
+class SshExtension extends ServerBase
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
     /**
      * SSH session.
      * @var Ssh\Session
@@ -29,14 +24,6 @@ class SshExtension implements ServerInterface
      * @var array
      */
     private $directories = [];
-
-    /**
-     * @param Configuration $configuration
-     */
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
 
     /**
      * {@inheritdoc}
@@ -111,6 +98,8 @@ class SshExtension implements ServerInterface
      */
     public function run($command)
     {
+        $command = $this->parseCommand($command);
+
         $this->checkConnection();
 
         $pty = $this->getConfiguration()->getSsh2Pty();
@@ -147,13 +136,5 @@ class SshExtension implements ServerInterface
         if (!$this->session->getSftp()->receive($remote, $local)) {
             throw new \RuntimeException('Can not download file.');
         }
-    }
-
-    /**
-     * @return Configuration
-     */
-    public function getConfiguration()
-    {
-        return $this->configuration;
     }
 }

--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -109,9 +109,20 @@ class SshExtension implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command)
+    public function run($command, array $env = [])
     {
         $this->checkConnection();
+
+        $composerAuth = $this->getConfiguration()->getComposerAuth();
+        if (!empty($composerAuth)) {
+           $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+        }
+
+        $exports = '';
+        foreach ($env as $key => $value) {
+            $exports = sprintf('export %s=%s;', $key, $value);
+        }
+        $command = $exports . $command;
 
         $pty = $this->getConfiguration()->getSsh2Pty();
         return $this->session->getExec()->run($command, $pty);

--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -115,7 +115,7 @@ class SshExtension implements ServerInterface
 
         $composerAuth = $this->getConfiguration()->getComposerAuth();
         if (!empty($composerAuth)) {
-           $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
         }
 
         $exports = '';

--- a/src/Server/Remote/SshExtension.php
+++ b/src/Server/Remote/SshExtension.php
@@ -109,20 +109,9 @@ class SshExtension implements ServerInterface
     /**
      * {@inheritdoc}
      */
-    public function run($command, array $env = [])
+    public function run($command)
     {
         $this->checkConnection();
-
-        $composerAuth = $this->getConfiguration()->getComposerAuth();
-        if (!empty($composerAuth)) {
-            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
-        }
-
-        $exports = '';
-        foreach ($env as $key => $value) {
-            $exports = sprintf('export %s=%s;', $key, $value);
-        }
-        $command = $exports . $command;
 
         $pty = $this->getConfiguration()->getSsh2Pty();
         return $this->session->getExec()->run($command, $pty);

--- a/src/Server/ServerBase.php
+++ b/src/Server/ServerBase.php
@@ -56,8 +56,8 @@ abstract class ServerBase implements ServerInterface
      * @param string $command
      * @return string The parsed command
      */
-    protected function parseCommand($command) {
-
+    protected function parseCommand($command)
+    {
         $env = [];
 
         $composerAuth = $this->getConfiguration()->getComposerAuth();

--- a/src/Server/ServerBase.php
+++ b/src/Server/ServerBase.php
@@ -1,0 +1,75 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Server;
+
+abstract class ServerBase implements ServerInterface
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @param $config
+     */
+    public function __construct(Configuration $config = null)
+    {
+        $this->configuration = $config;
+    }
+
+    /**
+     * @return Configuration
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function connect();
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function run($command);
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function upload($local, $remote);
+
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function download($local, $remote);
+
+    /**
+     * Parse commands before execution.
+     *
+     * @param string $command
+     * @return string The parsed command
+     */
+    protected function parseCommand($command) {
+
+        $env = [];
+
+        $composerAuth = $this->getConfiguration()->getComposerAuth();
+        if (!empty($composerAuth)) {
+            $env = ['COMPOSER_AUTH' => sprintf('"%s"', str_replace('"', '\"', $composerAuth))] + $env;
+        }
+
+        $exports = '';
+        foreach ($env as $key => $value) {
+            $exports = sprintf('export %s=%s;', $key, $value);
+        }
+
+        return $exports . $command;
+    }
+}

--- a/src/Server/ServerInterface.php
+++ b/src/Server/ServerInterface.php
@@ -24,7 +24,7 @@ interface ServerInterface
      * @param string $command
      * @return string Output of command.
      */
-    public function run($command, array $env = []);
+    public function run($command);
 
     /**
      * Upload file to remote server.

--- a/src/Server/ServerInterface.php
+++ b/src/Server/ServerInterface.php
@@ -24,7 +24,7 @@ interface ServerInterface
      * @param string $command
      * @return string Output of command.
      */
-    public function run($command);
+    public function run($command, array $env = []);
 
     /**
      * Upload file to remote server.

--- a/src/Util/Composer.php
+++ b/src/Util/Composer.php
@@ -1,0 +1,95 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Util;
+
+class Composer
+{
+    public static function getComposerAuth()
+    {
+        $composerAuth = '';
+
+        $environment = getenv('COMPOSER_AUTH');
+        if ($environment) {
+            $composerAuth = json_decode($environment);
+        }
+
+        if (empty($composerAuth)) {
+            $filename = self::getComposerHomeDir() . DIRECTORY_SEPARATOR . 'auth.json';
+            if (file_exists(realpath($filename))) {
+                $composerAuth = json_decode(file_get_contents($filename));
+            }
+        }
+
+        if (!empty($composerAuth)) {
+            return json_encode($composerAuth);
+        }
+        return '';
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return string
+     */
+    public static function getComposerHomeDir()
+    {
+        $home = getenv('COMPOSER_HOME');
+        if ($home) {
+            return $home;
+        }
+
+        if (Platform::isWindows()) {
+            if (!getenv('APPDATA')) {
+                throw new \RuntimeException('The APPDATA or COMPOSER_HOME environment variable must be set for composer to run correctly');
+            }
+
+            return rtrim(strtr(getenv('APPDATA'), '\\', '/'), '/') . '/Composer';
+        }
+
+        $userDir = self::getUserDir();
+        if (is_dir($userDir . '/.composer')) {
+            return $userDir . '/.composer';
+        }
+
+        if (self::useXdg()) {
+            // XDG Base Directory Specifications
+            $xdgConfig = getenv('XDG_CONFIG_HOME') ?: $userDir . '/.config';
+
+            return $xdgConfig . '/composer';
+        }
+
+        return $userDir . '/.composer';
+    }
+
+    /**
+     * @return bool
+     */
+    private static function useXdg()
+    {
+        foreach (array_keys($_SERVER) as $key) {
+            if (substr($key, 0, 4) === 'XDG_') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return string
+     */
+    private static function getUserDir()
+    {
+        $home = getenv('HOME');
+        if (!$home) {
+            throw new \RuntimeException('The HOME or COMPOSER_HOME environment variable must be set for composer to run correctly');
+        }
+
+        return rtrim(strtr($home, '\\', '/'), '/');
+    }
+}

--- a/src/Util/Platform.php
+++ b/src/Util/Platform.php
@@ -1,0 +1,41 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Util;
+
+class Platform
+{
+    /**
+     * @return string The formal user home as detected from environment parameters
+     * @throws \RuntimeException If the user home could not reliably be determined
+     */
+    public static function getUserDirectory()
+    {
+        if (false !== ($home = getenv('HOME'))) {
+            return $home;
+        }
+
+        if (self::isWindows() && false !== ($home = getenv('USERPROFILE'))) {
+            return $home;
+        }
+
+        if (function_exists('posix_getuid') && function_exists('posix_getpwuid')) {
+            $info = posix_getpwuid(posix_getuid());
+            return $info['dir'];
+        }
+
+        throw new \RuntimeException('Could not determine user directory');
+    }
+
+    /**
+     * @return bool Whether the host machine is running a Windows OS
+     */
+    public static function isWindows()
+    {
+        return defined('PHP_WINDOWS_VERSION_BUILD');
+    }
+}

--- a/test/src/Server/BuilderTest.php
+++ b/test/src/Server/BuilderTest.php
@@ -317,4 +317,20 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $b = new Builder($config, $env);
         $b->forwardAgent();
     }
+
+    /**
+     * Test use forward composer auth
+     */
+    public function testForwardComposerAuth()
+    {
+        $config = $this->getMockBuilder('Deployer\Server\Configuration')->disableOriginalConstructor()->getMock();
+        $config->expects($this->once())
+            ->method('setComposerAuth')
+            ->with(\Deployer\Util\Composer::getComposerAuth())
+            ->will($this->returnSelf());
+        $env = $this->createMock('Deployer\Server\Environment');
+
+        $b = new Builder($config, $env);
+        $b->forwardComposerAuth();
+    }
 }

--- a/test/src/Util/PlatformTest.php
+++ b/test/src/Util/PlatformTest.php
@@ -1,0 +1,54 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Util;
+
+class PlatformTest extends \PHPUnit_Framework_TestCase
+{
+    protected $home;
+
+    protected $userProfile;
+
+    public function setUp()
+    {
+        $this->home = getenv('HOME');
+        $this->userProfile = getenv('USERPROFILE');
+    }
+
+    public function tearDown()
+    {
+        if ($this->home) {
+            putenv("HOME={$this->home}");
+        } else {
+            putenv('HOME');
+        }
+
+        if ($this->userProfile) {
+            putenv("USERPROFILE={$this->userProfile}");
+        } else {
+            putenv('USERPROFILE');
+        }
+    }
+
+    public function testGetUserDirectory()
+    {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            putenv('USERPROFILE=C:\Users\test');
+            $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')), Platform::getUserDirectory());
+        } else {
+            putenv('HOME=/home/test');
+            $this->assertEquals((getenv('HOME') ?: getenv('USERPROFILE')), Platform::getUserDirectory());
+        }
+    }
+
+    public function testIsWindows()
+    {
+        // Compare 2 common tests for Windows to the built-in Windows test
+        $this->assertEquals(('\\' === DIRECTORY_SEPARATOR), Platform::isWindows());
+        $this->assertEquals(defined('PHP_WINDOWS_VERSION_MAJOR'), Platform::isWindows());
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Issue Type        | Feature Request
| Deployer Version  | N/A
| Local Machine OS  | N/A
| Remote Machine OS | N/A

### Short Description 
Add an option to forward composer auth (similar to forward agent) to the remote servers in order to access private repositories.

### Description
Using composer private repositories via Satis or Toran Proxy does not work unless `forward agent` is used. However, these repositories are cloned instead of downloaded which is slow.
```bash
[staging] <   - Installing example/package (1.0)
[staging] <     Downloading
[staging] <     Failed to download example/package from dist: The 'https://packages.example.com/packages/composer/dist/archive.zip?project_id=212&ref=1.0' URL required authentication.
[staging] < You must be using the interactive console to authenticate
[staging] <     Now trying to download from source
[staging] <   - Installing example/package (1.0)
[staging] <     Cloning 738e67d11e33b924bac17eddcccc2a0dfaef3bd
```
This can be mitigated by forwarding composer auth to the deployment server using COMPOSER_AUTH environment variable.
### References
- https://getcomposer.org/doc/articles/http-basic-authentication.md
- https://getcomposer.org/doc/03-cli.md#composer-auth

