### PR TITLE
Make way for host-containers: Task-iterations and command-template functionality

### DIFF
--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -114,7 +114,6 @@ class Task
         }
 
         foreach ($this->iterationConfigurations as $configuration) {
-
             $overwritten = $this->applyDeltaSettings($context, $configuration);
 
             // Call task
@@ -129,7 +128,6 @@ class Task
             if ($context->getConfig() !== null) {
                 $context->getConfig()->set('working_path', false);
             }
-
         }
 
         if ($this->once) {
@@ -358,11 +356,9 @@ class Task
 
         $overwritten = [];
         foreach ($settings as $key => $value) {
-
             if ($configuration->has($key)) {
                 $overwritten[$key] = $configuration->get($key);
-            }
-            else {
+            } else {
                 $overwritten[$key] = null;
             }
 


### PR DESCRIPTION
PR to put out some feelers about handling deployments for projects running in containers on the remote host. This is by no means meant to be "the final solution" (although it can be), but simply an initial attempt to get some discussion going. It does work and does exactly what I wrote it for, for your information :)

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I did not want to make too big of a change to the base functionality. I also wanted to avoid adding container specific functionality in this project, as that should probably be a recipe. 

Managed to come up with the following 2-fold approach to allow the functionality I wanted:
* A `Task` now has `iterate`-functionality. This allows you to specify a set of configuration "delta" items and the task will be ran on the host for each of those deltas. In between runs (and after) the replaced values will be restored (or set to `null` if they were added because deleting is not supported). Idea here is that we want to be able to run a task on one or more containers on the host. It's also the most compact way to add the needed functionality to a `Task`
* The `run()`-function can now wrap the command to execute in a so called `command_template`. As long as this configuration value is not empty (and `apply_command_template` is not set to `false`), the template will be used as the command instead. The command to execute is stored in the `command`-configuration value. 

Using this we can achieve running commands within docker on the host fairly easy  (assuming the docker/similar recipe included at the bottom is there):

**Wrap existing task (move into container)**
```
runTaskInDocker('deploy:vendors', 'my_container_name', ['release_path' => '{{container_source_path}}']);
```
Everything the "`deploy:vendors`" task does will now be ran in the `my_container_name`-container on the host. The `release_path` variable will - for the duration of the task - be replace with whatever container_source_path is set to, so that we don't have to rewrite any of the original task but it will run fine within the docker container.

**Within a container task: run statement on the host**
```
runOnHost('{{bin/docker-compose}} up -d');
```
Using the `runWithoutTemplate` functionality, this disables using the `command_template` for a single callback and thus runs the regular way.


**Some explanation up front**

*Why iterations?*
I get that, most of the time, it will probably be a single container, but adding it within a possible iteration just seemed cleaner to me. Like that it also works for both a single and multiple runs of that task. I can see someone setting up a bunch of containers in 1 go with the same task, so why not allow it. The functionality is also not container specific, so who knows what else can be done.

`{{?command}}`?

The command template has support for tokens that should only be parsed when we're actually about to run the task. This is needed because we want to get the value of the template and "install" it before any parsing is done on the original command. 

For example imagine you want to run "`{{bin/php}} -i`" in a container: If the `command_template` would simply contain "`{{command}}`", attempting to get the template value would result in a call to `locateBinaryPath('php')` since everything is parsed recursively (assuming that `set('command', ...)` was called already). 

`locateBinaryPatth` would start running commands to try to locate the `php` executable. Unfortunately these will run on the host instead of in the container. 

By delaying substitution for some tokens (like the command), we can fetch the template value, change "`{{?command}}`" into "`{{command}}`" and then run the template with normal parsing. 
Instead of `command -v 'php'` this will now result in `/usr/bin/docker exec -i my_container_name bash -c 'command -v '\''php'\'`''

`docker_command_template`?
I have been in some situations where I want to be able to specify a different user to run a command, so this allows you to override the template with one of your own, for example:

`set('docker_command_template', '{{bin/docker}} exec -i --user not_root {{container}} bash -c {{?command}}');`

Curious about your thoughts.

**Docker recipe**
```
namespace Deployer;

function runTaskInDocker($task, $containers, $additionalConfiguration = [])
{
    $task = Deployer::get()->tasks->get($task);

    if (!$task) {
        throw new \InvalidArgumentException('Invalid task specified');
    }

    $containers = (array) $containers;
    $iterations = [];
    foreach ($containers as $name) {
        $iteration = [
            'command_template' => has('docker_command_template') ?
                get('docker_command_template') : '{{bin/docker}} exec -i {{container}} bash -c {{?command}}',
            'container' => $name
        ];

        foreach ($additionalConfiguration as $key => $value) {
            $iteration[$key] = $value;
        }

        $iterations[] = $iteration;
    }

    $task->iterate($iterations);
}

function runOnHost($command, $options = []) {
    return runWithoutTemplate(function() use ($command, $options) {
        return run($command, $options);
    });
}

set('bin/docker', function () {
    return runWithoutTemplate(function() {
        return locateBinaryPath('docker');
    });
});

set('bin/docker-compose', function () {
    return runWithoutTemplate(function() {
        return locateBinaryPath('docker-compose');
    });
});
```