### PR TITLE
Add run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Check what `unzip` exists in `deploy:vendors` task
+- Added `dep run` command [#1263]
 
 ### Changed
 - Use either one of `command`, `which` or `type` commands to locate custom binary path.
@@ -228,6 +229,7 @@
 
 [#1268]: https://github.com/deployphp/deployer/pull/1268
 [#1265]: https://github.com/deployphp/deployer/pull/1265
+[#1263]: https://github.com/deployphp/deployer/pull/1263
 [#1252]: https://github.com/deployphp/deployer/pull/1252
 [#1251]: https://github.com/deployphp/deployer/pull/1251
 [#1246]: https://github.com/deployphp/deployer/pull/1246

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -1,0 +1,110 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console;
+
+use Deployer\Deployer;
+use Deployer\Exception\Exception;
+use Deployer\Task\Context;
+use Deployer\Task\Task;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\OutputInterface as Output;
+use function Deployer\run;
+use function Deployer\write;
+
+class RunCommand extends Command
+{
+    /**
+     * @var Deployer
+     */
+    private $deployer;
+
+    /**
+     * @param Deployer $deployer
+     */
+    public function __construct(Deployer $deployer)
+    {
+        parent::__construct('run');
+        $this->setDescription('Run any arbitrary command on hosts');
+        $this->deployer = $deployer;
+    }
+
+    /**
+     * Configures the command
+     */
+    protected function configure()
+    {
+        $this->addArgument(
+            'command-to-run',
+            InputArgument::REQUIRED,
+            'Command to run'
+        );
+        $this->addOption(
+            'log',
+            null,
+            Option::VALUE_REQUIRED,
+            'Log to file'
+        );
+        $this->addOption(
+            'stage',
+            null,
+            Option::VALUE_REQUIRED,
+            'Stage to deploy'
+        );
+        $this->addOption(
+            'roles',
+            null,
+            Option::VALUE_REQUIRED,
+            'Roles to deploy'
+        );
+        $this->addOption(
+            'hosts',
+            null,
+            Option::VALUE_REQUIRED,
+            'Host to deploy, comma separated, supports ranges [:]'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(Input $input, Output $output)
+    {
+        $command = $input->getArgument('command-to-run');
+        $stage = $input->getOption('stage');
+        $roles = $input->getOption('roles');
+        $hosts = $input->getOption('hosts');
+
+        if (!empty($input->getOption('log'))) {
+            $this->deployer->config['log_file'] = $input->getOption('log');
+        }
+
+        if (!empty($hosts)) {
+            $hosts = $this->deployer->hostSelector->getByHostnames($hosts);
+        } elseif (!empty($roles)) {
+            $hosts = $this->deployer->hostSelector->getByRoles($roles);
+        } else {
+            $hosts = $this->deployer->hostSelector->getHosts($stage);
+        }
+
+        if (empty($hosts)) {
+            throw new Exception('No host selected');
+        }
+
+        $task = new Task($command, function () use ($command) {
+            $output = run($command);
+            write($output);
+        });
+
+        foreach ($hosts as $host) {
+            $task->run(new Context($host, $input, $output));
+        }
+    }
+}

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputOption as Option;
 use Symfony\Component\Console\Output\OutputInterface as Output;
 use function Deployer\run;
 use function Deployer\write;
+use function Deployer\writeln;
 
 class RunCommand extends Command
 {
@@ -98,9 +99,13 @@ class RunCommand extends Command
             throw new Exception('No host selected');
         }
 
-        $task = new Task($command, function () use ($command) {
+        $task = new Task($command, function () use ($command, $hosts) {
             $output = run($command);
-            write($output);
+            if (count($hosts) > 1) {
+                writeln("[{{hostname}}] > $output");
+            } else {
+                write($output);
+            }
         });
 
         foreach ($hosts as $host) {

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -13,6 +13,7 @@ use Deployer\Console\CommandEvent;
 use Deployer\Console\InitCommand;
 use Deployer\Console\Output\Informer;
 use Deployer\Console\Output\OutputWatcher;
+use Deployer\Console\RunCommand;
 use Deployer\Console\SshCommand;
 use Deployer\Console\TaskCommand;
 use Deployer\Console\WorkerCommand;
@@ -215,6 +216,7 @@ class Deployer extends Container
         $this->getConsole()->add(new WorkerCommand($this));
         $this->getConsole()->add($this['init_command']);
         $this->getConsole()->add(new SshCommand($this));
+        $this->getConsole()->add(new RunCommand($this));
         $this->getConsole()->afterRun([$this, 'collectAnonymousStats']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | -

This PR add `run` command:

```sh
dep run 'which php'
```

```sh
dep run 'which php' --hosts one,two,three
```