### PR TITLE
TASK: Fix deployer namespace and remove deprecated method calls +

### DIFF
--- a/recipe/flow_framework.php
+++ b/recipe/flow_framework.php
@@ -5,13 +5,15 @@
  * file that was distributed with this source code.
  */
 
+namespace Deployer;
+
 require_once __DIR__ . '/common.php';
 
 // Flow-Framework application-context
-env('flow_context', 'Production');
+set('flow_context', 'Production');
 
 // Flow-Framework cli-command
-env('flow_command', 'flow');
+set('flow_command', 'flow');
 
 // Flow-Framework shared directories
 set('shared_dirs', [


### PR DESCRIPTION
The deployer namespace was missing in the flow recipe and also the deprecated env methods were used.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
