### PR TITLE
make sure `deploy:lock` can be called several times, when the lock wa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
 ### Fixed
-- fix within() to also restore the working-path when the given callback throws a Exception [#1463]
+- Make sure we can use invoke('deploy:lock'); several times within the recipe without errors [#1470]
+- Fix within() to also restore the working-path when the given callback throws a Exception [#1463]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -338,7 +339,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1470]: https://github.com/deployphp/deployer/pull/1470
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -11,6 +11,12 @@ use Deployer\Exception\GracefulShutdownException;
 
 desc('Lock deploy');
 task('deploy:lock', function () {
+
+    if (get('holds_deploy_lock')) {
+        // we already hold the lock
+        return;
+    }
+
     $locked = test("[ -f {{deploy_path}}/.dep/deploy.lock ]");
 
     if ($locked) {
@@ -22,10 +28,12 @@ task('deploy:lock', function () {
         );
     } else {
         run("touch {{deploy_path}}/.dep/deploy.lock");
+        set('holds_deploy_lock', true);
     }
 });
 
 desc('Unlock deploy');
 task('deploy:unlock', function () {
     run("rm -f {{deploy_path}}/.dep/deploy.lock");//always success
+    set('holds_deploy_lock', false);
 });


### PR DESCRIPTION
…s acquired successfully once

| Q             | A
| ------------- | ---
| Bug fix?      | Kindof
| New feature?  | Yes 
| BC breaks?    | Kindof
| Deprecations? | No
| Fixed tickets | N/A

Make sure we can use `invoke('deploy:lock');` several times within the recipe without errors

this changes allows recepies like
```php
task('build', function() {
    //...
    
    invoke('deploy:prepare'); // create basic folder structure
    invoke('deploy:lock');
    //...
    // runLocally('{{composer_command}}');
    // runLocally('npm install');
    // runLocally('{{grunt_command}}');
});

task('release', function() {
    //...
    
    invoke('deploy:prepare'); // create basic folder structure
    invoke('deploy:lock');
    //...
    // invoke('deploy:release');
    // upload($releaseTar, '{{release_path}}');
    // invoke('deploy:symlink');
    //...   
});

task('deploy', [
    'build',
    'release',
])->shallow();
```

without this change I can not do `dep deploy` because it would throw a error on the 2nd `deploy:lock` invocation