### PR TITLE
Create `writable_dirs` if they don’t exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed an issue with the output of ls in releases_list [#1004](https://github.com/deployphp/deployer/issues/1004) [#1036](https://github.com/deployphp/deployer/pull/1036/)
 - Fixed possibility to use PEM files with Native SSH
 - Fixed old releases not being cleaned up when keep_releases reduced by more than half.
+- Fixed creating non-existed `writable_dirs` [#1000](https://github.com/deployphp/deployer/pull/1000)
 
 ### Changed
 - Add task queue:restart for Laravel recipe [#1007](https://github.com/deployphp/deployer/pull/1007)

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -33,6 +33,9 @@ task('deploy:writable', function () {
     try {
         cd('{{release_path}}');
 
+        // Create directories if they don't exist
+        run("mkdir -p $dirs");
+
         if ($mode === 'chown') {
             // Change owner.
             // -R   operate on files and directories recursively

--- a/test/recipe/CommonTest.php
+++ b/test/recipe/CommonTest.php
@@ -93,13 +93,14 @@ class CommonTest extends RecipeTester
     {
         \Deployer\set('writable_mode', 'chmod');
         \Deployer\set('writable_chmod_mod', '0777');
-        \Deployer\set('writable_dirs', ['app/cache', 'app/logs']);
+        \Deployer\set('writable_dirs', ['app/cache', 'app/logs', 'app/path/to/non-existed/folder']);
         \Deployer\set('writable_use_sudo', false);
 
         $this->exec('deploy:writable');
 
         $this->assertTrue(is_writable($this->getEnv('release_path') . '/app/cache'));
         $this->assertTrue(is_writable($this->getEnv('release_path') . '/app/logs'));
+        $this->assertTrue(is_writable($this->getEnv('release_path') . '/app/path/to/non-existed/folder'));
     }
 
     public function testVendor()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | [PR#1000](https://github.com/deployphp/deployer/pull/1000)

I am not sure is it bug or not. Anton, it's up to you.
