### PR TITLE
Improve the WordPress recipe

### DIFF
--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -26,7 +26,7 @@ task('deploy', [
     'deploy:release',
     'deploy:update_code',
     'deploy:shared',
-    'deploy:vendors', 
+    'deploy:vendors',
     'deploy:writable',
     'deploy:symlink',
     'deploy:chown',

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -9,15 +9,27 @@ namespace Deployer;
 
 require_once __DIR__ . '/common.php';
 
+set('shared_files', ['wp-config.php']);
+set('shared_dirs', ['wp-content/uploads']);
+
 /**
- * Main task
+ * Chown files to correct web server user
+ * for your OS, so uploads work.
  */
+task('deploy:chown', function () {
+  run('chown -R www-data:www-data ' . env('deploy_path'));
+});
+
 task('deploy', [
     'deploy:prepare',
     'deploy:lock',
     'deploy:release',
     'deploy:update_code',
+    'deploy:shared',
+    'deploy:vendors', 
+    'deploy:writable',
     'deploy:symlink',
+    'deploy:chown',
     'deploy:unlock',
     'cleanup',
 ])->desc('Deploy your project');

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -11,14 +11,7 @@ require_once __DIR__ . '/common.php';
 
 set('shared_files', ['wp-config.php']);
 set('shared_dirs', ['wp-content/uploads']);
-
-/**
- * Chown files to correct web server user
- * for your OS, so uploads work.
- */
-task('deploy:chown', function () {
-    run('chown -R www-data:www-data ' . env('deploy_path'));
-});
+set('writable_dirs', ['wp-content/uploads']);
 
 task('deploy', [
     'deploy:prepare',

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -17,7 +17,7 @@ set('shared_dirs', ['wp-content/uploads']);
  * for your OS, so uploads work.
  */
 task('deploy:chown', function () {
-  run('chown -R www-data:www-data ' . env('deploy_path'));
+    run('chown -R www-data:www-data ' . env('deploy_path'));
 });
 
 task('deploy', [

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -22,7 +22,6 @@ task('deploy', [
     'deploy:vendors',
     'deploy:writable',
     'deploy:symlink',
-    'deploy:chown',
     'deploy:unlock',
     'cleanup',
 ])->desc('Deploy your project');


### PR DESCRIPTION
* Configure files commonly shared across deploys (`wp-config.php` and the uploads folder)
* Run Composer (many WordPress sites use Composer with WPackagist)
* chown file to the web server owner. (Might be platform-dependent, but this is a good default)

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | Yes (If someone  had include the old recipe)
| Deprecations? | No
| Fixed tickets | N/A
