### PR TITLE
support php7 \Errors in CommandEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changed
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1391]
 
+### Fixed
+- support php7 \Errors in CommandEvent [#1442]
+
 ## v4.3.1
 [v4.3.0...v4.3.1](https://github.com/deployphp/deployer/compare/v4.3.0...v4.3.1)
 

--- a/src/Console/CommandEvent.php
+++ b/src/Console/CommandEvent.php
@@ -24,7 +24,7 @@ class CommandEvent
      * @param $command
      * @param $input
      * @param $output
-     * @param \Exception|\Error $exception
+     * @param \Throwable $exception
      * @param $exitCode
      */
     public function __construct(Command $command, InputInterface $input, OutputInterface $output, $exception = null, $exitCode = 0)

--- a/src/Console/CommandEvent.php
+++ b/src/Console/CommandEvent.php
@@ -24,10 +24,10 @@ class CommandEvent
      * @param $command
      * @param $input
      * @param $output
-     * @param $exception
+     * @param \Exception|\Error $exception
      * @param $exitCode
      */
-    public function __construct(Command $command, InputInterface $input, OutputInterface $output, \Exception $exception = null, $exitCode = 0)
+    public function __construct(Command $command, InputInterface $input, OutputInterface $output, $exception = null, $exitCode = 0)
     {
         $this->command = $command;
         $this->input = $input;
@@ -61,7 +61,7 @@ class CommandEvent
     }
 
     /**
-     * @return \Exception
+     * @return \Exception|\Error
      */
     public function getException()
     {

--- a/src/Console/CommandEvent.php
+++ b/src/Console/CommandEvent.php
@@ -61,7 +61,7 @@ class CommandEvent
     }
 
     /**
-     * @return \Exception|\Error
+     * @return \Throwable
      */
     public function getException()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

should fix the typeerror:

```php
[ERROR] TypeError: Argument 4 passed to Deployer\Console\CommandEvent::__construct() must be an instance of Exception,
         instance of Error given, called in phar:///usr/local/bin/dep/src/Console/Application.php on line 131 and
         defined in phar:///usr/local/bin/dep/src/Console/CommandEvent.php:30
         Stack trace:
         #0 phar:///usr/local/bin/dep/src/Console/Application.php(131):
         Deployer\Console\CommandEvent->__construct(Object(Deployer\Console\TaskCommand),
         Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput),
         Object(Error), 0)
         #1 phar:///usr/local/bin/dep/vendor/symfony/console/Application.php(223):
         Deployer\Console\Application->doRunCommand(Object(Deployer\Console\TaskCommand),
         Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
         #2 phar:///usr/local/bin/dep/vendor/symfony/console/Application.php(130):
         Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput),
         Object(Symfony\Component\Console\Output\ConsoleOutput))
         #3 phar:///usr/local/bin/dep/src/Deployer.php(194):
         Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput),
         Object(Symfony\Component\Console\Output\ConsoleOutput))
         #4 phar:///usr/local/bin/dep/bin/dep(119): Deployer\Deployer->run()
         #5 /usr/local/bin/dep(4): require('phar:///usr/loc...')
         #6 {main}

```
