### PR TITLE
Enable autocomplete for ask()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - `add()` now merges configuration options recursively [#962](https://github.com/deployphp/deployer/pull/962)
 - Added `writable_chmod_recursive` boolean option to enable non-recursive `chmod`
+- `ask()` now supports autocomplete [#978](https://github.com/deployphp/deployer/pull/978)
 
 ## v4.1.0
 [v4.0.2...v4.1.0](https://github.com/deployphp/deployer/compare/v4.0.2...v4.1.0)

--- a/src/functions.php
+++ b/src/functions.php
@@ -546,11 +546,16 @@ function has($name)
 /**
  * @param string $message
  * @param string|null $default
+ * @param string[]|null $suggestedChoices
  * @return string
  * @codeCoverageIgnore
  */
-function ask($message, $default = null)
+function ask($message, $default = null, $suggestedChoices = null)
 {
+    if (($suggestedChoices !== null) && (empty($suggestedChoices))) {
+        throw new \InvalidArgumentException('Suggested choices should not be empty');
+    }
+
     if (isQuiet()) {
         return $default;
     }
@@ -560,6 +565,10 @@ function ask($message, $default = null)
     $message = "<question>$message" . (($default === null) ? "" : " [$default]") . "</question> ";
 
     $question = new Question($message, $default);
+
+    if (empty($suggestedChoices) === false) {
+        $question->setAutocompleterValues($suggestedChoices);
+    }
 
     return $helper->ask(input(), output(), $question);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This PR enables the use of Symfony Console [autocomplete](http://symfony.com/blog/new-in-symfony-2-2-autocomplete-on-the-command-line) for `ask()` deployer function.

In my usecase, I use `ask()` to ask the user which branch he wishes to deploy, and since some branch names can be very long, autocomplete can be pretty handy. 
