### PR TITLE
Add a "find" mode

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -82,6 +82,8 @@ task('deploy:writable', function () {
             } else {
                 throw new \RuntimeException("Cant't set writable dirs with ACL.");
             }
+        } elseif ($mode === 'find') {
+            run("$sudo find $dirs -type d -exec chmod {{writable_chmod_mode}} {} \;");
         } else {
             throw new \RuntimeException("Unknown writable_mode `$mode`.");
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | xx

Add a "find" mode, that prevent errors when writables folders are not empty, with files no-writables
