### PR TITLE
Fix bug with $httpGroup guard clause

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -43,7 +43,7 @@ task('deploy:writable', function () {
             // -R   operate on files and directories recursively
             // -L   if a command line argument is a symbolic link to a directory, traverse it
             $httpGroup = get('http_group', false);
-            if ($httpUser === false) {
+            if ($httpGroup === false) {
                 throw new \RuntimeException("Please setup `http_group` config parameter.");
             }
             run("$sudo chgrp -RH $httpGroup $dirs");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Just found this bug reading the source code. I think you meant to use `httpGroup` and not `httpUser` 😂 