### PR TITLE
Only enable/disable maintenance when current exists

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -41,12 +41,12 @@ task('magento:deploy:assets', function () {
 
 desc('Enable maintenance mode');
 task('magento:maintenance:enable', function () {
-    run("{{bin/php}} {{deploy_path}}/current/bin/magento maintenance:enable");
+    run("if [ -d $(echo {{deploy_path}}/current) ]; then {{bin/php}} {{deploy_path}}/current/bin/magento maintenance:enable; fi");
 });
 
 desc('Disable maintenance mode');
 task('magento:maintenance:disable', function () {
-    run("{{bin/php}} {{deploy_path}}/current/bin/magento maintenance:disable");
+    run("if [ -d $(echo {{deploy_path}}/current) ]; then {{bin/php}} {{deploy_path}}/current/bin/magento maintenance:disable; fi");
 });
 
 desc('Upgrade magento database');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

This fixes the first deployment for Magento2, where the `current` symlink does not yet exist.

Alternative approach would be to split the `deploy:magento`, en run the database upgrade *after* symlink changing, which would allow to enable/disable maintenance mode in the current directory; or share the maintenance flag between releases.

(Please double check, but I think the syntax is correct here)
