### PR TITLE
Support for SSH config file in NativeSsh implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
+- Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
 
 ### Fixed
 - Fixed `Can not share same dirs` for shared folders having similar names [#995](https://github.com/deployphp/deployer/issues/995)

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -139,7 +139,7 @@ class NativeSsh implements ServerInterface
         $scpOptions = [];
 
         if ($serverConfig->getConfigFile()) {
-            $sshOptions[] = '-F ' . escapeshellarg($serverConfig->getConfigFile());
+            $scpOptions[] = '-F ' . escapeshellarg($serverConfig->getConfigFile());
         }
 
         if ($serverConfig->getPort()) {

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -65,6 +65,10 @@ class NativeSsh implements ServerInterface
         }
         $hostname = $serverConfig->getHost();
 
+        if ($serverConfig->getConfigFile()) {
+            $sshOptions[] = '-F ' . escapeshellarg($serverConfig->getConfigFile());
+        }
+
         if ($serverConfig->getPort()) {
             $sshOptions[] = '-p ' . escapeshellarg($serverConfig->getPort());
         }
@@ -133,6 +137,10 @@ class NativeSsh implements ServerInterface
         $serverConfig = $this->getConfiguration();
 
         $scpOptions = [];
+
+        if ($serverConfig->getConfigFile()) {
+            $sshOptions[] = '-F ' . escapeshellarg($serverConfig->getConfigFile());
+        }
 
         if ($serverConfig->getPort()) {
             $scpOptions[] = '-P ' . escapeshellarg($serverConfig->getPort());
@@ -241,6 +249,9 @@ class NativeSsh implements ServerInterface
         $hostname = $serverConfig->getHost();
 
         $sshOptions = [];
+        if ($serverConfig->getConfigFile()) {
+            $sshOptions[] = '-F ' . escapeshellarg($serverConfig->getConfigFile());
+        }
         if ($serverConfig->getPort()) {
             $sshOptions[] = '-p ' . escapeshellarg($serverConfig->getPort());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #979 

This PR adds support for specifying an SSH config file (e.g. `->configFile('~/.ssh/custom')`) and actually have it work in the NativeSsh implementation, using the `-F` option of the `ssh` program.