### PR TITLE
Cleanup keeps the right amount of releases

### DIFF
--- a/recipe/deploy/cleanup.php
+++ b/recipe/deploy/cleanup.php
@@ -18,12 +18,10 @@ task('cleanup', function () {
         return;
     }
 
-    while ($keep - 1 > 0) {
-        array_shift($releases);
-        --$keep;
-    }
+    $keeps   = array_slice($releases, 0, $keep);
+    $removes = array_diff($releases, $keeps);
 
-    foreach ($releases as $release) {
+    foreach ($removes as $release) {
         run("$sudo rm -rf {{deploy_path}}/releases/$release");
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  |  No
| BC breaks?    |  No
| Deprecations? |  No
| Fixed tickets | #1175 

Pulls out the releases to keep and then gets a diff to show the ones that need to be removed. 
