### PR TITLE
deploy:cache:clear task contains excess option "--no-debug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Fixed bug with wrong version printed after self-update command
+- Fixed bug with excess option "--no-debug" in deploy:cache:clear task [#1290]
 
 
 ## v5.1.2

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -106,7 +106,7 @@ task('deploy:assetic:dump', function () {
  * Clear Cache
  */
 task('deploy:cache:clear', function () {
-    run('{{env_vars}} {{bin/php}} {{bin/console}} cache:clear {{console_options}} --no-debug --no-warmup');
+    run('{{env_vars}} {{bin/php}} {{bin/console}} cache:clear {{console_options}} --no-warmup');
 })->desc('Clear cache');
 
 /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Issue Type        | Bug
| Deployer Version  | N/A
| Local Machine OS  | N/A
| Remote Machine OS | N/A

### Description 
deploy:cache:clear task contains excess option "--no-debug". Because this option is already defined as **console_options** variable.
