### PR TITLE
Pretty-print uncaught exceptions with SymfonyStyle

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -99,6 +99,15 @@ $input = new \Symfony\Component\Console\Input\ArgvInput();
 $output = new \Symfony\Component\Console\Output\ConsoleOutput();
 $deployer = new \Deployer\Deployer($console, $input, $output);
 
+// Pretty-print uncaught exceptions in symfony-console
+// SymfonyStyle was added in sf-console 2.7, therefore we feature detect first
+if (class_exists('\Symfony\Component\Console\Style\SymfonyStyle')) {
+    set_exception_handler(function($e) use ($input, $output) {
+        $io = new \Symfony\Component\Console\Style\SymfonyStyle($input, $output);
+        $io->error($e);
+    });
+}
+
 // Require deploy.php file
 if (is_readable($deployFile)) {
     // Prevent variable leak into deploy.php file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Pretty print uncaught exceptions using SymfonyStyle. Those exceptions occur e.g. when the enduser does not respect phpdocs and uses wrong argument types etc.

repro:
```
// inside your deploy.php
before('does_not_exist_task', 'do_something');
```

before
![image](https://cloud.githubusercontent.com/assets/120441/23793100/03cb7a5c-058a-11e7-89eb-c7c878064363.png)

after
![image](https://cloud.githubusercontent.com/assets/120441/23793035/c640ff2c-0589-11e7-940e-dd9b83e6ac7f.png)
