### PR TITLE
Add a variable for "realhostname"

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -35,6 +35,10 @@ set('hostname', function () {
     return Context::get()->getHost()->getHostname();
 });
 
+set('realhostname', function () {
+    return Context::get()->getHost()->getRealHostname();
+});
+
 set('user', function () {
     try {
         return runLocally('git config --get user.name');


### PR DESCRIPTION
In a setup like this:
```
host('production')
    ->hostname('server.example.com)
    ->user('example')
    ->forwardAgent(true)
    ->set('environment', 'production')
    ->set('deploy_path', '/var/www');
```

the `hostname`  variable is actually the stage name (`production`) rather than the hostname (`server.example.com`). 

This PR adds a `realhostname` variable that can be used to refer to .. well, the real hostname :smile: 