### PR TITLE
added onStart and onEnd tasks

### DIFF
--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -61,7 +61,15 @@ class TaskCommand extends Command
     {
         $stage = $input->hasArgument('stage') ? $input->getArgument('stage') : null;
 
-        $tasks = $this->deployer->getScriptManager()->getTasks($this->getName(), $stage);
+        $tasks = [];
+        if ($this->deployer->tasks->has('onStart')) {
+            $tasks = array_merge($tasks, $this->deployer->getScriptManager()->getTasks('onStart', $stage));
+        }
+        $tasks = array_merge($tasks, $this->deployer->getScriptManager()->getTasks($this->getName(), $stage));
+        if ($this->deployer->tasks->has('onEnd')) {
+            $tasks = array_merge($tasks, $this->deployer->getScriptManager()->getTasks('onEnd', $stage));
+        }
+
         $servers = $this->deployer->getStageStrategy()->getServers($stage);
         $environments = iterator_to_array($this->deployer->environments);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #791 

A quick fix for added on start and on end tasks, similar to beforeAll / afterAll from #791.

@elfet pls close this PR if you have a better way soon. Thanks!

