### PR TITLE
Check laravel version before symlink storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 - Fixed upload / download with optional rsync ssh options [#1227]
 - Disable maintenance mode when Magento2 deployment fails [#1251]
-- Fixed storage link error when deploying Laravel < 5.3 
+- Fixed storage link error when deploying Laravel < 5.3. 
 - Helps [#1153]
 
 ## v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 - Fixed upload / download with optional rsync ssh options [#1227]
 - Disable maintenance mode when Magento2 deployment fails [#1251]
-- Fixed storage link error when deploying Laravel < 5.3. 
+- Fixed storage link error when deploying Laravel < 5.3 
 - Helps [#1153]
 
 ## v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fixed storage link error when deploying Laravel < 5.3. 
 - Helps [#1153]
 - Disable maintenance mode when Magento2 deployment fails [#1251]
+- Fixed storage link error when deploying Laravel < 5.3. 
+- Helps [#1153]
 
 ## v5.0.1
 [v5.0.0...v5.0.1](https://github.com/deployphp/deployer/compare/v5.0.0...v5.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 
 ### Fixed
 - Fixed upload / download with optional rsync ssh options [#1227]
-- Fixed storage link error when deploying Laravel < 5.3. 
-- Helps [#1153]
 - Disable maintenance mode when Magento2 deployment fails [#1251]
-- Fixed storage link error when deploying Laravel < 5.3. 
+- Fixed storage link error when deploying Laravel < 5.3 
 - Helps [#1153]
 
 ## v5.0.1
@@ -232,6 +230,7 @@
 [#1145]: https://github.com/deployphp/deployer/pull/1145
 [#1146]: https://github.com/deployphp/deployer/pull/1146
 [#1152]: https://github.com/deployphp/deployer/pull/1152
+[#1153]: https://github.com/deployphp/deployer/issues/1153
 [#1165]: https://github.com/deployphp/deployer/issues/1165
 [#1175]: https://github.com/deployphp/deployer/pull/1175
 [#330]: https://github.com/deployphp/deployer/pull/330

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 - Fixed upload / download with optional rsync ssh options [#1227]
+- Fixed storage link error when deploying Laravel < 5.3. 
+- Helps [#1153]
 
 ## v5.0.1
 [v5.0.0...v5.0.1](https://github.com/deployphp/deployer/compare/v5.0.0...v5.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed upload / download with optional rsync ssh options [#1227]
 - Fixed storage link error when deploying Laravel < 5.3. 
 - Helps [#1153]
+- Disable maintenance mode when Magento2 deployment fails [#1251]
 
 ## v5.0.1
 [v5.0.0...v5.0.1](https://github.com/deployphp/deployer/compare/v5.0.0...v5.0.1)
@@ -202,6 +203,7 @@
 ## v4.0.0
 🙄
 
+[#1251]: https://github.com/deployphp/deployer/pull/1251
 [#1218]: https://github.com/deployphp/deployer/issues/1218
 [#1205]: https://github.com/deployphp/deployer/issues/1205
 [#1204]: https://github.com/deployphp/deployer/issues/1204

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -105,7 +105,9 @@ task('artisan:queue:restart', function () {
 
 desc('Execute artisan storage:link');
 task('artisan:storage:link', function () {
-    run('{{bin/php}} {{release_path}}/artisan storage:link');
+    if (get('laravel_version') > 5.2) {
+        run('{{bin/php}} {{release_path}}/artisan storage:link');
+    }
 });
 
 desc('Get Laravel version');
@@ -151,6 +153,7 @@ task('deploy', [
     'deploy:shared',
     'deploy:vendors',
     'deploy:writable',
+    'artisan:version',
     'artisan:storage:link',
     'artisan:view:clear',
     'artisan:cache:clear',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -35,6 +35,16 @@ set('writable_dirs', [
     'storage/logs',
 ]);
 
+set('laravel_version', function () {
+    $result = run('{{bin/php}} {{release_path}}/artisan --version');
+
+    preg_match_all('/version\ (.+?)$/', $result, $matches);
+
+    $version = $matches[1][0] ?? 5.4;
+
+    return (float) $version;
+});
+
 /**
  * Helper tasks
  */
@@ -110,17 +120,6 @@ task('artisan:storage:link', function () {
     }
 });
 
-desc('Get Laravel version');
-task('artisan:version', function () {
-    $result = run('{{bin/php}} {{release_path}}/artisan --version');
-
-    preg_match_all('/version\ (.+?)$/', $result, $matches);
-
-    $version = $matches[1][0] ?? get('laravel_version') ?? 5.4;
-
-    set('laravel_version', (float) $version);
-});
-
 /**
  * Task deploy:public_disk support the public disk.
  * To run this task automatically, please add below line to your deploy.php file
@@ -153,7 +152,6 @@ task('deploy', [
     'deploy:shared',
     'deploy:vendors',
     'deploy:writable',
-    'artisan:version',
     'artisan:storage:link',
     'artisan:view:clear',
     'artisan:cache:clear',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -38,11 +38,11 @@ set('writable_dirs', [
 set('laravel_version', function () {
     $result = run('{{bin/php}} {{release_path}}/artisan --version');
 
-    preg_match_all('/version\ (.+?)$/', $result, $matches);
+    preg_match_all('/([0-9\.])$/', $result, $matches);
 
     $version = $matches[1][0] ?? 5.4;
 
-    return (float) $version;
+    return $version;
 });
 
 /**
@@ -115,7 +115,10 @@ task('artisan:queue:restart', function () {
 
 desc('Execute artisan storage:link');
 task('artisan:storage:link', function () {
-    if (version_compare(get('laravel_version'), 5.2, '>')) {
+    $needsVersion = 5.3;
+    $currentVersion = get('laravel_version');
+
+    if (version_compare($currentVersion, $needsVersion, '>=')) {
         run('{{bin/php}} {{release_path}}/artisan storage:link');
     }
 });

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -108,6 +108,17 @@ task('artisan:storage:link', function () {
     run('{{bin/php}} {{release_path}}/artisan storage:link');
 });
 
+desc('Get Laravel version');
+task('artisan:version', function () {
+    $result = run('{{bin/php}} {{release_path}}/artisan --version');
+
+    preg_match_all('/version\ (.+?)$/', $result, $matches);
+
+    $version = $matches[1][0] ?? get('laravel_version') ?? 5.4;
+
+    set('laravel_version', (float) $version);
+});
+
 /**
  * Task deploy:public_disk support the public disk.
  * To run this task automatically, please add below line to your deploy.php file

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -115,7 +115,7 @@ task('artisan:queue:restart', function () {
 
 desc('Execute artisan storage:link');
 task('artisan:storage:link', function () {
-    if (get('laravel_version') > 5.2) {
+    if (version_compare(get('laravel_version'), 5.2, '>')) {
         run('{{bin/php}} {{release_path}}/artisan storage:link');
     }
 });

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -87,3 +87,5 @@ task('deploy', [
     'cleanup',
     'success'
 ]);
+
+after('deploy:failed', 'magento:maintenance:disable');


### PR DESCRIPTION
Since Laravel 5.2 doesn't have `artisan storage:link` command, we can't call on versions below `5.3`.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/deployer/blob/master/CHANGELOG.md)
