### PR TITLE
Per user persistent storage

### DIFF
--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -31,7 +31,7 @@ class Storage
 		// default persistent storage in case we can't use the configured value
 		// or we can't create the default location
 		// use the system temporary folder and the current pid to make the path unique
-		$tmp = sys_get_temp_dir() . '/' . uuid(posix_getpid());
+		$tmp = sys_get_temp_dir() . '/' . uniqid(posix_getpid());
 		
 		// get the location for the deployer configuration
 		$deployerConfig = $config->has('deployer_config') ? $config->get('deployer_config') : null;

--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -14,6 +14,72 @@ use function Deployer\Support\array_flatten;
 
 class Storage
 {
+	/**
+	 * In a multi user environment where multiple projects are located on the same instance(s)
+	 *	if two or more users are deploying a project on the same environment, the generated hosts files
+	 *	are overwritten or worse, the deploy will fail due to file permissions
+	 *
+	 * Make the persistent storage folder configurable or use the system tmp 
+	 *	as default if not possible
+	 * 
+	 * @return string
+	 * @throws Exception
+	 */
+	private static function _getPersistentStorageLocation() {
+		$config = \Deployer\Deployer::get()->config;
+
+		// default persistent storage in case we can't use the configured value
+		// or we can't create the default location
+		// use the system temporary folder and the current pid to make the path unique
+		$tmp = sys_get_temp_dir() . '/' . uuid(posix_getpid());
+		
+		// get the location for the deployer configuration
+		$deployerConfig = $config->has('deployer_config') ? $config->get('deployer_config') : null;
+
+		if ( !is_null($deployerConfig) ) {
+			// check if the folder exists and it's writable
+			if ( !(is_dir($deployerConfig) && is_writable($deployerConfig)) ) {
+				throw new Exception("Deployer folder `$deployerConfig` doesn't exists or doesn't writable.");
+			}
+		} else {
+			// not configured, generate deployer folder name
+
+			// use the home dir of the current user 
+			// and the repository name
+			$userInfo = posix_getpwuid(posix_getuid());
+			
+			// if for some reason we couldn't find a valid home folder
+			// or if it's not writable, use the default location
+			if ( !isset($userInfo['dir']) || !(is_dir($userInfo['dir']) && is_writable($userInfo['dir'])) ) {
+				return $tmp;
+			}
+			
+			// we have a folder name
+			$deployerConfig = $userInfo['dir'] . '/.deployer';
+			
+			//if it doesn't exists, create it
+			if ( !file_exists($deployerConfig) ) {
+				mkdir($deployerConfig, 0777, true);
+			} 
+
+			//it exists, check if it's a folder and if it's writable
+			if ( !(is_dir($deployerConfig) && is_writable($deployerConfig)) ) {
+				return $tmp;
+			}
+		}
+		
+		// we will store the persistent data per repository
+		$configRepository = $config->has('repository') ? $config->get('repository') : null;
+		if (empty($configRepository)) {
+			return $tmp;
+		} 
+		
+		// we now have the repository name
+		$repository = str_replace('/', '_', substr($configRepository, (strrpos($configRepository, ':') + 1)));
+		
+		return $deployerConfig . '/' . $repository;
+	}
+
     /**
      * @param Host[] $hosts
      */
@@ -27,7 +93,7 @@ class Storage
                 $values[$key] = $host->get($key);
             }
 
-            $file = sys_get_temp_dir() . '/' . $host->getHostname() . '.dep';
+            $file = self::_getPersistentStorageLocation() . '/' . $host->getHostname() . '.dep';
             $values['host_config_storage'] = $file;
 
             $persistentCollection = new PersistentCollection($file, $values);

--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -14,73 +14,6 @@ use function Deployer\Support\array_flatten;
 
 class Storage
 {
-	/**
-	 * In a multi user environment where multiple projects are located on the same instance(s)
-	 *	if two or more users are deploying at the same time on the same environment, 
-	 *	the generated hosts files are overwritten or worse, the deploy will fail 
-	 *	due to file permissions
-	 *
-	 * Make the persistent storage folder configurable or use the system tmp 
-	 *	as default if not possible
-	 * 
-	 * @return string
-	 * @throws Exception
-	 */
-	private static function _getPersistentStorageLocation() {
-		$config = \Deployer\Deployer::get()->config;
-
-		// use the system temporary folder and the current pid as default 
-		// persistent storage in case we can't use the configured value
-		// or we can't create the default location
-		$tmp = sys_get_temp_dir() . '/' . posix_getpid();
-
-		// get the location for the deployer configuration
-		$deployerConfig = $config->has('deployer_config') ? $config->get('deployer_config') : null;
-
-		if ( !is_null($deployerConfig) ) {
-			// check if the folder exists and it's writable
-			if ( !(is_dir($deployerConfig) && is_writable($deployerConfig)) ) {
-				throw new Exception("Deployer folder `$deployerConfig` doesn't exists or doesn't writable.");
-			}
-		} else {
-			// not configured, generate deployer folder name
-
-			// use the home dir of the current user 
-			// and the repository name
-			$userInfo = posix_getpwuid(posix_getuid());
-			
-			// if for some reason we couldn't find a valid home folder
-			// or if it's not writable, use the default location
-			if ( !isset($userInfo['dir']) || !(is_dir($userInfo['dir']) && is_writable($userInfo['dir'])) ) {
-				return $tmp;
-			}
-			
-			// we have a folder name
-			$deployerConfig = $userInfo['dir'] . '/.deployer';
-			
-			//if it doesn't exists, create it
-			if ( !file_exists($deployerConfig) ) {
-				mkdir($deployerConfig, 0777, true);
-			} 
-
-			//it exists, check if it's a folder and if it's writable
-			if ( !(is_dir($deployerConfig) && is_writable($deployerConfig)) ) {
-				return $tmp;
-			}
-		}
-		
-		// we will store the persistent data per repository
-		$configRepository = $config->has('repository') ? $config->get('repository') : null;
-		if (empty($configRepository)) {
-			return $tmp;
-		} 
-		
-		// we now have the repository name
-		$repository = str_replace('/', '_', substr($configRepository, (strrpos($configRepository, ':') + 1)));
-
-		return $deployerConfig . '/' . $repository;
-	}
-
     /**
      * @param Host[] $hosts
      */
@@ -94,7 +27,7 @@ class Storage
                 $values[$key] = $host->get($key);
             }
 
