### PR TITLE
Check if permissions are set if using sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for GroupTask in invoke() [#1364]
 - Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
 - Host's `roles()` API now can accept arrays too 
+- Checking if ACLs are set when using sudo and skip if so.
 
 ## v6.0.3
 [v6.0.2...v6.0.3](https://github.com/deployphp/deployer/compare/v6.0.2...v6.0.3)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

When using sudo, setting the permissions for writable directories should work the same as without sudo.
I now check if the acl is already set and abort if so.

Background: Setting ACLs took over 5min on our production server due to the large amount of small files inside subfolders. With this change we now are back to a comfortable 5 seconds. 