### PR TITLE
Handle option value with equal sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Improved `config:current` output (print each host's current release)
+- Fix bug where `ParallelExecutor` threw an error when custom options were added.
 
 
 ## v5.1.1

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -252,7 +252,7 @@ class ParallelExecutor implements ExecutorInterface
         foreach (['log'] as $option) {
             $value = $this->input->getOption($option);
             if ($value) {
-                $input .= " --$option $value";
+                $input .= " --$option=$value";
             }
         }
 
@@ -268,7 +268,7 @@ class ParallelExecutor implements ExecutorInterface
         foreach ($this->console->getUserDefinition()->getOptions() as $option) {
             $value = $this->input->getOption($option->getName());
             if ($value) {
-                $input .= " --{$option->getName()} $value";
+                $input .= " --{$option->getName()}=$value";
             }
         }
 


### PR DESCRIPTION
option should be handled with an equal sign.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

`ParallelExecutor` throws an error if you add user defined options.


```
                                                          
  [Symfony\Component\Console\Exception\RuntimeException]  
  Too many arguments, expected arguments "command".       
                                                          
Exception trace:
 () at vendor/symfony/console/Input/ArgvInput.php:189
 Symfony\Component\Console\Input\ArgvInput->parseArgument() at vendor/symfony/console/Input/ArgvInput.php:88
 Symfony\Component\Console\Input\ArgvInput->parse() at vendor/symfony/console/Input/Input.php:63
 Symfony\Component\Console\Input\Input->bind() at vendor/symfony/console/Command/Command.php:222
 Symfony\Component\Console\Command\Command->run() at vendor/symfony/console/Application.php:869
 Symfony\Component\Console\Application->doRunCommand() at vendor/deployer/deployer/src/Console/Application.php:132
 Deployer\Console\Application->doRunCommand() at vendor/symfony/console/Application.php:223
 Symfony\Component\Console\Application->doRun() at vendor/symfony/console/Application.php:130
 Symfony\Component\Console\Application->run() at vendor/deployer/deployer/src/Deployer.php:320
 Deployer\Deployer::run() at vendor/deployer/deployer/bin/dep:120

worker [--hostname HOSTNAME] [--task TASK] [--config-file CONFIG-FILE] [--log LOG]
```

It's throwing an error because the worker that's trying to execute in the background looks like this.
`"/usr/bin/php vendor/deployer/deployer/bin/dep  worker --my-custom-option 1 --ansi --hostname xxx.xxx.xxx.xxx --task deploy --config-file /tmp/xxx.xxx.xxx.xxx.dep"`
