### PR TITLE
Get releases list before create metadata for current release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 [v6.0.4...master](https://github.com/deployphp/deployer/compare/v6.0.4...master)
 
+### Fixed
+- Fixed `previous_release` var
 
 ## v6.0.4
 [v6.0.3...v6.0.4](https://github.com/deployphp/deployer/compare/v6.0.3...v6.0.4)

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -116,6 +116,7 @@ task('deploy:release', function () {
     }
 
     $releasePath = parse("{{deploy_path}}/releases/{{release_name}}");
+    $releasesList = get('releases_list');
 
     // Metainfo.
     $date = run('date +"%Y%m%d%H%M%S"');
@@ -126,8 +127,6 @@ task('deploy:release', function () {
     // Make new release
     run("mkdir $releasePath");
     run("{{bin/symlink}} $releasePath {{deploy_path}}/release");
-
-    $releasesList = get('releases_list');
 
     // Add to releases list
     array_unshift($releasesList, $releaseName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | xx

Var `$releasesList` must be set before creating metainfo and folder for current release. Now current release name added in `$releasesList` twice.

```php
<?php
    // Save metainfo about release
    run("echo '$date,{{release_name}}' >> .dep/releases");

    // Make new release
    run("mkdir $releasePath");
    run("{{bin/symlink}} $releasePath {{deploy_path}}/release");

    $releasesList = get('releases_list'); // <-- Current release version already hear

    // Add to releases list
    array_unshift($releasesList, $releaseName);
    set('releases_list', $releasesList); // <-- Release version add to array again

    // Set previous_release
    if (isset($releasesList[1])) { // <-- 0 and 1 elements of array is a __current release__
        set('previous_release', "{{deploy_path}}/releases/{$releasesList[1]}");
    }
```

Thanks.