### PR TITLE
Add `--no-hooks` option for running commands without `before()` and `after()` (#934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
 - Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
+- Add `--no-hooks` option for running commands without `before()` and `after()` [#934](https://github.com/deployphp/deployer/pull/934)
 
 ### Changed
 - Autoload functions via Composer [#1015](https://github.com/deployphp/deployer/pull/1015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
 - Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
-- Add `--no-hooks` option for running commands without `before()` and `after()` [#934](https://github.com/deployphp/deployer/pull/934)
+- Add `--no-hooks` option for running commands without `before()` and `after()` [#1061](https://github.com/deployphp/deployer/pull/1061)
 
 ### Changed
 - Autoload functions via Composer [#1015](https://github.com/deployphp/deployer/pull/1015)

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -119,7 +119,6 @@ argument('stage', InputArgument::OPTIONAL, 'Run tasks only on this server or gro
 option('tag', null, InputOption::VALUE_OPTIONAL, 'Tag to deploy');
 option('revision', null, InputOption::VALUE_OPTIONAL, 'Revision to deploy');
 option('branch', null, InputOption::VALUE_OPTIONAL, 'Branch to deploy');
-option('no-hooks', null, InputOption::VALUE_NONE, 'Run task without after/before hooks');
 
 /**
  * Tasks

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -119,6 +119,7 @@ argument('stage', InputArgument::OPTIONAL, 'Run tasks only on this server or gro
 option('tag', null, InputOption::VALUE_OPTIONAL, 'Tag to deploy');
 option('revision', null, InputOption::VALUE_OPTIONAL, 'Revision to deploy');
 option('branch', null, InputOption::VALUE_OPTIONAL, 'Branch to deploy');
+option('no-hooks', null, InputOption::VALUE_NONE, 'Run task without after/before hooks');
 
 /**
  * Tasks

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -52,6 +52,12 @@ class TaskCommand extends Command
             'p',
             Option::VALUE_NONE,
             'Run tasks in parallel.'
+        )
+        ->addOption(
+            'no-hooks',
+            null,
+            Option::VALUE_NONE,
+            'Run task without after/before hooks'
         );
     }
 

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -62,6 +62,8 @@ class TaskCommand extends Command
     {
         $stage = $input->hasArgument('stage') ? $input->getArgument('stage') : null;
 
+        $this->deployer->getScriptManager()->setHooksEnabled(!$input->getOption('no-hooks'));
+
         $tasks = $this->deployer->getScriptManager()->getTasks($this->getName(), $stage);
         $servers = $this->deployer->getStageStrategy()->getServers($stage);
         $environments = iterator_to_array($this->deployer->environments);

--- a/src/Task/GroupTask.php
+++ b/src/Task/GroupTask.php
@@ -50,12 +50,24 @@ class GroupTask extends Task
     }
 
     /**
-     * List of tasks names.
+     * List of tasks names with before and after hooks.
+     *
+     * @deprecated v5.0
      *
      * @return array
      */
     public function getTasks()
     {
         return array_merge($this->getBefore(), $this->group, $this->getAfter());
+    }
+
+    /**
+     * List of dependent tasks names.
+     *
+     * @return array
+     */
+    public function getGroup()
+    {
+        return $this->group;
     }
 }

--- a/src/Task/ScriptManager.php
+++ b/src/Task/ScriptManager.php
@@ -62,11 +62,11 @@ class ScriptManager
             return $relatedTasks;
         };
 
-        $taskHierarchy = $collect($name);
+        $script = $collect($name);
 
         // Flatten
         $tasks = [];
-        array_walk_recursive($taskHierarchy, function ($a) use (&$tasks) {
+        array_walk_recursive($script, function ($a) use (&$tasks) {
             $tasks[] = $a;
         });
 

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -228,7 +228,7 @@ class Task
     public function addBefore($task)
     {
         if (!is_string($task)) {
-            throw new \RuntimeException('Invalid argument to `before` hook of "' . $this->getName() . '" task.');
+            throw new \InvalidArgumentException('Invalid argument to `before` hook of "' . $this->getName() . '" task.');
         }
 
         array_unshift($this->before, $task);
@@ -240,7 +240,7 @@ class Task
     public function addAfter($task)
     {
         if (!is_string($task)) {
-            throw new \RuntimeException('Invalid argument to `after` hook of "' . $this->getName() . '" task.');
+            throw new \InvalidArgumentException('Invalid argument to `after` hook of "' . $this->getName() . '" task.');
         }
 
         array_push($this->after, $task);

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -227,6 +227,10 @@ class Task
      */
     public function addBefore($task)
     {
+        if (!is_string($task)) {
+            throw new \RuntimeException('Invalid argument to `before` hook of "' . $this->getName() . '" task.');
+        }
+
         array_unshift($this->before, $task);
     }
 
@@ -235,6 +239,10 @@ class Task
      */
     public function addAfter($task)
     {
+        if (!is_string($task)) {
+            throw new \RuntimeException('Invalid argument to `after` hook of "' . $this->getName() . '" task.');
+        }
+
         array_push($this->after, $task);
     }
 

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -164,6 +164,32 @@ class FunctionsTest extends TestCase
         $this->assertEquals(['main', 'after'], $names);
     }
 
+    public function testTaskWithoutHooks()
+    {
+        task('main', function () {});
+        task('groupTask', ['main']);
+        task('before', function () {});
+        task('after', function () {});
+
+        before('main', 'before');
+        after('main', 'after');
+
+        before('groupTask', 'before');
+        after('groupTask', 'after');
+
+        $names = $this->taskToNames($this->deployer->getScriptManager()->getTasks('main'));
+        $this->assertEquals(['before', 'main', 'after'], $names);
+        $names = $this->taskToNames($this->deployer->getScriptManager()->getTasks('groupTask'));
+        $this->assertEquals(['before', 'before', 'main', 'after', 'after'], $names);
+
+        $this->deployer->getScriptManager()->setHooksEnabled(false);
+
+        $names = $this->taskToNames($this->deployer->getScriptManager()->getTasks('main'));
+        $this->assertEquals(['main'], $names);
+        $names = $this->taskToNames($this->deployer->getScriptManager()->getTasks('groupTask'));
+        $this->assertEquals(['main'], $names);
+    }
+
     private function taskToNames($tasks)
     {
         return array_map(function ($task) {

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -166,10 +166,13 @@ class FunctionsTest extends TestCase
 
     public function testTaskWithoutHooks()
     {
-        task('main', function () {});
+        $emptyCallback = function () {
+        };
+
+        task('main', $emptyCallback);
         task('groupTask', ['main']);
-        task('before', function () {});
-        task('after', function () {});
+        task('before', $emptyCallback);
+        task('after', $emptyCallback);
 
         before('main', 'before');
         after('main', 'after');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | Yes
| Fixed tickets | N/A

Updated version of https://github.com/deployphp/deployer/pull/934.
