### PR TITLE
Added --hook option

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -118,6 +118,7 @@ argument('stage', InputArgument::OPTIONAL, 'Run tasks only on this server or gro
 option('tag', null, InputOption::VALUE_OPTIONAL, 'Tag to deploy');
 option('revision', null, InputOption::VALUE_OPTIONAL, 'Revision to deploy');
 option('branch', null, InputOption::VALUE_OPTIONAL, 'Branch to deploy');
+option('hooks', null, InputOption::VALUE_OPTIONAL, 'Set to false to skip after/before hooks', true);
 
 /**
  * Tasks

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -63,7 +63,7 @@ class TaskCommand extends Command
 
         $tasks = $this->deployer->getScriptManager()->getTasks($this->getName(), $stage);
 
-        if (!$input->getOption('hooks') || $input->getOption('hooks') == 'false') {
+        if (!$input->getOption('hooks') || $input->getOption('hooks') === 'false') {
             $tasks = array_filter($tasks, function ($task) {
                 return $this->getName() == $task->getName();
             });

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -62,6 +62,13 @@ class TaskCommand extends Command
         $stage = $input->hasArgument('stage') ? $input->getArgument('stage') : null;
 
         $tasks = $this->deployer->getScriptManager()->getTasks($this->getName(), $stage);
+
+        if (!$input->getOption('hooks') || $input->getOption('hooks') == 'false') {
+            $tasks = array_filter($tasks, function ($task) {
+                return $this->getName() == $task->getName();
+            });
+        }
+
         $servers = $this->deployer->getStageStrategy()->getServers($stage);
         $environments = iterator_to_array($this->deployer->environments);
 

--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -74,7 +74,7 @@ class Environment
     private function checkIfNameIsProtected($name)
     {
         $length = strlen($name);
-        
+
         foreach ($this->protectedNames as $protectedName) {
             $len = strlen($protectedName);
             if ($name === $protectedName) {


### PR DESCRIPTION
Added --hook option to disable running other tasks than the one specified

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I wanted a way to run certain tasks without having the before/after hooks set in deploy.php to be run, because some of those tasks might assume we are in a deploy context while maybe we're not.

We can now do;

```bash
dep custom:command:here staging --hooks false
```

While we have

```php
before('custom:command:here', 'another:command:before:custom');
after('custom:command:here', 'another:command:after:custom');
```

So not to run `another:command:after:custom` or `another:command:before:custom` but still run `custom:command:here`.