### PR TITLE
permission denied for the git working direcotry

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -76,7 +76,8 @@ task('deploy:update_code', function () {
             $depth = '';
         }
     }
-
+    
+    cd('{{deploy_path}}');
     if ($gitCache && has('previous_release')) {
         try {
             run("$git clone $at $recursive -q --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);


### PR DESCRIPTION
When using the "become" option in a host configuration, the work directory for git needs to be accesible for that user.
For example, the homedirectory from the user I use to SSH isn't readable for the user I use to deploy, so it fails with a "permission denied".
(also make sure to set the HOME enviroment variable so the correct git configuation can be read if needed)

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

