### PR TITLE
Allow for naming the symbolic link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [v6.0.3...master](https://github.com/deployphp/deployer/compare/v6.0.3...master)
 
 ### Changed
+- Added support for naming the symbolic link
 - Added support for GroupTask in invoke() [#1364]
 - Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
 - Host's `roles()` API now can accept arrays too 

--- a/recipe/deploy/symlink.php
+++ b/recipe/deploy/symlink.php
@@ -9,13 +9,15 @@ namespace Deployer;
 
 desc('Creating symlink to release');
 task('deploy:symlink', function () {
+    $symlink_name = get('symlink_name', 'current');
+
     if (get('use_atomic_symlink')) {
-        run("mv -T {{deploy_path}}/release {{deploy_path}}/current");
+        run("mv -T {{deploy_path}}/release {{deploy_path}}/{$symlink_name}");
     } else {
         // Atomic symlink does not supported.
         // Will use simple≤ two steps switch.
 
-        run("cd {{deploy_path}} && {{bin/symlink}} {{release_path}} current"); // Atomic override symlink.
+        run("cd {{deploy_path}} && {{bin/symlink}} {{release_path}} {$symlink_name}"); // Atomic override symlink.
         run("cd {{deploy_path}} && rm release"); // Remove release link.
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This is a feature I needed which made me think I'm not the only one.
It's backwards compatible and allows for changing the symbolic link name (`current`) to a user defined value, like this:

    set('symlink_name', 'latest');