### PR TITLE
Add task onCondition support:

### DIFF
--- a/src/Task/GroupTask.php
+++ b/src/Task/GroupTask.php
@@ -8,6 +8,7 @@
 namespace Deployer\Task;
 
 use Deployer\Exception\Exception;
+use function Deployer\task;
 
 class GroupTask extends Task
 {
@@ -44,6 +45,16 @@ class GroupTask extends Task
     public function getGroup()
     {
         return $this->group;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onCondition(...$conditions)
+    {
+        foreach ($this->getGroup() as $task) {
+            call_user_func_array([task($task), 'onCondition'], $conditions);
+        }
     }
 
     public function local()

--- a/test/src/Task/GroupTaskTest.php
+++ b/test/src/Task/GroupTaskTest.php
@@ -7,6 +7,8 @@
 
 namespace Deployer\Task;
 
+use Deployer\Console\Application;
+use Deployer\Deployer;
 use PHPUnit\Framework\TestCase;
 
 class GroupTaskTest extends TestCase
@@ -19,6 +21,31 @@ class GroupTaskTest extends TestCase
         $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
         $task = new GroupTask('group', []);
+        $task->run($context);
+    }
+
+    public function testOnCondition() {
+        $context = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+
+        $mock = self::getMockBuilder('stdClass')
+            ->setMethods(['callback'])
+            ->getMock();
+
+        //test boolean condition
+        $mock
+            ->expects(self::once())
+            ->method('callback');
+
+        $task = new Task('task', [$mock, 'callback']);
+        (new Deployer(new Application()))->tasks->set('task', $task);
+
+
+        $groupTask = new GroupTask('group', ['task']);
+        $groupTask->onCondition(false);
+        $task->run($context);
+
+        //and test once
+        $groupTask->onCondition(true);
         $task->run($context);
     }
 }

--- a/test/src/Task/TaskTest.php
+++ b/test/src/Task/TaskTest.php
@@ -125,6 +125,54 @@ class TaskTest extends TestCase
         $task3 = new Task('task3', new StubTask());
         $task3->run($context);
         self::assertEquals(1, StubTask::$runned);
+
+        // Test create task with condition [$object, 'method']
+        $context = new Context(new Host('a'));
+
+        $mock4 = self::getMockBuilder('stdClass')
+            ->setMethods(['callback1', 'callback2', 'callback3', 'callback4'])
+            ->getMock();
+
+        //test boolean condition
+        $mock4
+            ->expects(self::once())
+            ->method('callback1');
+
+        $task4 = new Task('task4', [$mock4, 'callback1']);
+        $task4
+            ->onCondition(true)
+            ->run($context);
+
+
+        //test string condition
+        $context->getConfig()->set('test', true);
+        $mock4
+            ->expects(self::once())
+            ->method('callback2');
+
+        $task4 = new Task('task4', [$mock4, 'callback2']);
+        $task4
+            ->onCondition('test')
+            ->run($context);
+
+        //test callback condition
+        $mock4
+            ->expects(self::once())
+            ->method('callback3');
+        $task4 = new Task('task4', [$mock4, 'callback3']);
+        $task4
+            ->onCondition(function () {
+                return true;
+            })
+            ->run($context);
+
+        $mock4
+            ->expects(self::never())
+            ->method('callback4');
+        $task4 = new Task('task4', [$mock4, 'callback4']);
+        $task4
+            ->onCondition(false)
+            ->run($context);
     }
 }
 


### PR DESCRIPTION
task()->onCondition(bool)
task()->onCondition(string) = get will be used
task()->onCondition(callback)

Callback and get should be runned in the current context (moved to run section)

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/deployer/blob/master/CHANGELOG.md)
