### PR TITLE
Fix array access

### DIFF
--- a/src/Bootstrap/BootstrapByConfigFile.php
+++ b/src/Bootstrap/BootstrapByConfigFile.php
@@ -66,9 +66,9 @@ class BootstrapByConfigFile
                 $builder->identityFile();
             } else {
                 $builder->identityFile(
-                    $config['identity_file.public_key'],
-                    $config['identity_file.private_key'],
-                    $config['identity_file.password']
+                    $config['identity_file']['public_key'],
+                    $config['identity_file']['private_key'],
+                    $config['identity_file']['password']
                 );
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Array dot access doesn't work when importing servers from YAML, resulting in the error ```Object `identity_file.public_key` does not exist in Collection```.

This PR should fix this issue.

