### PR TITLE
SSH Command expects optional parameter and use default instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Only native ssh client for now [#1092](https://github.com/deployphp/deployer/pull/1092)
 - Task `current` to `config:current` [#1092](https://github.com/deployphp/deployer/pull/1092)
 - `onFailure` to `fail` [#1092](https://github.com/deployphp/deployer/pull/1092)
+- `ssh` no longer need parameter when using default host [#1144](https://github.com/deployphp/deployer/pull/1144)
 
 
 ## v4.3.0

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -39,7 +39,7 @@ class SshCommand extends Command
     {
         $this->addArgument(
             'hostname',
-            InputArgument::REQUIRED,
+            InputArgument::OPTIONAL,
             'Hostname'
         );
     }
@@ -49,7 +49,10 @@ class SshCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $host = $this->deployer->hosts->get($input->getArgument('hostname'));
+        $firstHostname = $this->deployer->hosts->getIterator()->current()->getHostname();
+        $hostname = $input->getArgument('hostname') ?? $firstHostname;
+
+        $host = $this->deployer->hosts->get($hostname);
         Context::push(new Context($host, $input, $output));
 
         $options = $host->sshOptions();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Make SshCommand host parameter optional when only using the default (first) host.

> dep ssh