### PR TITLE
Raise timeout for runLocally to 300 seconds

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -331,7 +331,7 @@ function run($command)
  * @return Result Output of command.
  * @throws \RuntimeException
  */
-function runLocally($command, $timeout = 60)
+function runLocally($command, $timeout = 300)
 {
     $command = parse($command);
 


### PR DESCRIPTION
Similar to other locations this is now also raised to 5 minutes.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
