### PR TITLE
Fix/allow pem for native ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `Can not share same dirs` for shared folders having similar names [#995](https://github.com/deployphp/deployer/issues/995)
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
 - Fixed incompatible PHP 7.0 syntax [#1020](https://github.com/deployphp/deployer/pull/1020)
+- Fixed possibility to use PEM files with Native SSH
 
 
 ## v4.2.1

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -71,6 +71,8 @@ class NativeSsh implements ServerInterface
 
         if ($serverConfig->getPrivateKey()) {
             $sshOptions[] = '-i ' . escapeshellarg($serverConfig->getPrivateKey());
+        } else if ($serverConfig->getPemFile()) {
+            $sshOptions[] = '-i ' . escapeshellarg($serverConfig->getPemFile());
         }
 
         if ($serverConfig->getPty()) {
@@ -246,6 +248,8 @@ class NativeSsh implements ServerInterface
         }
         if ($serverConfig->getPrivateKey()) {
             $sshOptions[] = '-i ' . escapeshellarg($serverConfig->getPrivateKey());
+        } else if ($serverConfig->getPemFile()) {
+            $sshOptions[] = '-i ' . escapeshellarg($serverConfig->getPemFile());
         }
         $sshOptions = array_merge($sshOptions, $this->getMultiplexingSshOptions());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Quite self describing :-) PEM files are completely compatible with the -i flag of SSH just like any private key.