### PR TITLE
Show a progressbar while ssh upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a way to retrieve a defined task [#1008](https://github.com/deployphp/deployer/pull/1008)
 - Add support for configFile in the NativeSsh implementation [#979](https://github.com/deployphp/deployer/pull/979)
 - Add `--no-hooks` option for running commands without `before()` and `after()` [#1061](https://github.com/deployphp/deployer/pull/1061)
+- Add a progressbar while ssh upload [1085](https://github.com/deployphp/deployer/pull/1085)
 
 ### Changed
 - Parse hyphens in environment setting names [#1073](https://github.com/deployphp/deployer/pull/1074)

--- a/src/functions.php
+++ b/src/functions.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 // There are two types of functions: Deployer dependent and Context dependent.
 // Deployer dependent function uses in definition stage of recipe and may require Deployer::get() method.
@@ -427,6 +428,11 @@ function upload($local, $remote)
             ->ignoreDotFiles(false)
             ->in($local);
 
+        $progress = null;
+        if (!isDebug()) {
+            $progress = new ProgressBar(output(), count($files));
+        }
+
         /** @var $file \Symfony\Component\Finder\SplFileInfo */
         foreach ($files as $file) {
             if (isDebug()) {
@@ -437,6 +443,16 @@ function upload($local, $remote)
                 $file->getRealPath(),
                 $remote . '/' . $file->getRelativePathname()
             );
+
+            if ($progress) {
+                $progress->advance();
+            }
+        }
+
+        if ($progress) {
+            $progress->finish();
+            // make sure the "Ok" text will be rendered on a newline
+            output()->writeln('');
         }
     } else {
         throw new \RuntimeException("Uploading path '$local' does not exist.");

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -11,6 +11,7 @@ use Deployer\Console\Application;
 use Deployer\Server\Environment;
 use Deployer\Task\Context;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 
 class FunctionsTest extends TestCase
 {
@@ -50,6 +51,7 @@ class FunctionsTest extends TestCase
 
         $this->_input = $this->createMock('Symfony\Component\Console\Input\InputInterface');
         $this->_output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $this->_output->method('getFormatter')->willReturn(new OutputFormatter());
         $this->_server = $this->getMockBuilder('Deployer\Server\ServerInterface')->disableOriginalConstructor()->getMock();
 
         $this->_env = new Environment();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Adds a progressbar to the scp-copy steps.

before:
the deploy progress was not visible and the running command took minutes before actual progress is visible

after::
![image](https://cloud.githubusercontent.com/assets/120441/23797539/a6af2d2a-05a0-11e7-9162-4cca308d5f92.png)

see also http://symfony.com/doc/current/components/console/helpers/progressbar.html