### PR TITLE
Add non-recursive chmod flag to deploy:writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - `add()` now merges configuration options recursively [#962](https://github.com/deployphp/deployer/pull/962)
+- Added `writable_chmod_recursive` boolean option to enable non-recursive `chmod`
 
 ## v4.1.0
 [v4.0.2...v4.1.0](https://github.com/deployphp/deployer/compare/v4.0.2...v4.1.0)

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -42,6 +42,7 @@ set('writable_dirs', []);
 set('writable_mode', 'acl'); // chmod, chown, chgrp or acl.
 set('writable_use_sudo', false); // Using sudo in writable commands?
 set('writable_chmod_mode', '0755'); // For chmod mode
+set('writable_chmod_recursive', true); // For chmod mode
 
 set('http_user', false);
 set('http_group', false);

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -48,7 +48,8 @@ task('deploy:writable', function () {
             }
             run("$sudo chgrp -RH $httpGroup $dirs");
         } elseif ($mode === 'chmod') {
-            run("$sudo chmod -R {{writable_chmod_mode}} $dirs");
+            $recursive = get('writable_chmod_recursive') ? '-R' : '';
+            run("$sudo chmod $recursive {{writable_chmod_mode}} $dirs");
         } elseif ($mode === 'acl') {
             if (strpos(run("chmod 2>&1; true"), '+a') !== false) {
                 // Try OS-X specific setting of access-rights


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This commit enables the user to disable the recursive flag when setting writable dirs with `chmod`, by setting `writable_chmod_recursive` to `false`. It is per default set to `true`.

I have prefixed the setting with `writable_chmod_` to use the same naming convention as with `writable_chmod_mode`.

My personal scenario is that when I run the deployment, writable dirs are created by my own user and are then given 777 permission. The files within these writable dirs are then created by the web server user, and when I deploy the next time (without sudo), the deployment fails because the recursive flag makes the command trying to change permissions on the files as well, which my personal user doesn't own.

By removing the recursive flag, only the directories are being changed, which doesn't makes the deployment crash.