### PR TITLE
moved symfony finder to dev-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1390]
 - Added artisan:migrate:fresh task for laravel recipe
 - Added platform config to composer.json [#1426]
+- Moved symfony finder to dev-dependency [#1452]
 
 ### Fixed
 - Fixed bug when config:hosts shows more than one table of hosts [#1403]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1452]: https://github.com/deployphp/deployer/pull/1452
 [#1426]: https://github.com/deployphp/deployer/pull/1426
 [#1413]: https://github.com/deployphp/deployer/pull/1413
 [#1403]: https://github.com/deployphp/deployer/pull/1403

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
         "deployer/phar-update": "~2.0",
         "pimple/pimple": "~3.0",
         "symfony/console": "~2.7|~3.0",
-        "symfony/finder": "~2.7|~3.0",
         "symfony/process": "~2.7|~3.0",
         "symfony/yaml": "~2.7|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.1"
+        "phpunit/phpunit": "~6.1",      
+        "symfony/finder": "~2.7|~3.0"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

seems like the finder is not required for deployer itself, just for the build and phpcs.

Moved it to be a dev dependency so hopefully it wont be bundled with the deployer phar