### PR TITLE
Unify paths

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -131,7 +131,9 @@ option('branch', null, InputOption::VALUE_OPTIONAL, 'Branch to deploy');
  */
 desc('Show current release');
 task('current', function () {
-    writeln('Current release: ' . basename(realpath(get('current_path'))));
+    $current = run("readlink {{current_path}}")->toString();
+
+    writeln('Current release: ' . basename($current));
 });
 
 

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -69,12 +69,19 @@ set('git_cache', function () { //whether to use git cache - faster cloning by bo
 
 
 /**
- * Return current release path.
+ * Custom paths.
  */
-set('current_path', function () {
-    $link = run("readlink {{deploy_path}}/current")->toString();
-    return substr($link, 0, 1) === '/' ? $link : get('deploy_path') . '/' . $link;
-});
+set('current_dir', 'current');
+set('release_dir', 'release');
+set('releases_dir', 'releases');
+set('shared_dir', 'shared');
+set('dep_dir', '.dep');
+
+set('current_path', '{{deploy_path}}/{{current_dir}}');
+set('release_path', '{{deploy_path}}/{{release_dir}}');
+set('releases_path', '{{deploy_path}}/{{releases_dir}}');
+set('shared_path', '{{deploy_path}}/{{shared_dir}}');
+set('dep_path', '{{deploy_path}}/{{dep_dir}}');
 
 
 /**
@@ -124,7 +131,7 @@ option('branch', null, InputOption::VALUE_OPTIONAL, 'Branch to deploy');
  */
 desc('Show current release');
 task('current', function () {
-    writeln('Current release: ' . basename(get('current_path')));
+    writeln('Current release: ' . basename(realpath(get('current_path'))));
 });
 
 

--- a/recipe/deploy/cleanup.php
+++ b/recipe/deploy/cleanup.php
@@ -24,9 +24,9 @@ task('cleanup', function () {
     }
 
     foreach ($releases as $release) {
-        run("rm -rf {{deploy_path}}/releases/$release");
+        run("rm -rf {{releases_path}}/$release");
     }
 
-    run("cd {{deploy_path}} && if [ -e release ]; then rm release; fi");
-    run("cd {{deploy_path}} && if [ -h release ]; then rm release; fi");
+    run("if [ -e {{release_path}} ]; then rm {{release_path}}; fi");
+    run("if [ -h {{release_path}} ]; then rm {{release_path}}; fi");
 });

--- a/recipe/deploy/copy_dirs.php
+++ b/recipe/deploy/copy_dirs.php
@@ -16,6 +16,6 @@ task('deploy:copy_dirs', function () {
         run("if [ -d $(echo {{release_path}}/$dir) ]; then rm -rf {{release_path}}/$dir; fi");
 
         // Copy directory.
-        run("if [ -d $(echo {{deploy_path}}/current/$dir) ]; then cp -rpf {{deploy_path}}/current/$dir {{release_path}}/$dir; fi");
+        run("if [ -d $(echo {{current_path}}/$dir) ]; then cp -rpf {{current_path}}/$dir {{release_path}}/$dir; fi");
     }
 });

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -9,7 +9,7 @@ namespace Deployer;
 
 desc('Lock deploy');
 task('deploy:lock', function () {
-    $locked = run("if [ -f {{deploy_path}}/.dep/deploy.lock ]; then echo 'true'; fi")->toBool();
+    $locked = run("if [ -f {{dep_path}}/deploy.lock ]; then echo 'true'; fi")->toBool();
 
     if ($locked) {
         throw new \RuntimeException(
@@ -17,11 +17,11 @@ task('deploy:lock', function () {
             "Run deploy:unlock command to unlock."
         );
     } else {
-        run("touch {{deploy_path}}/.dep/deploy.lock");
+        run("touch {{dep_path}}/deploy.lock");
     }
 });
 
 desc('Unlock deploy');
 task('deploy:unlock', function () {
-    run("rm {{deploy_path}}/.dep/deploy.lock");
+    run("rm {{dep_path}}/deploy.lock");
 });

--- a/recipe/deploy/prepare.php
+++ b/recipe/deploy/prepare.php
@@ -34,17 +34,17 @@ task('deploy:prepare', function () {
     run('if [ ! -d {{deploy_path}} ]; then mkdir -p {{deploy_path}}; fi');
 
     // Check for existing /current directory (not symlink)
-    $result = run('if [ ! -L {{deploy_path}}/current ] && [ -d {{deploy_path}}/current ]; then echo true; fi')->toBool();
+    $result = run('if [ ! -L {{current_path}} ] && [ -d {{current_path}} ]; then echo true; fi')->toBool();
     if ($result) {
-        throw new \RuntimeException('There already is a directory (not symlink) named "current" in ' . get('deploy_path') . '. Remove this directory so it can be replaced with a symlink for atomic deployments.');
+        throw new \RuntimeException('There already is a directory (not symlink) named "' . get('current_dir') . '" in ' . get('deploy_path') . '. Remove this directory so it can be replaced with a symlink for atomic deployments.');
     }
 
     // Create metadata .dep dir.
-    run("cd {{deploy_path}} && if [ ! -d .dep ]; then mkdir .dep; fi");
+    run("if [ ! -d {{dep_path}} ]; then mkdir {{dep_path}}; fi");
 
     // Create releases dir.
-    run("cd {{deploy_path}} && if [ ! -d releases ]; then mkdir releases; fi");
+    run("if [ ! -d {{releases_path}} ]; then mkdir {{releases_path}}; fi");
 
     // Create shared dir.
-    run("cd {{deploy_path}} && if [ ! -d shared ]; then mkdir shared; fi");
+    run("if [ ! -d {{shared_path}} ]; then mkdir {{shared_path}}; fi");
 });

--- a/recipe/deploy/rollback.php
+++ b/recipe/deploy/rollback.php
@@ -12,13 +12,13 @@ task('rollback', function () {
     $releases = get('releases_list');
 
     if (isset($releases[1])) {
-        $releaseDir = "{{deploy_path}}/releases/{$releases[1]}";
+        $releaseDir = "{{releases_path}}/{$releases[1]}";
 
         // Symlink to old release.
-        run("cd {{deploy_path}} && {{bin/symlink}} $releaseDir current");
+        run("{{bin/symlink}} $releaseDir {{current_path}}");
 
         // Remove release
-        run("rm -rf {{deploy_path}}/releases/{$releases[0]}");
+        run("rm -rf {{releases_path}}/{$releases[0]}");
 
         if (isVerbose()) {
             writeln("Rollback to `{$releases[1]}` release was successful.");

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -9,17 +9,15 @@ namespace Deployer;
 
 desc('Creating symlinks for shared files and dirs');
 task('deploy:shared', function () {
-    $sharedPath = "{{deploy_path}}/shared";
-
     foreach (get('shared_dirs') as $dir) {
         // Check if shared dir does not exists.
-        if (!test("[ -d $sharedPath/$dir ]")) {
+        if (!test("[ -d {{shared_path}}/$dir ]")) {
             // Create shared dir if it does not exist.
-            run("mkdir -p $sharedPath/$dir");
+            run("mkdir -p {{shared_path}}/$dir");
 
             // If release contains shared dir, copy that dir from release to shared.
             if (test("[ -d $(echo {{release_path}}/$dir) ]")) {
-                run("cp -rv {{release_path}}/$dir $sharedPath/" . dirname($dir));
+                run("cp -rv {{release_path}}/$dir {{shared_path}}/" . dirname($dir));
             }
         }
 
@@ -31,7 +29,7 @@ task('deploy:shared', function () {
         run("mkdir -p `dirname {{release_path}}/$dir`");
 
         // Symlink shared dir to release dir
-        run("{{bin/symlink}} $sharedPath/$dir {{release_path}}/$dir");
+        run("{{bin/symlink}} {{shared_path}}/$dir {{release_path}}/$dir");
     }
 
     foreach (get('shared_files') as $file) {
@@ -43,12 +41,12 @@ task('deploy:shared', function () {
         run("if [ ! -d $(echo {{release_path}}/$dirname) ]; then mkdir -p {{release_path}}/$dirname;fi");
 
         // Create dir of shared file
-        run("mkdir -p $sharedPath/" . $dirname);
+        run("mkdir -p {{shared_path}}/" . $dirname);
 
         // Touch shared
-        run("touch $sharedPath/$file");
+        run("touch {{shared_path}}/$file");
 
         // Symlink shared dir to release dir
-        run("{{bin/symlink}} $sharedPath/$file {{release_path}}/$file");
+        run("{{bin/symlink}} {{shared_path}}/$file {{release_path}}/$file");
     }
 });

--- a/recipe/deploy/symlink.php
+++ b/recipe/deploy/symlink.php
@@ -14,8 +14,9 @@ task('deploy:symlink', function () {
     } else {
         // Atomic symlink does not supported.
         // Will use simple≤ two steps switch.
+        $release = run("readlink {{release_path}}")->toString();
 
-        run("{{bin/symlink}} {{release_path}} {{current_path}}"); // Atomic override symlink.
+        run("{{bin/symlink}} {$release} {{current_path}}"); // Atomic override symlink.
         run("rm {{release_path}}"); // Remove release link.
     }
 });

--- a/recipe/deploy/symlink.php
+++ b/recipe/deploy/symlink.php
@@ -10,12 +10,12 @@ namespace Deployer;
 desc('Creating symlink to release');
 task('deploy:symlink', function () {
     if (run('if [[ "$(man mv)" =~ "--no-target-directory" ]]; then echo "true"; fi')->toBool()) {
-        run("mv -T {{deploy_path}}/release {{deploy_path}}/current");
+        run("mv -T {{release_path}} {{current_path}}");
     } else {
         // Atomic symlink does not supported.
         // Will use simple≤ two steps switch.
 
-        run("cd {{deploy_path}} && {{bin/symlink}} {{release_path}} current"); // Atomic override symlink.
-        run("cd {{deploy_path}} && rm release"); // Remove release link.
+        run("{{bin/symlink}} {{release_path}} {{current_path}}"); // Atomic override symlink.
+        run("rm {{release_path}}"); // Remove release link.
     }
 });

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -49,9 +49,9 @@ task('deploy:update_code', function () {
 
     if ($gitCache && isset($releases[1])) {
         try {
-            run("$git clone $at --recursive -q --reference {{deploy_path}}/releases/{$releases[1]} --dissociate $repository  {{release_path}} 2>&1");
+            run("$git clone $at --recursive -q --reference {{releases_path}}/{$releases[1]} --dissociate $repository  {{release_path}} 2>&1");
         } catch (\RuntimeException $exc) {
-            // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
+            // If {{releases_path}}/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
             run("$git clone $at --recursive -q $repository {{release_path}} 2>&1");
         }
     } else {

--- a/recipe/drupal7.php
+++ b/recipe/drupal7.php
@@ -74,7 +74,7 @@ task('drupal:settings', function () {
         $tmpFilename = tempnam($basepath, 'tmp_settings_');
         file_put_contents($tmpFilename, $settings);
 
-        upload($tmpFilename, '{{deploy_path}}/shared/sites/{{drupal_site}}/settings.php');
+        upload($tmpFilename, '{{shared_path}}/sites/{{drupal_site}}/settings.php');
 
         unlink($tmpFilename);
     }
@@ -83,6 +83,6 @@ task('drupal:settings', function () {
 //Upload Drupal 7 files folder
 task('drupal:upload_files', function () {
     if (askConfirmation('Are you sure?')) {
-        upload('sites/{{drupal_site}}/files', '{{deploy_path}}/shared/sites/{{drupal_site}}/files');
+        upload('sites/{{drupal_site}}/files', '{{shared_path}}/sites/{{drupal_site}}/files');
     }
 });

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -40,13 +40,13 @@ set('writable_dirs', [
  */
 desc('Disable maintenance mode');
 task('artisan:up', function () {
-    $output = run('if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan up; fi');
+    $output = run('if [ -f {{current_path}}/artisan ]; then {{bin/php}} {{current_path}}/artisan up; fi');
     writeln('<info>' . $output . '</info>');
 });
 
 desc('Enable maintenance mode');
 task('artisan:down', function () {
-    $output = run('if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi');
+    $output = run('if [ -f {{current_path}}/artisan ]; then {{bin/php}} {{current_path}}/artisan down; fi');
     writeln('<info>' . $output . '</info>');
 });
 
@@ -112,10 +112,10 @@ task('deploy:public_disk', function () {
     run('if [ -d $(echo {{release_path}}/public/storage) ]; then rm -rf {{release_path}}/public/storage; fi');
 
     // Create shared dir if it does not exist.
-    run('mkdir -p {{deploy_path}}/shared/storage/app/public');
+    run('mkdir -p {{shared_path}}/storage/app/public');
 
     // Symlink shared dir to release dir
-    run('{{bin/symlink}} {{deploy_path}}/shared/storage/app/public {{release_path}}/public/storage');
+    run('{{bin/symlink}} {{shared_path}}/storage/app/public {{release_path}}/public/storage');
 });
 
 /**

--- a/test/recipe/CommonTest.php
+++ b/test/recipe/CommonTest.php
@@ -23,21 +23,21 @@ class CommonTest extends RecipeTester
     {
         $this->exec('deploy:prepare');
 
-        $this->assertFileExists(self::$deployPath . '/releases');
-        $this->assertFileExists(self::$deployPath . '/shared');
+        $this->assertFileExists($this->getEnv('releases_path'));
+        $this->assertFileExists($this->getEnv('shared_path'));
     }
 
     public function testRelease()
     {
         $this->exec('deploy:release');
 
-        $this->assertFileExists(self::$deployPath . '/release');
+        $this->assertFileExists($this->getEnv('release_path'));
     }
 
     public function testReleaseSymlink()
     {
-        $removedDirectory = self::$deployPath . '/directory';
-        $releaseSymlink = self::$deployPath . '/release';
+        $removedDirectory = $this->getEnv('deploy_path') . '/directory';
+        $releaseSymlink = $this->getEnv('release_path');
 
         mkdir($removedDirectory);
         unlink($releaseSymlink);
@@ -68,15 +68,15 @@ class CommonTest extends RecipeTester
 
         $this->assertEquals(
             realpath($this->getEnv('release_path') . '/app/logs'),
-            $this->getEnv('deploy_path') . '/shared/app/logs'
+            $this->getEnv('shared_path') . '/app/logs'
         );
         $this->assertEquals(
             realpath($this->getEnv('release_path') . '/app/config/parameters.yml'),
-            $this->getEnv('deploy_path') . '/shared/app/config/parameters.yml'
+            $this->getEnv('shared_path') . '/app/config/parameters.yml'
         );
 
-        $this->assertTrue(is_dir($this->getEnv('deploy_path') . '/shared/app/logs'));
-        $this->assertFileExists($this->getEnv('deploy_path') . '/shared/app/config/parameters.yml');
+        $this->assertTrue(is_dir($this->getEnv('shared_path') . '/app/logs'));
+        $this->assertFileExists($this->getEnv('shared_path') . '/app/config/parameters.yml');
     }
 
     public function testWriteable()
@@ -103,18 +103,15 @@ class CommonTest extends RecipeTester
     {
         $this->exec('deploy:symlink');
 
-        $this->assertTrue(realpath($this->getEnv('deploy_path') . '/current') !== false);
-        clearstatcache($this->getEnv('deploy_path') . '/release');
-        $this->assertFalse(realpath($this->getEnv('deploy_path') . '/release') !== false, 'Symlink to release directory must gone after deploy:symlink.');
+        $this->assertTrue(realpath($this->getEnv('current_path')) !== false);
+        clearstatcache($this->getEnv('release_path'));
+        $this->assertFalse(realpath($this->getEnv('release_path')) !== false, 'Symlink to release directory must gone after deploy:symlink.');
     }
 
     public function testCurrent()
     {
-        $this->exec('current');
+        $result = $this->exec('current');
 
-        $this->assertEquals(
-            realpath($this->getEnv('deploy_path') . '/current'),
-            $this->getEnv('current_path')
-        );
+        $this->assertContains('2', $result);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes 
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #922 #921 #920 #879 

I'm trying to unify all paths into a variables (similar to Capistrano). What do you think about this PR? I know it's not complete, and will require to change some things and some documentation maybe.

With this PR, one should be able to modify the structure of deployer using the new variables.

We can include new paths like: `current_release` or `previous_release` to simplify and make simple to use `release_path` outside a release.

