### PR TITLE
Adds support for GroupTask in invoke

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -394,15 +394,11 @@ function roles(...$roles)
  */
 function invoke($task)
 {
-    $informer = Deployer::get()->informer;
-    $task = Deployer::get()->tasks->get($task);
-    $input = Context::get()->getInput();
-    $output = Context::get()->getOutput();
-    $host = Context::get()->getHost();
+    $hosts = [Context::get()->getHost()];
+    $tasks = Deployer::get()->scriptManager->getTasks($task, $hosts);
 
-    $informer->startTask($task);
-    $task->run(new Context($host, $input, $output));
-    $informer->endTask($task);
+    $executor = Deployer::get()->seriesExecutor;
+    $executor->run($tasks, $hosts);
 }
 
 /**

--- a/test/fixture/recipe/party.php
+++ b/test/fixture/recipe/party.php
@@ -46,6 +46,28 @@ task('test_invoke:subtask2', function () {
 
 
 /*
+ * Invoke group test
+ */
+
+task('test_invoke_group', function () {
+    invoke('test_invoke_group:group');
+});
+
+task('test_invoke_group:group', [
+    'test_invoke_group:subtask1',
+    'test_invoke_group:subtask2',
+]);
+
+task('test_invoke_group:subtask1', function () {
+    writeln('first');
+});
+
+task('test_invoke_group:subtask2', function () {
+    writeln('second');
+});
+
+
+/*
  * Function "on" test
  */
 

--- a/test/recipe/PartyTest.php
+++ b/test/recipe/PartyTest.php
@@ -33,6 +33,13 @@ class PartyTest extends DepCase
         self::assertContains('second', $output);
     }
 
+    public function testInvokeGroup()
+    {
+        $output = $this->start('test_invoke_group');
+        self::assertContains('first', $output);
+        self::assertContains('second', $output);
+    }
+
     public function testOn()
     {
         $output = $this->start('test_on');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Calling invoke on a GroupTask throw a `Can't run group task.` exception.
Using `ScriptManager::getTasks` and a `SeriesExecutor` allows to use invoke on GroupTasks.