### PR TITLE
Mitigate missing `which` command on some systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 # Added
 - Check what `unzip` exists in `deploy:vendors` task
 
+# Changed
+- Use either one of `command`, `which` or `type` commands to locate custom binary path.
+
 
 ## v5.0.3
 [v5.0.2...v5.0.3](https://github.com/deployphp/deployer/compare/v5.0.2...v5.0.3)

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -99,16 +99,16 @@ set('current_path', function () {
  * Custom bins.
  */
 set('bin/php', function () {
-    return run('which php')->toString();
+    return locateBinaryPath('php');
 });
 
 set('bin/git', function () {
-    return run('which git')->toString();
+    return locateBinaryPath('git');
 });
 
 set('bin/composer', function () {
     if (commandExist('composer')) {
-        $composer = run('which composer')->toString();
+        $composer = locateBinaryPath('composer');
     }
 
     if (empty($composer)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A or xx

Some systems, especially thin Docker images, do not have `which` command, used to locate path of `php`, `git`, `composer` etc.

This pull request adds method which should mitigate this on most systems, prioritizing `command` over `which` with fallback to `type`. This should cover most systems out there.

Related to #484, #607, #586

See [this SXC article](https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then) for more related info.