### PR TITLE
use try/finally to make sure working-path restore on Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
 ### Fixed
-- use try/finally to make sure working-path restore on Exceptions [#1463]
+- fix within() to also restore the working-path when the given callback throws a Exception [#1463]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+### Fixed
+- use try/finally to make sure working-path restore on Exceptions [#1463]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -337,6 +339,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452
 [#1426]: https://github.com/deployphp/deployer/pull/1426

--- a/src/functions.php
+++ b/src/functions.php
@@ -263,7 +263,7 @@ function within($path, $callback)
         $callback();
     } finally {
         set('working_path', $lastWorkingPath);
-    }        
+    }
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -258,8 +258,8 @@ function cd($path)
 function within($path, $callback)
 {
     $lastWorkingPath = get('working_path', '');
-    set('working_path', parse($path));
     try {
+        set('working_path', parse($path));
         $callback();
     } finally {
         set('working_path', $lastWorkingPath);

--- a/src/functions.php
+++ b/src/functions.php
@@ -259,8 +259,11 @@ function within($path, $callback)
 {
     $lastWorkingPath = get('working_path', '');
     set('working_path', parse($path));
-    $callback();
-    set('working_path', $lastWorkingPath);
+    try {
+        $callback();
+    } finally {
+        set('working_path', $lastWorkingPath);
+    }        
 }
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

fix `within()` to also restore the working-path when the given callback throws a Exception