-            $file = self::_getPersistentStorageLocation() . '/' . $host->getHostname() . '.dep';
+            $file = self::getPersistentStorageLocation() . '/' . $host->getHostname() . '.dep';
             $values['host_config_storage'] = $file;
 
             $persistentCollection = new PersistentCollection($file, $values);
@@ -150,4 +83,79 @@ class Storage
         $persistentCollection->load();
         $host->getConfig()->setCollection($persistentCollection);
     }
+	
+	/**
+	 * In a multi user environment where multiple projects are located on the same instance(s)
+	 *	if two or more users are deploying at the same time on the same environment, 
+	 *	the generated hosts files are overwritten or worse, the deploy will fail 
+	 *	due to file permissions
+	 *
+	 * Make the persistent storage folder configurable or use the system tmp 
+	 *	as default if not possible
+	 * 
+	 * @return string
+	 * @throws Exception
+	 */
+	private static function getPersistentStorageLocation() {
+		$config = \Deployer\Deployer::get()->config;
+
+		// use the system temporary folder and the current pid as default 
+		// persistent storage in case we can't use the configured value
+		// or we can't create the default location
+		$tmp = sys_get_temp_dir() . '/' . posix_getpid();
+
+		// use the home dir of the current user 
+		// and the repository name
+		
+		//posix compatible
+		if (function_exists('posix_getpwuid')) {
+			$userInfo = posix_getpwuid(posix_getuid());
+
+			// if for some reason we couldn't find a valid home folder
+			// or if it's not writable, use the default location
+			if ( !isset($userInfo['dir']) || !(is_dir($userInfo['dir']) && is_writable($userInfo['dir'])) ) {
+				return $tmp;
+			}
+			
+			// we have a folder name
+			$homeDir = $userInfo['dir'];
+		} else {
+			if (getenv('HOME')) {
+				 // MacOS and other *nix
+				$homeDir = getenv('HOME');
+			} else if (getenv('HOMEDRIVE') && getenv('HOMEPATH')) {
+				// Windows 8+
+				$homeDir = getenv('HOMEDRIVE') . getenv('HOMEPATH');
+			}
+		}
+
+		if (empty($homeDir)) {
+			// unable to get the home dir
+			return $tmp;
+		} else {
+			// we have a folder name
+			$persistentStorage = $homeDir . '/.deployer';
+		}
+
+		//if it doesn't exists, create it
+		if ( !file_exists($persistentStorage) ) {
+			mkdir($persistentStorage, 0777, true);
+		} 
+
+		//it exists, check if it's a folder and if it's writable
+		if ( !(is_dir($persistentStorage) && is_writable($persistentStorage)) ) {
+			return $tmp;
+		}
+		
+		// we will store the persistent data per repository
+		$configRepository = $config->has('repository') ? $config->get('repository') : null;
+		if (empty($configRepository)) {
+			return $tmp;
+		} 
+		
+		// we now have the repository name
+		$repository = str_replace('/', '_', substr($configRepository, (strrpos($configRepository, ':') + 1)));
+
+		return $persistentStorage . '/' . $repository;
+	}
 }

