### PR TITLE
Properly install composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,11 @@ matrix:
   allow_failures:
     - php: 7.1
 
-env:
-  matrix:
-    - COMPOSER_FLAGS="--prefer-lowest"
-    - COMPOSER_FLAGS="--prefer-stable"
-
 install:
   - eval `ssh-agent -s`
   - test/travis/setup-secure-shell.sh
   - composer self-update
-  - composer update --no-interaction --prefer-source $COMPOSER_FLAGS
+  - composer install --no-interaction --prefer-source
 
 script:
   - phpunit


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Code should be tested on package versions defined in `composer.lock` rather then last versions of packages from `composer update`.

Commit c3564a28ac5289465494c23a1ad763edec4737b2 introduced `composer update` to workaround symfony php 5.4 compability.