### PR TITLE
Introduce git_recursive option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Added possibility to use callable when setting 'default_stage'.
 - Added console init template for TYPO3 CMS [#1300]
+- Added `git_recursive` option
 
 ## v5.1.3
 [v5.1.2...v5.1.3](https://github.com/deployphp/deployer/compare/v5.1.2...v5.1.3)

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -15,6 +15,7 @@ task('deploy:update_code', function () {
     $branch = get('branch');
     $git = get('bin/git');
     $gitCache = get('git_cache');
+    $recursive = get('git_recursive', true) ? '--recursive' : '';
     $depth = $gitCache ? '' : '--depth 1';
     $options = [
         'tty' => get('git_tty', false),
@@ -52,14 +53,14 @@ task('deploy:update_code', function () {
 
     if ($gitCache && has('previous_release')) {
         try {
-            run("$git clone $at --recursive -q --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);
+            run("$git clone $at $recursive -q --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);
         } catch (RuntimeException $exc) {
             // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
-            run("$git clone $at --recursive -q $repository {{release_path}} 2>&1", $options);
+            run("$git clone $at $recursive -q $repository {{release_path}} 2>&1", $options);
         }
     } else {
         // if we're using git cache this would be identical to above code in catch - full clone. If not, it would create shallow clone.
-        run("$git clone $at $depth --recursive -q $repository {{release_path}} 2>&1", $options);
+        run("$git clone $at $depth $recursive -q $repository {{release_path}} 2>&1", $options);
     }
 
     if (!empty($revision)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This PR introduces an option to enable or disable the `--recursive` flag while cloning. The use case is that we only have submodules for development related stuff, so dropping the `--recursive` flag would be more performant and it would keep us from having to include deploy keys for those git repositories as well.

```php
set('git_recursive', true);
```

```bash
➤ Executing task deploy:update_code
...
[example.com] > /usr/bin/git clone  --depth 1 --recursive -q git@github.com:deployphp/deployer.git /srv/http/foobar/releases/9 2>&1
```

```php
set('git_recursive', false);
```

```bash
➤ Executing task deploy:update_code
...
[example.com] > /usr/bin/git clone  --depth 1  -q git@github.com:deployphp/deployer.git /srv/http/foobar/releases/8 2>&1
```

I didn't see any tests I could extend with this new option, let me know if I missed something.

I've also created a PR to update the documentation: https://github.com/deployphp/docs/pull/102