### PR TITLE
fixed uploading of files containing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed creating non-existed `writable_dirs` [#1000](https://github.com/deployphp/deployer/pull/1000)
 - Fixed uploading files with spaces in a path via Native SSH [#1010](https://github.com/deployphp/deployer/issues/1010)
 - Fix merge of string array config options [#1067](https://github.com/deployphp/deployer/pull/1067)
+- Fixed uploading of files containing spaces [#1077](https://github.com/deployphp/deployer/issues/1077)
 
 ## v4.2.1
 [v4.2.0...v4.2.1](https://github.com/deployphp/deployer/compare/v4.2.0...v4.2.1)

--- a/src/Server/Remote/NativeSsh.php
+++ b/src/Server/Remote/NativeSsh.php
@@ -105,7 +105,6 @@ class NativeSsh implements ServerInterface
      */
     public function upload($local, $remote)
     {
-        $local = str_replace(' ', '\ ', $local);
         $remote = str_replace(' ', '\ ', $remote);
 
         $serverConfig = $this->getConfiguration();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Issue Type        | Bug
| Deployer Version  | 4.2.1
| Local Machine OS  | ubuntu16.04 lts
| Remote Machine OS | ubuntu16.04 lts

```
php -v
PHP 7.0.16-4+deb.sury.org~xenial+1 (cli) (built: Mar  2 2017 10:36:04) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.0.16-4+deb.sury.org~xenial+1, Copyright (c) 1999-2017, by Zend Technologies
    with blackfire v1.15.0~linux-x64-non_zts70, https://blackfire.io, by Blackfireio Inc.
```

### Description 
the copy using scp fails, as arguments are not properly escaped.

### Steps to reproduce
copy a directory which contains file, containing a space in the filename with the following task

```
task('deploy:update_code', function () {
    upload('.', '{{release_path}}');
});
```


### Output log

```
 [Symfony\Component\Process\Exception\ProcessFailedException]
  The command "scp -P '22' -i '/home/mstaab/.ssh/id_rsa' -o ControlMaster=auto -o ControlPersist=5 -o ControlPath='~/.ssh/YYY@XX:22' '/my/local/path/vendor/filp/whoops/docs/Framework Integration.md' 'mstaab@XYX:/my/remote/path/test123/releases/1/vendor/filp/whoops/docs/Framework Integration.md'" failed.
  Exit Code: 1(General error)
  Working directory: /my/local/path/
  Output:
  ================
  Error Output:
  ================
  scp: ambiguous target
```

Fixes #1077