### PR TITLE
print ssh commands when running in debug-mode (-vvv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+- print ssh commands when running in debug-mode (-vvv) [#1461]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -337,6 +338,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1461]: https://github.com/deployphp/deployer/pull/1461
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452
 [#1426]: https://github.com/deployphp/deployer/pull/1426

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -70,7 +70,7 @@ class Client
             if ($this->output->isDebug()) {
                 $this->pop->writeln(Process::OUT, $host->getHostname(), $ssh);
             }
-            
+
             $process = new Process($ssh);
             $process
                 ->setTimeout($config['timeout'])
@@ -151,7 +151,7 @@ class Client
         if ($this->output->isDebug()) {
             $this->pop->writeln(Process::OUT, $host->getHostname(), $ssh);
         }
-        
+
         $process = new Process();
         $process->run($ssh);
         return (bool)preg_match('/Master running/', $process->getOutput());
@@ -164,7 +164,7 @@ class Client
             ['pipe', 'w'],
             ['pipe', 'w'],
         ];
-        
+
         if ($this->output->isDebug()) {
             $this->pop->writeln(Process::OUT, $host->getHostname(), $command);
         }        

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -167,7 +167,7 @@ class Client
 
         if ($this->output->isDebug()) {
             $this->pop->writeln(Process::OUT, $host->getHostname(), $command);
-        }        
+        }
 
         // Don't read from stderr, there is a bug in OpenSSH_7.2p2 (stderr doesn't closed with ControlMaster)
 

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -67,6 +67,10 @@ class Client
             $command = escapeshellarg($command);
 
             $ssh = "ssh $sshArguments $host $command";
+            if ($this->output->isDebug()) {
+                $this->pop->writeln(Process::OUT, $host->getHostname(), $ssh);
+            }
+            
             $process = new Process($ssh);
             $process
                 ->setTimeout($config['timeout'])
@@ -81,6 +85,9 @@ class Client
         }
 
         $ssh = "ssh $sshArguments $host $become 'bash -s; printf \"[exit_code:%s]\" $?;'";
+        if ($this->output->isDebug()) {
+            $this->pop->writeln(Process::OUT, $host->getHostname(), $ssh);
+        }
 
         $process = new Process($ssh);
         $process
@@ -127,7 +134,8 @@ class Client
                 $this->pop->writeln(Process::OUT, $host->getHostname(), 'ssh multiplexing initialization');
             }
 
-            $output = $this->exec("ssh -N $sshArguments $host");
+            $ssh = "ssh -N $sshArguments $host";
+            $output = $this->exec($host, $ssh);
 
             if ($this->output->isVeryVerbose()) {
                 $this->pop->writeln(Process::OUT, $host->getHostname(), $output);
@@ -139,18 +147,27 @@ class Client
 
     private function isMultiplexingInitialized(Host $host, Arguments $sshArguments)
     {
-        $process = new Process("ssh -O check $sshArguments $host 2>&1");
-        $process->run();
+        $ssh = "ssh -O check $sshArguments $host 2>&1";
+        if ($this->output->isDebug()) {
+            $this->pop->writeln(Process::OUT, $host->getHostname(), $ssh);
+        }
+        
+        $process = new Process();
+        $process->run($ssh);
         return (bool)preg_match('/Master running/', $process->getOutput());
     }
 
-    private function exec($command, &$exitCode = null)
+    private function exec(Host $host, $command, &$exitCode = null)
     {
         $descriptors = [
             ['pipe', 'r'],
             ['pipe', 'w'],
             ['pipe', 'w'],
         ];
+        
+        if ($this->output->isDebug()) {
+            $this->pop->writeln(Process::OUT, $host->getHostname(), $command);
+        }        
 
         // Don't read from stderr, there is a bug in OpenSSH_7.2p2 (stderr doesn't closed with ControlMaster)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

added more debug output in ssh-client to ease debugging of possible host-configuration problems.

hopefully it gets easier to find the root-cause for https://github.com/deployphp/deployer/issues/1449 with this change applied.