### PR TITLE
Update update_code.php

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -85,6 +85,8 @@ task('deploy:update_code', function () {
         } catch (RuntimeException $exc) {
             // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
             run("$git clone $at $recursive -q $repository {{release_path}} 2>&1", $options);
+        } catch (\Symfony\Component\Process\Exception\ProcessFailedException $exc){
+            run("$git clone $at --recursive -q $repository {{release_path}} 2>&1", $options);
         }
     } else {
         // if we're using git cache this would be identical to above code in catch - full clone. If not, it would create shallow clone.


### PR DESCRIPTION
I was seeing the following exception when trying to deploy my project:
```
fatal: reference repository '/home/mysite/staging/releases/29' is shallow

  [Symfony\Component\Process\Exception\ProcessFailedException]
  The command "ssh -A -tt mysite@mysite.ca '/usr/local/bin/git clone -b dev --recursive -q --reference /home/mysite/staging/releases/29 --dissociate git@bitbucket.
  org:mysite/mysite.git  /home/mysite/staging/releases/30 2>&1'" failed.
  Exit Code: 128(Invalid exit argument)
  Working directory: /Users/nickv/Projects/mysite
  Output:
  ================
  Error Output:
  ================
```

The try catch block should also be looking for the ```ProcessFailedException```. I've added it in and now the release properly clones.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/deployer/blob/master/CHANGELOG.md)