--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -16,8 +16,9 @@ class Storage
 {
 	/**
 	 * In a multi user environment where multiple projects are located on the same instance(s)
-	 *	if two or more users are deploying a project on the same environment, the generated hosts files
-	 *	are overwritten or worse, the deploy will fail due to file permissions
+	 *	if two or more users are deploying at the same time on the same environment, 
+	 *	the generated hosts files are overwritten or worse, the deploy will fail 
+	 *	due to file permissions
 	 *
 	 * Make the persistent storage folder configurable or use the system tmp 
 	 *	as default if not possible
@@ -28,11 +29,11 @@ class Storage
 	private static function _getPersistentStorageLocation() {
 		$config = \Deployer\Deployer::get()->config;
 
-		// default persistent storage in case we can't use the configured value
+		// use the system temporary folder and the current pid as default 
+		// persistent storage in case we can't use the configured value
 		// or we can't create the default location
-		// use the system temporary folder and the current pid to make the path unique
-		$tmp = sys_get_temp_dir() . '/' . uniqid(posix_getpid());
-		
+		$tmp = sys_get_temp_dir() . '/' . posix_getpid();
+
 		// get the location for the deployer configuration
 		$deployerConfig = $config->has('deployer_config') ? $config->get('deployer_config') : null;
 
@@ -76,7 +77,7 @@ class Storage
 		
 		// we now have the repository name
 		$repository = str_replace('/', '_', substr($configRepository, (strrpos($configRepository, ':') + 1)));
-		
+
 		return $deployerConfig . '/' . $repository;
 	}
 

--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -102,7 +102,7 @@ class Storage
 		// use the system temporary folder and the current pid as default 
 		// persistent storage in case we can't use the configured value
 		// or we can't create the default location
-		$tmp = sys_get_temp_dir() . '/' . posix_getpid();
+		$tmp = sys_get_temp_dir() . '/' . (function_exists('posix_getpid') ? posix_getpid() : getmypid());
 
 		// use the home dir of the current user 
 		// and the repository name

--- a/src/Host/Storage.php
+++ b/src/Host/Storage.php
@@ -27,7 +27,7 @@ class Storage
                 $values[$key] = $host->get($key);
             }
 
-            $file = self::getPersistentStorageLocation() . '/' . $host->getHostname() . '.dep';
+            $file = sys_get_temp_dir() . '/' . uniqid('deployer-') . '-' . $host->getHostname() . '.dep';
             $values['host_config_storage'] = $file;
 
             $persistentCollection = new PersistentCollection($file, $values);
@@ -83,79 +83,4 @@ class Storage
         $persistentCollection->load();
         $host->getConfig()->setCollection($persistentCollection);
     }
-	
-	/**
-	 * In a multi user environment where multiple projects are located on the same instance(s)
-	 *	if two or more users are deploying at the same time on the same environment, 
-	 *	the generated hosts files are overwritten or worse, the deploy will fail 
-	 *	due to file permissions
-	 *
-	 * Make the persistent storage folder configurable or use the system tmp 
-	 *	as default if not possible
-	 * 
-	 * @return string
-	 * @throws Exception
-	 */
-	private static function getPersistentStorageLocation() {
-		$config = \Deployer\Deployer::get()->config;
-
-		// use the system temporary folder and the current pid as default 
-		// persistent storage in case we can't use the configured value
-		// or we can't create the default location
-		$tmp = sys_get_temp_dir() . '/' . (function_exists('posix_getpid') ? posix_getpid() : getmypid());
-
-		// use the home dir of the current user 
-		// and the repository name
-		
-		//posix compatible
-		if (function_exists('posix_getpwuid')) {
-			$userInfo = posix_getpwuid(posix_getuid());
-
-			// if for some reason we couldn't find a valid home folder
-			// or if it's not writable, use the default location
-			if ( !isset($userInfo['dir']) || !(is_dir($userInfo['dir']) && is_writable($userInfo['dir'])) ) {
-				return $tmp;
-			}
-			
-			// we have a folder name
-			$homeDir = $userInfo['dir'];
-		} else {
-			if (getenv('HOME')) {
-				 // MacOS and other *nix
-				$homeDir = getenv('HOME');
-			} else if (getenv('HOMEDRIVE') && getenv('HOMEPATH')) {
-				// Windows 8+
-				$homeDir = getenv('HOMEDRIVE') . getenv('HOMEPATH');
-			}
-		}
-
-		if (empty($homeDir)) {
-			// unable to get the home dir
-			return $tmp;
-		} else {
-			// we have a folder name
-			$persistentStorage = $homeDir . '/.deployer';
-		}
-
-		//if it doesn't exists, create it
-		if ( !file_exists($persistentStorage) ) {
-			mkdir($persistentStorage, 0777, true);
-		} 
-
-		//it exists, check if it's a folder and if it's writable
-		if ( !(is_dir($persistentStorage) && is_writable($persistentStorage)) ) {
-			return $tmp;
-		}
-		
-		// we will store the persistent data per repository
-		$configRepository = $config->has('repository') ? $config->get('repository') : null;
-		if (empty($configRepository)) {
-			return $tmp;
-		} 
-		
-		// we now have the repository name
-		$repository = str_replace('/', '_', substr($configRepository, (strrpos($configRepository, ':') + 1)));
-
-		return $persistentStorage . '/' . $repository;
-	}
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

In a multi user environment where multiple projects are located on the same instance(s)
if two or more users are deploying a project on the same environment, the generated hosts files
in the system tmp folder are overwritten or worse, the deploy will fail due to file permissions.

Make the persistent storage folder configurable or use the system tmp  as default if not possible.