### PR TITLE
fix laravel artisan:queue:restart task

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -100,7 +100,11 @@ task('artisan:optimize', function () {
 
 desc('Execute artisan queue:restart');
 task('artisan:queue:restart', function () {
-    run('{{bin/php}} {{release_path}}/artisan queue:restart');
+    $releases = get('releases_list');
+    if (isset($releases[1])) {
+        $previousReleasePath = "{{deploy_path}}/releases/{$releases[1]}";
+        run("{{bin/php}} $previousReleasePath/artisan queue:restart");
+    }
 });
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Launching ```artisan:queue:restart``` command in current release's folder has no effect - old workers still running in old release's context and checking for ```'illuminate:queue:restart'``` cache key to know when to stop. By default framework's cache stored at files, so we must set cache key ``` 'illuminate:queue:restart'```in old release's folder.
When cache driver is different than default ```'file'```, queue will restarts too.
