### PR TITLE
Fixed old releases not being cleaned up when keep_releases reduced by than half.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed incompatible PHP 7.0 syntax [#1020](https://github.com/deployphp/deployer/pull/1020)
 - Fixed an issue with the output of ls in releases_list that was breaking cleanup. 
 - Fixed possibility to use PEM files with Native SSH
+- Fixed old releases not being cleaned up when keep_releases reduced by more than half.
 
 ### Changed
 - Add task queue:restart for Laravel recipe [#1007](https://github.com/deployphp/deployer/pull/1007)

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -59,7 +59,8 @@ set('releases_list', function () {
             // will output a really big list of previous releases.
             // It spoils appearance of output log, to make it pretty,
             // we limit it to `n*2 + 5` lines from end of file (15 lines).
-            $csv = run("tail -n " . min(count($releases), ($keepReleases * 2 + 5)) . " .dep/releases");
+			// Always read as many lines as there are release directories.
+            $csv = run("tail -n " . max(count($releases), ($keepReleases * 2 + 5)) . " .dep/releases");
         }
 
         $metainfo = Csv::parse($csv);

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -59,7 +59,7 @@ set('releases_list', function () {
             // will output a really big list of previous releases.
             // It spoils appearance of output log, to make it pretty,
             // we limit it to `n*2 + 5` lines from end of file (15 lines).
-            $csv = run("tail -n " . ($keepReleases * 2 + 5) . " .dep/releases");
+            $csv = run("tail -n " . min(count($releases), ($keepReleases * 2 + 5)) . " .dep/releases");
         }
 
         $metainfo = Csv::parse($csv);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | Side effect noticed after fixing #1004 #1036

If as a user reduced their keep_releases by more than half of the number of releases they have on their server, the oldest would be ignored and not cleaned up. 

For example, if you have 100 releases on your server and reduce keep_releases to 20, only the most recent 45 releases would be read from the CSV. This would cause the oldest 55 releases to be ignored and not cleaned up.

The simple fix was to make sure it always reads as many lines from the CSV as there are release directories.