### PR TITLE
Fix bug with parallel deploy to same host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed parallel execution with non-standart php bin path [#1265]
 - Fixed ssh multiplexing initialization [#1268]
 - Fixed exit code on error [#1236]
+- Fixed bug with deploying in parallel to same host
 
 ## v5.0.3
 [v5.0.2...v5.0.3](https://github.com/deployphp/deployer/compare/v5.0.2...v5.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fixed parallel execution with non-standart php bin path [#1265]
 - Fixed ssh multiplexing initialization [#1268]
 - Fixed exit code on error [#1236]
-- Fixed bug with deploying in parallel to same host
+- Fixed bug with deploying in parallel to same host [#1271]
 
 ## v5.0.3
 [v5.0.2...v5.0.3](https://github.com/deployphp/deployer/compare/v5.0.2...v5.0.3)
@@ -230,6 +230,7 @@
 ## v4.0.0
 🙄
 
+[#1271]: https://github.com/deployphp/deployer/pull/1271
 [#1268]: https://github.com/deployphp/deployer/pull/1268
 [#1265]: https://github.com/deployphp/deployer/pull/1265
 [#1263]: https://github.com/deployphp/deployer/pull/1263

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -17,6 +17,7 @@ class Host
     use ConfigurationAccessor;
 
     private $hostname;
+    private $realHostname;
     private $user;
     private $port;
     private $configFile;
@@ -31,6 +32,7 @@ class Host
     public function __construct(string $hostname)
     {
         $this->hostname = $hostname;
+        $this->setRealHostname($hostname);
         $this->config = new Configuration();
         $this->sshArguments = new Arguments();
     }
@@ -62,8 +64,7 @@ class Host
     public function __toString()
     {
         $user = empty($this->user) ? '' : "{$this->user}@";
-        $hostname = preg_replace('/\/.+$/', '', $this->hostname);
-        return "$user$hostname";
+        return "$user{$this->realHostname}";
     }
 
     /**
@@ -80,8 +81,16 @@ class Host
      */
     public function hostname(string $hostname)
     {
-        $this->hostname = $hostname;
+        $this->setRealHostname($hostname);
         return $this;
+    }
+
+    /**
+     * @param mixed $hostname
+     */
+    private function setRealHostname(string $hostname)
+    {
+        $this->realHostname = preg_replace('/\/.+$/', '', $hostname);
     }
 
     /**

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -37,8 +37,9 @@ class FileLoaderTest extends TestCase
         self::assertEquals('/var/local', $local->get('deploy_to'));
 
         // bar configured properly
-        $bar = $this->getHost('bar.com');
-        self::assertEquals('bar.com', $bar->getHostname());
+        $bar = $this->getHost('bar');
+        self::assertEquals('bar', $bar->getHostname());
+        self::assertEquals('user@bar.com', "$bar");
         self::assertEquals('user', $bar->getUser());
         self::assertEquals(22, $bar->getPort());
         self::assertEquals('configFile', $bar->getConfigFile());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Now it's possible to parallel deploy with this configuration:

```php
host('prod')
    ->hostname('45.32.112.252')
    ->set('deploy_path', '~/prod');

host('beta')
    ->hostname('45.32.112.252')
    ->set('deploy_path', '~/beta');
```