### PR TITLE
Try to remove deploy.lock when deploy is fail

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -141,4 +141,6 @@ task('success', function () {
  */
 task('deploy:failed', function () {
 })->setPrivate();
+
 onFailure('deploy', 'deploy:failed');
+before('deploy:failed', 'deploy:unlock');


### PR DESCRIPTION
Try to remove deploy.lock when deploy is fail

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Try to remove `deploy.lock` when deploy is fail to make it simpler
