### PR TITLE
Run autoloader after compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 [v6.0.3...master](https://github.com/deployphp/deployer/compare/v6.0.3...master)
 
+### Changed
+- Laravel version check defaults to 5.5 if not found [#1365]
 
 
 ## v6.0.3
@@ -311,7 +313,7 @@
 - Fixed remove of shared dir on first deploy
 
 
-
+[#1365]: https://github.com/deployphp/deployer/pull/1365
 [#1352]: https://github.com/deployphp/deployer/pull/1352
 [#1311]: https://github.com/deployphp/deployer/pull/1311
 [#1300]: https://github.com/deployphp/deployer/pull/1300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [v6.0.3...master](https://github.com/deployphp/deployer/compare/v6.0.3...master)
 
 ### Changed
-- Laravel version check defaults to 5.5 if not found [#1365]
+- Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
 
 
 ## v6.0.3

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -32,6 +32,7 @@ task('magento:enable', function () {
 desc('Compile magento di');
 task('magento:compile', function () {
     run("{{bin/php}} {{release_path}}/bin/magento setup:di:compile");
+    run('cd {{release_path}} && {{bin/composer}} dump-autoload -o');
 });
 
 desc('Deploy assets');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No?
| Deprecations? | No
| Fixed tickets | N/A

According to the Magento opmization guide, the dump-autoload command should be called after the compiling of classes:
http://devdocs.magento.com/guides/v2.1/config-guide/prod/prod_perf-optimize.html

> After running setup:di:compile to generate classes, use composer to update the autoloader.