### PR TITLE
use a single square-brocket in commandsSupportsOption() like we do in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
 ### Fixed
-- fix within() to also restore the working-path when the given callback throws a Exception [#1463]
+- Fix within() to also restore the working-path when the given callback throws a Exception [#1463]
+- Fix "[[: not found" warning in `commandSupportsOption()` [#1445]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -339,6 +340,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1445]: https://github.com/deployphp/deployer/issues/1445
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452

--- a/src/functions.php
+++ b/src/functions.php
@@ -727,7 +727,7 @@ function commandExist($command)
 
 function commandSupportsOption($command, $option)
 {
-    return test("[[ $(man $command 2>&1 || $command -h 2>&1 || $command --help 2>&1) =~ '$option' ]]");
+    return test("[ $(man $command 2>&1 || $command -h 2>&1 || $command --help 2>&1) =~ '$option' ]");
 }
 
 /**


### PR DESCRIPTION
… all other calls to test()

| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  |  No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1445

should fix "[[: not found" warning in `commandSupportsOption()`

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/deployer/blob/master/CHANGELOG.md)
> * Add description under added/changed/fixed section.
> * Add reference to closed issues `[#000]`.
> * Add link to issue in the end of document.
