### PR TITLE
phpdocs on shallow()

### DIFF
--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -77,7 +77,7 @@ class Task
     private $hasRun = false;
 
     /**
-     * Shallow task will not print execution message/finish massage.
+     * Shallow task will not print execution message/finish messages.
      * Useful for success messages and info printing.
      *
      * @var bool
@@ -295,6 +295,9 @@ class Task
 
     /**
      * Sets task shallow.
+     *
+     * Shallow task will not print execution message/finish messages.
+     *
      * @return $this
      */
     public function shallow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

just phpdocs. copy description to the shallow() method as this is what people see when working with IDEs.