### PR TITLE
added deploy:islocked task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+### Added
+- `deploy:islocked` task which allows to determine if a lock was already acquired by another process/task [#1469]
+
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
 
@@ -339,6 +342,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1469]: https://github.com/deployphp/deployer/pull/1469
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -29,3 +29,8 @@ desc('Unlock deploy');
 task('deploy:unlock', function () {
     run("rm -f {{deploy_path}}/.dep/deploy.lock");//always success
 });
+
+desc('Checks whether deploy is locked');
+task('deploy:islocked', function () {
+    return test("[ -f {{deploy_path}}/.dep/deploy.lock ]");
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes 
| BC breaks?    | No
| Deprecations? |  No
| Fixed tickets | N/A 

added `deploy:islocked` task which allows to determine if a lock was already acquired by another process/task. this can be usefull to fast fail before starting a extensive build-process and finally run into a "already locked" error after waiting mintues for a build.
