### PR TITLE
Fixed an issue with the output of ls in releases_list that was breaking cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed `Can not share same dirs` for shared folders having similar names [#995](https://github.com/deployphp/deployer/issues/995)
 - Fixed scalar override on recursive option merge [#1003](https://github.com/deployphp/deployer/pull/1003)
 - Fixed incompatible PHP 7.0 syntax [#1020](https://github.com/deployphp/deployer/pull/1020)
-
+- Fixed an issue with the output of ls in releases_list that was breaking cleanup. 
 
 ### Changed
 - Add task queue:restart for Laravel recipe [#1007](https://github.com/deployphp/deployer/pull/1007)

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -37,11 +37,11 @@ set('releases_list', function () {
     }
 
     // Will list only dirs in releases.
-    $list = run('cd releases && ls -t -d */')->toArray();
+    $list = run('cd releases && ls -t -1 -d */')->toArray();
 
     // Prepare list.
     $list = array_map(function ($release) {
-        return basename(rtrim($release, '/'));
+        return basename(rtrim(trim($release), '/'));
     }, $list);
 
     $releases = []; // Releases list.


### PR DESCRIPTION
Forces single column output and trims newlines from ls. On our servers, we have an alias for ls that improves the default output but was causing cleanup to not work.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | Unsure