### PR TITLE
Removed dependecy on the man binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Only native ssh client for now [#1092](https://github.com/deployphp/deployer/pull/1092)
 - Task `current` to `config:current` [#1092](https://github.com/deployphp/deployer/pull/1092)
 - `onFailure` to `fail` [#1092](https://github.com/deployphp/deployer/pull/1092)
+- Removed the dependency on the man binary
 
 
 ## v4.3.0

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -63,10 +63,10 @@ set('clear_use_sudo', false);    // Using sudo in clean commands?
 set('cleanup_use_sudo', false); // Using sudo in cleanup commands?
 
 set('use_relative_symlink', function () {
-    return test('[[ "$(man ln)" =~ "--relative" ]]');
+    return test('[[ "$(ln --help)" =~ "--relative" ]]');
 });
 set('use_atomic_symlink', function () {
-    return test('[[ "$(man mv)" =~ "--no-target-directory" ]]');
+    return test('[[ "$(mv --help)" =~ "--no-target-directory" ]]');
 });
 
 set('composer_action', 'install');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? |No
| Fixed tickets | N/A 

Barebone production environments often don't have the man binary or the
don't have man pages installed.

