### PR TITLE
Add storage:link option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Added console init template for Yii2 basic and advanced receipe [#1146](https://github.com/deployphp/deployer/pull/1146)
+- Added `artisan:storage:link` task to the Laravel recipe to symlink the public storage directory [#1152](https://github.com/deployphp/deployer/pull/1152)
 
 ### Changed
 - Error message on locked release [#1145](https://github.com/deployphp/deployer/pull/1145)

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -140,6 +140,7 @@ task('deploy', [
     'deploy:shared',
     'deploy:vendors',
     'deploy:writable',
+    'artisan:storage:link',
     'artisan:view:clear',
     'artisan:cache:clear',
     'artisan:config:cache',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -103,6 +103,11 @@ task('artisan:queue:restart', function () {
     run('{{bin/php}} {{release_path}}/artisan queue:restart');
 });
 
+desc('Execute artisan storage:link');
+task('artisan:storage:link', function () {
+    run('{{bin/php}} {{release_path}}/artisan storage:link');
+});
+
 /**
  * Task deploy:public_disk support the public disk.
  * To run this task automatically, please add below line to your deploy.php file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1086

This add `artisan:storage:link`. We could add it by default, by adding it after `deploy:writable`. It only creates the link when no dir exists.
