### PR TITLE
Fix `parse` not replacing variables containing a `-` like `{{webserver-user}}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master
 [v4.2.1...master](https://github.com/deployphp/deployer/compare/v4.2.1...master)
 
--
+- Fixed `parse` not replacing variables containing a `-` like `{{webserver-user}}`
 
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)

--- a/src/Server/Environment.php
+++ b/src/Server/Environment.php
@@ -157,7 +157,7 @@ class Environment
     public function parse($value)
     {
         if (is_string($value)) {
-            $value = preg_replace_callback('/\{\{\s*([\w\.\/]+)\s*\}\}/', [$this, 'parseCallback'], $value);
+            $value = preg_replace_callback('/\{\{\s*([\w\.\-\/]+)\s*\}\}/', [$this, 'parseCallback'], $value);
         }
 
         return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? |  No
| Fixed tickets | N/A

CHANGELOG.md is updated.

In the current master it is not possible to use a `_` in variables that are to be replaced using `\Deployer\parse()`.
This pull request updates the affected regex so it is possible to have variables like `{{webserver-user}}` replaced with the value from the config.
