### PR TITLE
Ensure CommandEvent respects PHP syntax < 7.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
+- Fixed incompatible PHP 7.0 syntax [#1020](https://github.com/deployphp/deployer/pull/1020)
 
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)

--- a/src/Console/CommandEvent.php
+++ b/src/Console/CommandEvent.php
@@ -39,7 +39,7 @@ class CommandEvent
     /**
      * @return Command
      */
-    public function getCommand(): Command
+    public function getCommand()
     {
         return $this->command;
     }
@@ -47,7 +47,7 @@ class CommandEvent
     /**
      * @return InputInterface
      */
-    public function getInput(): InputInterface
+    public function getInput()
     {
         return $this->input;
     }
@@ -55,7 +55,7 @@ class CommandEvent
     /**
      * @return OutputInterface
      */
-    public function getOutput(): OutputInterface
+    public function getOutput()
     {
         return $this->output;
     }
@@ -63,7 +63,7 @@ class CommandEvent
     /**
      * @return \Exception
      */
-    public function getException(): \Exception
+    public function getException()
     {
         return $this->exception;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

---

Ensure CommandEvent respects PHP syntax < 7.0.
