### PR TITLE
print the task description when in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+### Added
+
+- DX: print the task description when in debug mode, to get a human friendly message what the task is supposed todo [#1468]
+
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
 
@@ -339,6 +343,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1468]: https://github.com/deployphp/deployer/pull/1468
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452

--- a/src/Console/Output/Informer.php
+++ b/src/Console/Output/Informer.php
@@ -40,7 +40,7 @@ class Informer
             $this->output->writeln("➤ Executing task <info>{$task->getName()}</info>");
 
             if ($this->output->isDebug() && $task->getDescription()) {
-                $this->output->writeln("  ".$task->getDescription());
+                $this->output->writeln("  <comment>".$task->getDescription() ."<comment>");
             }
 
             $this->output->setWasWritten(false);

--- a/src/Console/Output/Informer.php
+++ b/src/Console/Output/Informer.php
@@ -38,6 +38,11 @@ class Informer
             !$task->isShallow()
         ) {
             $this->output->writeln("➤ Executing task <info>{$task->getName()}</info>");
+
+            if ($this->output->isDebug() && $task->getDescription()) {
+                $this->output->writeln("  ".$task->getDescription());
+            }
+
             $this->output->setWasWritten(false);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes 
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A 

DX: print the task description when in debug mode, to get a human friendly message what the task is supposed todo.

especially for the builtin tasks this is very helpful.