### PR TITLE
Set infinite timeout for local commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## master
 [v4.1.0...master](https://github.com/deployphp/deployer/compare/v4.1.0...master)
 
-—
+### Changed
+- Set infinite timeout for `runLocally()` and `Local::run()` [#974](https://github.com/deployphp/deployer/pull/974)
 
 ## v4.1.0
 [v4.0.2...v4.1.0](https://github.com/deployphp/deployer/compare/v4.0.2...v4.1.0)

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -11,8 +11,6 @@ use Symfony\Component\Process\Process;
 
 class Local implements ServerInterface
 {
-    const TIMEOUT = 300;
-
     /**
      * @var Configuration
      */
@@ -64,8 +62,8 @@ class Local implements ServerInterface
     {
         $process = new Process($command);
         $process
-            ->setTimeout(self::TIMEOUT)
-            ->setIdleTimeout(self::TIMEOUT)
+            ->setTimeout(null)
+            ->setIdleTimeout(null)
             ->mustRun($callback);
 
         return $process->getOutput();

--- a/src/functions.php
+++ b/src/functions.php
@@ -331,7 +331,7 @@ function run($command)
  * @return Result Output of command.
  * @throws \RuntimeException
  */
-function runLocally($command, $timeout = 300)
+function runLocally($command, $timeout = null)
 {
     $command = parse($command);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Very long running commands (e.g. DB import) can exceed even 5 minutes (see #955) thus switch to an infinite timeout for local commands.