### PR TITLE
Add a way to retrieve a defined task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v4.2.1...master](https://github.com/deployphp/deployer/compare/v4.2.1...master)
 
+### Added
+- Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
+
 ### Fixed
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -135,14 +135,21 @@ function desc($title = null)
 /**
  * Define a new task and save to tasks list.
  *
+ * Alternatively get a defined task.
+ *
  * @param string $name Name of current task.
- * @param callable|array|string $body Callable task or array of other tasks names.
+ * @param callable|array|string|null $body Callable task, array of other tasks names or nothing to get a defined tasks
  * @return Task\Task
  * @throws \InvalidArgumentException
  */
-function task($name, $body)
+function task($name, $body = null)
 {
     $deployer = Deployer::get();
+
+    if (empty($body)) {
+        $task = $deployer->tasks->get($name);
+        return $task;
+    }
 
     if ($body instanceof \Closure) {
         $task = new T($name, $body);

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -132,6 +132,9 @@ class FunctionsTest extends TestCase
         $task = $this->deployer->tasks->get('task');
         $this->assertInstanceOf('Deployer\Task\Task', $task);
 
+        $task = task('task');
+        $this->assertInstanceOf('Deployer\Task\Task', $task);
+
         task('group', ['task']);
         $task = $this->deployer->tasks->get('group');
         $this->assertInstanceOf('Deployer\Task\GroupTask', $task);


### PR DESCRIPTION
This is useful to reconfigure tasks defined in 3rd party recipes,
e.g. to limit execution to a few servers.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #954
