### PR TITLE
Bump passphrase timeout to 30secs, check if process is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 - Throw the correct exception on git --reference fail
-- Check if multiplexing is working before continuing
+- Check if multiplexing is working before continuing [#1192]
 - Fixed upload with non-standard SSH port [#1218]
 
 ## v5.0.0

--- a/src/Exception/InitializationException.php
+++ b/src/Exception/InitializationException.php
@@ -1,0 +1,12 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Exception;
+
+class InitializationException extends GracefulShutdownException
+{
+}

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -129,12 +129,17 @@ class Client
 
             // Open master connection explicit,
             // ControlMaster=auto could not working
-            (new Process("ssh -M $sshArguments $host"))->start();
+            $process = new Process("ssh -M $sshArguments $host");
+            $process->start();
 
             $attempts = 0;
             while (!$this->isMultiplexingInitialized($host, $sshArguments)) {
-                if ($attempts++ > 5) {
+                if ($attempts++ > 30) {
                     throw new Exception('Wait time exceeded for ssh multiplexing initialization');
+                }
+
+                if (!$process->isRunning()) {
+                    throw new Exception('Failed to initialize ssh multiplexing');
                 }
 
                 // Delay to check again if the connection is established

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -7,7 +7,7 @@
 
 namespace Deployer\Ssh;
 
-use Deployer\Exception\Exception;
+use Deployer\Exception\InitializationException;
 use Deployer\Exception\RuntimeException;
 use Deployer\Host\Host;
 use Deployer\Utility\ProcessOutputPrinter;
@@ -135,11 +135,11 @@ class Client
             $attempts = 0;
             while (!$this->isMultiplexingInitialized($host, $sshArguments)) {
                 if ($attempts++ > 30) {
-                    throw new Exception('Wait time exceeded for ssh multiplexing initialization');
+                    throw new InitializationException('Wait time exceeded for ssh multiplexing initialization');
                 }
 
                 if (!$process->isRunning()) {
-                    throw new Exception('Failed to initialize ssh multiplexing');
+                    throw new InitializationException('Failed to initialize ssh multiplexing');
                 }
 
                 // Delay to check again if the connection is established


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1220

This bumps the wait time for a passphrase to 30 secs. It also checks if the process is running, otherwise throw an immediate exception (for example, after entering the wrong passphrase)