### PR TITLE
Copy nested directories

### DIFF
--- a/recipe/deploy/copy_dirs.php
+++ b/recipe/deploy/copy_dirs.php
@@ -16,11 +16,12 @@ task('deploy:copy_dirs', function () {
         foreach ($dirs as $dir) {
             $path = "{{deploy_path}}/releases/{$releases[0]}/$dir";
 
-            // Create destination dir(needed for nested dirs)
-            run("mkdir -p {{release_path}}/$dir");
-
             // Copy if dir exists.
             if (test("[ -d $path ]")) {
+
+                // Create destination dir(needed for nested dirs)
+                run("mkdir -p {{release_path}}/$dir");
+
                 run("rsync -av $path/ {{release_path}}/$dir");
             }
         }

--- a/recipe/deploy/copy_dirs.php
+++ b/recipe/deploy/copy_dirs.php
@@ -16,9 +16,12 @@ task('deploy:copy_dirs', function () {
         foreach ($dirs as $dir) {
             $path = "{{deploy_path}}/releases/{$releases[0]}/$dir";
 
+            // Create destination dir(needed for nested dirs)
+            run("mkdir -p {{release_path}}/$dir");
+
             // Copy if dir exists.
             if (test("[ -d $path ]")) {
-                run("cp -rpf $path {{release_path}}");
+                run("rsync -av $path/ {{release_path}}/$dir");
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Possibility to copy nested directories  ex:
set('copy_dirs', ['vendor', 'wp-content/plugins', 'wordpress']);

now it's not possible to copy for example: wp-content/plugins to the same location.