### PR TITLE
Fix a parsing of laravel version in output "php artisan --version"

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -38,7 +38,7 @@ set('writable_dirs', [
 set('laravel_version', function () {
     $result = run('{{bin/php}} {{release_path}}/artisan --version');
 
-    preg_match_all('/([0-9\.])$/', $result, $matches);
+    preg_match_all('/([0-9]\.*[0-9]*)/', $result, $matches);
 
     $version = $matches[1][0] ?? 5.4;
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -38,9 +38,9 @@ set('writable_dirs', [
 set('laravel_version', function () {
     $result = run('{{bin/php}} {{release_path}}/artisan --version');
 
-    preg_match_all('/([0-9]\.*[0-9]*)/', $result, $matches);
+    preg_match_all('/(\d+\.?)+/', $result, $matches);
 
-    $version = $matches[1][0] ?? 5.4;
+    $version = $matches[0][0] ?? 5.4;
 
     return $version;
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A

Fixed Laravel version parser

I have :
vagrant@homestead:~/sites/marso$ php artisan --version
Laravel Framework 5.4.14


You can see the differences:

```
<?php 

$result = 'Laravel Framework 5.4.14';

echo $result.PHP_EOL;

preg_match_all('/version\ (.+?)$/', $result, $matches);

echo 'Deployer Version 5.0.1 Result'.PHP_EOL;
var_dump($matches);
echo PHP_EOL;

preg_match_all('/([0-9\.])$/', $result, $matches);

echo 'Deployer Version 5.0.2 Result'.PHP_EOL;
var_dump($matches);
echo PHP_EOL;

preg_match_all('/([0-9]\.*[0-9]*)/', $result, $matches);

echo 'My Branch Result'.PHP_EOL;
var_dump($matches);
echo PHP_EOL;
```

