### PR TITLE
Add task queue:restart for Laravel recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Fixed
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
 
+### Changed
+- Add task queue:restart for Laravel recipe [#1007](https://github.com/deployphp/deployer/pull/1007)
+
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -14,12 +14,12 @@ require_once __DIR__ . '/common.php';
 
 // Laravel shared dirs
 set('shared_dirs', [
-    'storage'
+    'storage',
 ]);
 
 // Laravel shared file
 set('shared_files', [
-    '.env'
+    '.env',
 ]);
 
 // Laravel writable dirs
@@ -138,7 +138,6 @@ task('deploy', [
     'artisan:view:clear',
     'artisan:cache:clear',
     'artisan:config:cache',
-    'artisan:queue:restart',
     'artisan:optimize',
     'deploy:symlink',
     'deploy:unlock',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -98,6 +98,11 @@ task('artisan:optimize', function () {
     run('{{bin/php}} {{release_path}}/artisan optimize');
 });
 
+desc('Execute artisan queue:restart');
+task('artisan:queue:restart', function () {
+    run('{{bin/php}} {{release_path}}/artisan queue:restart');
+});
+
 /**
  * Task deploy:public_disk support the public disk.
  * To run this task automatically, please add below line to your deploy.php file
@@ -133,6 +138,7 @@ task('deploy', [
     'artisan:view:clear',
     'artisan:cache:clear',
     'artisan:config:cache',
+    'artisan:queue:restart',
     'artisan:optimize',
     'deploy:symlink',
     'deploy:unlock',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Laravel has an artisan command to send a restart signal to the queue workers. This is kind of a must during deployment. I noticed that the Laravel recipe does not have this artisan command, so here is a PR to add this command.

https://laravel.com/docs/5.4/queues#queue-workers-and-deployment
