### PR TITLE
Fix merge of string array config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fixed old releases not being cleaned up when keep_releases reduced by more than half.
 - Fixed creating non-existed `writable_dirs` [#1000](https://github.com/deployphp/deployer/pull/1000)
 - Fixed uploading files with spaces in a path via Native SSH [#1010](https://github.com/deployphp/deployer/issues/1010)
-
+- Fix merge of string array config options [#1067](https://github.com/deployphp/deployer/pull/1067)
 
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)

--- a/src/Type/Config.php
+++ b/src/Type/Config.php
@@ -26,8 +26,13 @@ class Config
         foreach ($override as $key => $value) {
             if (isset($original[$key])) {
                 if (!is_array($original[$key])) {
-                    // Override scalar value
-                    $original[$key] = $value;
+                    if (is_numeric($key)) {
+                        // Append scalar value
+                        $original[] = $value;
+                    } else {
+                        // Override scalar value
+                        $original[$key] = $value;
+                    }
                 } elseif (array_keys($original[$key]) === range(0, count($original[$key]) - 1)) {
                     // Uniquely append to array with numeric keys
                     $original[$key] = array_unique(array_merge($original[$key], $value));

--- a/test/src/DeployerTest.php
+++ b/test/src/DeployerTest.php
@@ -91,6 +91,9 @@ class DeployerTest extends TestCase
                 'second',
             ],
         ]);
+        Deployer::addDefault('config', [
+            'extra',
+        ]);
 
         $expected = [
             'one',
@@ -99,6 +102,7 @@ class DeployerTest extends TestCase
                 'first',
                 'second',
             ],
+            'extra',
         ];
 
         $this->assertEquals($expected, Deployer::getDefault('config'));

--- a/test/src/Server/EnvironmentTest.php
+++ b/test/src/Server/EnvironmentTest.php
@@ -132,6 +132,9 @@ class EnvironmentTest extends TestCase
                 'second',
             ],
         ]);
+        $env->add('config', [
+            'extra',
+        ]);
 
         $expected = [
             'one',
@@ -140,6 +143,7 @@ class EnvironmentTest extends TestCase
                 'first',
                 'second',
             ],
+            'extra',
         ];
 
         $this->assertEquals($expected, $env->get('config'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This unbreaks e.g. the following:

```php
add('shared_files', ['foo']);
add('shared_files', ['bar']);
```

Without this fix, this would become `['bar']` instead of `['foo', 'bar']`.
