### PR TITLE
Adjusted runLocally to throw ProcessFailedException in case of error

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -20,6 +20,7 @@ use Monolog\Logger;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Deployer\Cluster\ClusterFactory;
 use Symfony\Component\Console\Input\InputArgument;
@@ -353,7 +354,7 @@ function runLocally($command, $timeout = 60)
     });
 
     if (!$process->isSuccessful()) {
-        throw new \RuntimeException($process->getErrorOutput());
+        throw new ProcessFailedException($process);
     }
 
     $output = $process->getOutput();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Replaced the `\RuntimeException` in `runLocally` with Symfony's `Symfony\Component\Process\Exception\ProcessFailedException` which has more information on the command that failed (including command line and error output).

The `ProcessFailedException` extends the `\RuntimeException` so there shouldn't be a BC problem.

