### PR TITLE
Make uploading recursive in ssh native

### DIFF
--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -43,6 +43,7 @@ class NativeSsh implements ServerInterface
         $sshOptions = [
             '-A',
             '-q',
+            '-r',
             '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
         ];
 

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -14,6 +14,11 @@ use Symfony\Component\Process\Process;
 class NativeSsh implements ServerInterface
 {
     /**
+     * @var array
+     */
+    private $mkdirs = [];
+
+    /**
      * @var Configuration
      */
     private $configuration;
@@ -43,7 +48,6 @@ class NativeSsh implements ServerInterface
         $sshOptions = [
             '-A',
             '-q',
-            '-r',
             '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
         ];
 
@@ -81,6 +85,13 @@ class NativeSsh implements ServerInterface
 
         $username = $serverConfig->getUser() ? $serverConfig->getUser() : null;
         $hostname = $serverConfig->getHost();
+
+        $dir = dirname($remote);
+
+        if (!in_array($dir, $this->mkdirs)) {
+            $this->run('mkdir -p ' . escapeshellarg($dir));
+            $this->mkdirs[] = $dir;
+        }
 
         return $this->scpCopy($local, (!empty($username) ? $username . '@' : '') . $hostname . ':' . $remote);
     }


### PR DESCRIPTION
This tries to fix #889

`scp -r` does not work here, because `upload()` receives only files (not directories), so I've fixed it using `mkdir -p` before the `scp`. 
In order to improve performance, I've used a simple caching system with the private property `mkdirs`. Maybe it's not the ideal solution but I couldn't find anything better.