### PR TITLE
Set the correct port parameter to ssh/scp command

### DIFF
--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -58,7 +58,7 @@ class NativeSsh implements ServerInterface
         $hostname = $serverConfig->getHost();
 
         if ($serverConfig->getPort()) {
-            $sshOptions[] = '-p ' . escapeshellarg($serverConfig->getPort());
+            $sshOptions[] = '-P ' . escapeshellarg($serverConfig->getPort());
         }
 
         if ($serverConfig->getPrivateKey()) {


### PR DESCRIPTION
| Q             | A |
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

According to man scp -P (uppercase) is the correct parameter to set custom port number.
-p (lowercase) is valid scp parameter and according to the man page "Preserves modification times, access times, and modes from the original file."

The problem was discovered while transferring a file from /tmp directory, because the temp files are usually created with 0600 permission which is preserved on the remote machine. Without changing the ownership or permissions. it will not be readable by www-data user.

