### PR TITLE
Parallel executor does not wait for once() task even if they can have an impact of the future tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fixed `Can not share same dirs` for shared folders having similar names [#995](https://github.com/deployphp/deployer/issues/995)
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
 - Fixed incompatible PHP 7.0 syntax [#1020](https://github.com/deployphp/deployer/pull/1020)
-
+- Fixed parallel executor would not wait for once() tasks while they can have impact on future tasks.
 
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -337,9 +337,9 @@ class ParallelExecutor implements ExecutorInterface
                     $taskToDoStorage = new ArrayStorage();
                     $taskToDoStorage->push($this->tasksToDo);
                     $this->pure->setStorage('tasks_to_do', $taskToDoStorage);
-
-                    $this->wait = true;
                 }
+
+                $this->wait = true;
             } else {
                 $this->loop->stop();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
