### PR TITLE
Add a description to the autocomplete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+### Added
+- Added a description to the autocomplete command [#1472]
+
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
 
@@ -338,7 +341,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455
 [#1452]: https://github.com/deployphp/deployer/pull/1452

--- a/src/Console/AutocompleteCommand.php
+++ b/src/Console/AutocompleteCommand.php
@@ -16,16 +16,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @codeCoverageIgnore
  */
 class AutocompleteCommand extends Command
-{
-    public function __construct()
+{    
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
     {
-        parent::__construct('autocomplete');
-        $this->addOption(
-            '--install',
-            null,
-            InputOption::VALUE_NONE
-        );
-    }
+        $this
+            ->setName('autocomplete')
+            ->setDescription('Install command line autocompletion capabilities')
+            ->addOption('--install', null, InputOption::VALUE_NONE);
+    }    
 
     /**
      * {@inheritdoc}

--- a/src/Console/AutocompleteCommand.php
+++ b/src/Console/AutocompleteCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @codeCoverageIgnore
  */
 class AutocompleteCommand extends Command
-{    
+{
     /**
      * {@inheritDoc}
      */
@@ -26,7 +26,7 @@ class AutocompleteCommand extends Command
             ->setName('autocomplete')
             ->setDescription('Install command line autocompletion capabilities')
             ->addOption('--install', null, InputOption::VALUE_NONE);
-    }    
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Added a description to the autocomplete command.

while at it use the prefered "configure" method instead of overwriting __construct().