### PR TITLE
Change variable which was (propably) copy-pasted wrong

### DIFF
--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -126,7 +126,7 @@ class NativeSsh implements ServerInterface
         }
 
         if ($serverConfig->getPrivateKey()) {
-            $sshOptions[] = '-i ' . escapeshellarg($serverConfig->getPrivateKey());
+            $scpOptions[] = '-i ' . escapeshellarg($serverConfig->getPrivateKey());
         }
 
         $scpCommand = 'scp ' . implode(' ', $scpOptions) . ' ' . escapeshellarg($target) . ' ' . escapeshellarg($target2);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This bug meant that when deploying using a private key using ssh_type native would throw the following exception:
```
[Symfony\Component\Process\Exception\ProcessFailedException]
  The command "scp -P '22' 'app-deploy.tar.gz' '[USER]@[IP]:[FOLDER]/releases/20161219151859/app-deploy.tar.gz'" failed.
  Exit Code: 1(General error)
  Working directory: /opt/atlassian/pipelines/agent/build
  Output:
  ================
  Error Output:
  ================
  Write failed: Broken pipe
  lost connection
```

It seems like this was just a simple copy-paste error.