### PR TITLE
Magento2: use setup:upgrade --keep-generated

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -52,8 +52,7 @@ task('magento:maintenance:disable', function () {
 
 desc('Upgrade magento database');
 task('magento:upgrade:db', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:db-schema:upgrade");
-    run("{{bin/php}} {{release_path}}/bin/magento setup:db-data:upgrade");
+    run("{{bin/php}} {{release_path}}/bin/magento setup:upgrade --keep-generated");
 });
 
 desc('Flush Magento Cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

http://devdocs.magento.com/guides/v2.2/config-guide/deployment/single-machine.html

Suggest to just update setup:upgrade. As noted [here](http://devdocs.magento.com/guides/v2.2/install-gde/install/cli/install-cli-uninstall.html#instgde-install-keep) you can keep generated code, which saves time for deploying. This is essentially the same but with one command.