### PR TITLE
use php bin in parallel executer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@
 
 # Changed
 - Use either one of `command`, `which` or `type` commands to locate custom binary path.
+- use PHP_BINARY when triggering processes in parallel-executer
 
 
 ## v5.0.3
 [v5.0.2...v5.0.3](https://github.com/deployphp/deployer/compare/v5.0.2...v5.0.3)
 
-### Fixed 
+### Fixed
 - Fix a parsing of laravel version in output [#1252]
 
 
@@ -46,7 +47,7 @@
 ## v5.0.0
 [v5.0.0-beta.3...v5.0.0](https://github.com/deployphp/deployer/compare/v5.0.0-beta.3...v5.0.0)
 
-### Changed 
+### Changed
 - Working path default is `release_path` instead of home for simple tasks [#1205]
 
 ### Fixed

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -142,7 +142,7 @@ class ParallelExecutor implements ExecutorInterface
      */
     protected function getProcess($host, Task $task)
     {
-        $dep = DEPLOYER_BIN;
+        $dep = PHP_BINARY . ' ' . DEPLOYER_BIN;
         $options = $this->generateOptions();
         $hostname = $host->getHostname();
         $taskName = $task->getName();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

When using the parallel execution mode deployer invokes the dep script directly.
Which is fine as long as you only have one php version in your environment (like Build-Servers).

To ensure the usage of the php version that is used to trigger deployer, this pull request adds the PHP_BINARY to the sub-command.