### PR TITLE
Recursively add configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Added option `-L` to `setfacl` [#956](https://github.com/deployphp/deployer/pull/956)
 - Run `deploy:unlock` when deploy is fail [#958](https://github.com/deployphp/deployer/pull/958)
 - Now throw exception on duplicates in `shared_dirs`
-- `add()` now merges configuration options recursively
+- `add()` now merges configuration options recursively [#962](https://github.com/deployphp/deployer/pull/962)
 
 ### Fixed
 - Fixed native ssh scp option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added option `-L` to `setfacl` [#956](https://github.com/deployphp/deployer/pull/956)
 - Run `deploy:unlock` when deploy is fail [#958](https://github.com/deployphp/deployer/pull/958)
 - Now throw exception on duplicates in `shared_dirs`
+- `add()` now merges configuration options recursively
 
 ### Fixed
 - Fixed native ssh scp option

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -167,7 +167,7 @@ class Deployer extends Container
             if (!is_array($config)) {
                 throw new \RuntimeException("Configuration parameter `$name` isn't array.");
             }
-            self::setDefault($name, array_merge($config, $array));
+            self::setDefault($name, array_merge_recursive($config, $array));
         } else {
             self::setDefault($name, $array);
         }

--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -98,7 +98,7 @@ class Environment
             if (!is_array($config)) {
                 throw new \RuntimeException("Configuration parameter `$name` isn't array.");
             }
-            $this->set($name, array_merge($config, $array));
+            $this->set($name, array_merge_recursive($config, $array));
         } else {
             $this->set($name, $array);
         }

--- a/test/src/DeployerTest.php
+++ b/test/src/DeployerTest.php
@@ -74,10 +74,34 @@ class DeployerTest extends \PHPUnit_Framework_TestCase
 
     public function testAddDefault()
     {
-        Deployer::setDefault('config', ['one', 'two']);
-        Deployer::addDefault('config', ['three']);
+        Deployer::setDefault('config', [
+            'one',
+            'two',
+            'nested' => [],
+        ]);
+        Deployer::addDefault('config', [
+            'three',
+            'nested' => [
+                'first',
+            ],
+        ]);
+        Deployer::addDefault('config', [
+            'nested' => [
+                'second',
+            ],
+        ]);
 
-        $this->assertEquals(['one', 'two', 'three'], Deployer::getDefault('config'));
+        $expected = [
+            'one',
+            'two',
+            'three',
+            'nested' => [
+                'first',
+                'second',
+            ],
+        ];
+
+        $this->assertEquals($expected, Deployer::getDefault('config'));
     }
 
     /**

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -116,10 +116,34 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
     public function testAddParams()
     {
         $env = new Environment();
-        $env->set('config', ['one', 'two']);
-        $env->add('config', ['three']);
+        $env->set('config', [
+            'one',
+            'two',
+            'nested' => [],
+        ]);
+        $env->add('config', [
+            'three',
+            'nested' => [
+                'first',
+            ],
+        ]);
+        $env->add('config', [
+            'nested' => [
+                'second',
+            ],
+        ]);
 
-        $this->assertEquals(['one', 'two', 'three'], $env->get('config'));
+        $expected = [
+            'one',
+            'two',
+            'three',
+            'nested' => [
+                'first',
+                'second',
+            ],
+        ];
+
+        $this->assertEquals($expected, $env->get('config'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | Maybe
| Deprecations? | No
| Fixed tickets | N/A

This ensures that something like the following works:

```php
set('top', [
  'first' => [
    'second' => [
      'value1',
      'value2',
    ],
  ],
]);

add('top', [
  'first' => [
    'second' => [
      'value3',
    ],
  ],
]);

/*
The following should yield:

Array
(
    [first] => Array
        (
            [second] => Array
                (
                    [0] => value1
                    [1] => value2
                    [2] => value3
                )
        )

)
*/

print_r(get('top'));
