### PR TITLE
Added platform config to composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Host's `roles()` API now can accept arrays too 
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1390]
 - Added artisan:migrate:fresh task for laravel recipe
+- Added platform config to composer.json [#1426]
 
 ### Fixed
 - Fixed bug when config:hosts shows more than one table of hosts [#1403]
@@ -319,6 +320,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1426]: https://github.com/deployphp/deployer/pull/1426
 [#1413]: https://github.com/deployphp/deployer/pull/1413
 [#1403]: https://github.com/deployphp/deployer/pull/1403
 [#1390]: https://github.com/deployphp/deployer/pull/1390

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "phpunit/phpunit": "~6.1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "7.0.0"
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | xx

Added platform config to composer.json.
This ensures compatibility of composer.lock.

https://getcomposer.org/doc/06-config.md#platform