### PR TITLE
Fix inventory method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1413]: https://github.com/deployphp/deployer/pull/1413
 [#1403]: https://github.com/deployphp/deployer/pull/1403
 [#1390]: https://github.com/deployphp/deployer/pull/1390
 [#1365]: https://github.com/deployphp/deployer/pull/1365

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@
 - Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
 - Host's `roles()` API now can accept arrays too 
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1390]
-- Fixed bug that inventory method does not return Proxy [#1413]
 
 ### Fixed
 - Fixed bug when config:hosts shows more than one table of hosts [#1403]
+- Fixed bug that inventory method does not return Proxy [#1413]
 
 ## v6.0.3
 [v6.0.2...v6.0.3](https://github.com/deployphp/deployer/compare/v6.0.2...v6.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
 - Host's `roles()` API now can accept arrays too 
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1390]
+- Fixed bug that inventory method does not return Proxy [#1413]
 
 ### Fixed
 - Fixed bug when config:hosts shows more than one table of hosts [#1403]

--- a/src/functions.php
+++ b/src/functions.php
@@ -91,6 +91,7 @@ function localhost(...$hostnames)
  * Load list of hosts from file
  *
  * @param string $file
+ * @return Proxy
  */
 function inventory($file)
 {
@@ -98,9 +99,12 @@ function inventory($file)
     $fileLoader = new FileLoader();
     $fileLoader->load($file);
 
-    foreach ($fileLoader->getHosts() as $host) {
+    $hosts = $fileLoader->getHosts();
+    foreach ($hosts as $host) {
         $deployer->hosts->set($host->getHostname(), $host);
     }
+
+    return new Proxy($hosts);
 }
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I fixed it because I can not do the operation written in the documentaion.
https://deployer.org/docs/hosts#multiple-hosts

```php
inventory('hosts.yml') // ← not Proxy return!
    ->roles('app')
    ...
```
