### PR TITLE
Enable TTY for local commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
+- Enable TTY for local commands [#1028](https://github.com/deployphp/deployer/pull/1028)
 
 ### Fixed
 - Fixed `Can not share same dirs` for shared folders having similar names [#995](https://github.com/deployphp/deployer/issues/995)

--- a/src/Server/Local.php
+++ b/src/Server/Local.php
@@ -66,6 +66,7 @@ class Local implements ServerInterface
         $process
             ->setTimeout(self::TIMEOUT)
             ->setIdleTimeout(self::TIMEOUT)
+            ->setTty(true)
             ->mustRun($callback);
 
         return $process->getOutput();

--- a/src/functions.php
+++ b/src/functions.php
@@ -350,6 +350,7 @@ function runLocally($command, $timeout = 300)
 
     $process = new Process($command);
     $process->setTimeout($timeout);
+    $process->setTty(true);
     $process->run(function ($type, $buffer) {
         if (isDebug()) {
             if ('err' === $type) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This is essential when executing interactive commands via `runLocally()`.