### PR TITLE
Provide a usefull error when ask*() is not used wihtin a task()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
 - Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
 - Add `--no-hooks` option for running commands without `before()` and `after()` [#1061](https://github.com/deployphp/deployer/pull/1061)
+- Added a usefull error when ask*() is not used wihtin a task() [#1083](https://github.com/deployphp/deployer/pull/1083)
 
 ### Changed
 - Parse hyphens in environment setting names [#1073](https://github.com/deployphp/deployer/pull/1074)

--- a/src/Task/Context.php
+++ b/src/Task/Context.php
@@ -9,6 +9,7 @@ namespace Deployer\Task;
 
 use Deployer\Server\Environment;
 use Deployer\Server\ServerInterface;
+use Deployer\Exception\Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -67,6 +68,23 @@ class Context
     public static function get()
     {
         return end(self::$contexts);
+    }
+
+    /**
+     * Returns the current context when available.
+     *
+     * Throws a Exception when not called within a task-context and therefore no Context is available.
+     *
+     * This method provides a usefull error to the end-user to make him/her aware
+     * to use a function in the required task-context.
+     *
+     * @throws Exception
+     */
+    public static function required($callerName)
+    {
+        if (!self::get()) {
+            throw new Exception("'$callerName' can only be used within a 'task()'-function!");
+        }
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -16,6 +16,8 @@ use Deployer\Task\Task as T;
 use Deployer\Task\Context;
 use Deployer\Task\GroupTask;
 use Deployer\Type\Result;
+use Deployer\Cluster\ClusterFactory;
+use Deployer\Exception\Exception;
 use Monolog\Logger;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -23,7 +25,6 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
-use Deployer\Cluster\ClusterFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -560,6 +561,8 @@ function has($name)
  */
 function ask($message, $default = null, $suggestedChoices = null)
 {
+    requiresTaskContext(__FUNCTION__);
+
     if (($suggestedChoices !== null) && (empty($suggestedChoices))) {
         throw new \InvalidArgumentException('Suggested choices should not be empty');
     }
@@ -591,6 +594,8 @@ function ask($message, $default = null, $suggestedChoices = null)
  */
 function askChoice($message, array $availableChoices, $default = null, $multiselect = false)
 {
+    requiresTaskContext(__FUNCTION__);
+
     if (empty($availableChoices)) {
         throw new \InvalidArgumentException('Available choices should not be empty');
     }
@@ -624,6 +629,8 @@ function askChoice($message, array $availableChoices, $default = null, $multisel
  */
 function askConfirmation($message, $default = false)
 {
+    requiresTaskContext(__FUNCTION__);
+
     if (isQuiet()) {
         return $default;
     }
@@ -645,6 +652,8 @@ function askConfirmation($message, $default = false)
  */
 function askHiddenResponse($message)
 {
+    requiresTaskContext(__FUNCTION__);
+
     if (isQuiet()) {
         return '';
     }
@@ -741,4 +750,17 @@ function commandExist($command)
 function parse($value)
 {
     return Context::get()->getEnvironment()->parse($value);
+}
+
+/**
+ * Throws a Exception when not called within a task-context.
+ *
+ * This method provides a usefull error to the end-user to make him/her aware
+ * to use a function in the required task-context.
+ */
+function requiresTaskContext($callerName)
+{
+    if (!Context::get()) {
+        throw new Exception("'$callerName' can only be used within a 'task()'-function!");
+    }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,7 +17,6 @@ use Deployer\Task\Context;
 use Deployer\Task\GroupTask;
 use Deployer\Type\Result;
 use Deployer\Cluster\ClusterFactory;
-use Deployer\Exception\Exception;
 use Monolog\Logger;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -561,7 +560,7 @@ function has($name)
  */
 function ask($message, $default = null, $suggestedChoices = null)
 {
-    requiresTaskContext(__FUNCTION__);
+    Context::required(__FUNCTION__);
 
     if (($suggestedChoices !== null) && (empty($suggestedChoices))) {
         throw new \InvalidArgumentException('Suggested choices should not be empty');
@@ -594,7 +593,7 @@ function ask($message, $default = null, $suggestedChoices = null)
  */
 function askChoice($message, array $availableChoices, $default = null, $multiselect = false)
 {
-    requiresTaskContext(__FUNCTION__);
+    Context::required(__FUNCTION__);
 
     if (empty($availableChoices)) {
         throw new \InvalidArgumentException('Available choices should not be empty');
@@ -629,7 +628,7 @@ function askChoice($message, array $availableChoices, $default = null, $multisel
  */
 function askConfirmation($message, $default = false)
 {
-    requiresTaskContext(__FUNCTION__);
+    Context::required(__FUNCTION__);
 
     if (isQuiet()) {
         return $default;
@@ -652,7 +651,7 @@ function askConfirmation($message, $default = false)
  */
 function askHiddenResponse($message)
 {
-    requiresTaskContext(__FUNCTION__);
+    Context::required(__FUNCTION__);
 
     if (isQuiet()) {
         return '';
@@ -750,17 +749,4 @@ function commandExist($command)
 function parse($value)
 {
     return Context::get()->getEnvironment()->parse($value);
-}
-
-/**
- * Throws a Exception when not called within a task-context.
- *
- * This method provides a usefull error to the end-user to make him/her aware
- * to use a function in the required task-context.
- */
-function requiresTaskContext($callerName)
-{
-    if (!Context::get()) {
-        throw new Exception("'$callerName' can only be used within a 'task()'-function!");
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A


before this change a newcomer to this project sees errors like 
```
PHP Fatal error:  Uncaught Error: Call to a member function getOutput() on boolean in /cluster/www/www/www/tools/deployer/src/functions.php:677
Stack trace:
#0 /cluster/www/www/www/tools/deployer/src/functions.php(685): Deployer\output()
#1 /cluster/www/www/www/tools/deployer/src/functions.php(567): Deployer\isQuiet()
#2 /deploy/kunzmann/stage/rocket/deploy.php(51): Deployer\ask('Zielstage (prod...')
#3 /cluster/www/www/www/tools/deployer/bin/dep(106): require('/deploy/kunzman...')
#4 /cluster/www/www/www/tools/deployer/bin/dep(107): {closure}()
#5 {main}
  thrown in /cluster/www/www/www/tools/deployer/src/functions.php on line 677
```

when using a `ask()` function within global scope instead of a `task()`.

After this change the error turns into

```
PHP Fatal error:  Uncaught Deployer\Exception\Exception: 'Deployer\ask' can only be used within a 'task()'-function! in /cluster/www/www/www/tools/deployer/src/functions.php:757
Stack trace:
#0 /cluster/www/www/www/tools/deployer/src/functions.php(567): Deployer\requiresTaskContext('Deployer\\ask')
#1 /deploy/kunzmann/stage/rocket/deploy.php(51): Deployer\ask('Zielstage (prod...')
#2 /cluster/www/www/www/tools/deployer/bin/dep(106): require('/deploy/kunzman...')
#3 /cluster/www/www/www/tools/deployer/bin/dep(107): {closure}()
#4 {main}
  thrown in /cluster/www/www/www/tools/deployer/src/functions.php on line 757
```



based on a "discussion" in https://github.com/deployphp/deployer/issues/371#issuecomment-285592637
