### PR TITLE
always success

### DIFF
--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -23,5 +23,8 @@ task('deploy:lock', function () {
 
 desc('Unlock deploy');
 task('deploy:unlock', function () {
-    run("rm {{deploy_path}}/.dep/deploy.lock");
+    try {
+        run("rm {{deploy_path}}/.dep/deploy.lock");//always success
+    } catch (\Exception $e) {
+    }
 });

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -23,8 +23,5 @@ task('deploy:lock', function () {
 
 desc('Unlock deploy');
 task('deploy:unlock', function () {
-    try {
-        run("rm {{deploy_path}}/.dep/deploy.lock");//always success
-    } catch (\Exception $e) {
-    }
+    run("rm -f {{deploy_path}}/.dep/deploy.lock");//always success
 });


### PR DESCRIPTION
always success when running unlock

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Run `deploy:unlock` always return success instead of exception when `deploy.lock` not exist
