### PR TITLE
Show message on file download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Added `testLocally` function (analog `test` fn)
 - Added `ConfigurationException`
+- Show message on file download
 
 ### Changed
 - Server config `setPty` renamed to `pty` [#953](https://github.com/deployphp/deployer/pull/953)

--- a/src/functions.php
+++ b/src/functions.php
@@ -447,6 +447,7 @@ function download($local, $remote)
     $local = parse($local);
     $remote = parse($remote);
 
+    writeln("Download file <info>$remote</info> to <info>$local</info>");
     $server->download($local, $remote);
 }
 


### PR DESCRIPTION
Similar to upload() a message should be shown for file downloads.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](/CHANGELOG.md)
