### PR TITLE
Verify that writable directories exist

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -18,6 +18,9 @@ task('deploy:writable', function () {
         return;
     }
 
+    //verify that directories exist
+    run("mkdir -vp $dirs");
+
     if ($httpUser === false && $mode !== 'chmod') {
         // Detect http user in process list.
         $httpUser = run("ps axo user,comm | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | cut -d\\  -f1")->toString();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A 

If there is a directory in the `$writables` list that is not in the git repository, then attempting to set that directories permissions will cause the deploy to fail. 