### PR TITLE
Removed dependency for man package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
 - Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
+- Add use_atomic_symlink variable instead of depending on the man package [#1043](https://github.com/deployphp/deployer/pull/1043)
 
 ### Changed
 - Autoload functions via Composer [#1015](https://github.com/deployphp/deployer/pull/1015)

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -105,7 +105,7 @@ set('bin/composer', function () {
 set('bin/symlink', function () {
     if (get('use_relative_symlink')) {
         // Check if target system supports relative symlink.
-        if (run('if [[ "$(man ln)" =~ "--relative" ]]; then echo "true"; fi')->toBool()) {
+        if (run('if [[ "$(ln --help)" =~ "--relative" ]]; then echo "true"; fi')->toBool()) {
             return 'ln -nfs --relative';
         }
     }

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -51,6 +51,7 @@ set('clear_paths', []);         // Relative path from deploy_path
 set('clear_use_sudo', false);    // Using sudo in clean commands?
 
 set('use_relative_symlink', true);
+set('use_atomic_symlink', true);
 
 set('composer_action', 'install');
 set('composer_options', '{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
@@ -104,10 +105,7 @@ set('bin/composer', function () {
 
 set('bin/symlink', function () {
     if (get('use_relative_symlink')) {
-        // Check if target system supports relative symlink.
-        if (run('if [[ "$(ln --help)" =~ "--relative" ]]; then echo "true"; fi')->toBool()) {
-            return 'ln -nfs --relative';
-        }
+        return 'ln -nfs --relative';
     }
     return 'ln -nfs';
 });

--- a/recipe/deploy/symlink.php
+++ b/recipe/deploy/symlink.php
@@ -9,7 +9,7 @@ namespace Deployer;
 
 desc('Creating symlink to release');
 task('deploy:symlink', function () {
-    if (run('if [[ "$(mv --help)" =~ "--no-target-directory" ]]; then echo "true"; fi')->toBool()) {
+    if (get('use_atomic_symlink')) {
         run("mv -T {{deploy_path}}/release {{deploy_path}}/current");
     } else {
         // Atomic symlink does not supported.

--- a/recipe/deploy/symlink.php
+++ b/recipe/deploy/symlink.php
@@ -9,7 +9,7 @@ namespace Deployer;
 
 desc('Creating symlink to release');
 task('deploy:symlink', function () {
-    if (run('if [[ "$(man mv)" =~ "--no-target-directory" ]]; then echo "true"; fi')->toBool()) {
+    if (run('if [[ "$(mv --help)" =~ "--no-target-directory" ]]; then echo "true"; fi')->toBool()) {
         run("mv -T {{deploy_path}}/release {{deploy_path}}/current");
     } else {
         // Atomic symlink does not supported.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

The man package isn't present on our servers (space savings & speed-ups during apt-get actions). The same info could be retrieved with the `--help` attribute.

Without this fix Deployer won't use atomic deployments causing a small time frame in which our website returns 404 errors.
