### PR TITLE
Check multiplexing until initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Throw the correct exception on git --reference fail
+- Check if multiplexing is working before continuing.
 
 ## v5.0.0
 [v5.0.0-beta.3...v5.0.0](https://github.com/deployphp/deployer/compare/v5.0.0-beta.3...v5.0.0)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | #1192

Check the multiplex initialization, until it is working. Prevents async issues when prompting for a passphrase.