### PR TITLE
prevent warning when pcntl_fork() is on disable_functions php.ini bla…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
+- `pcntl_fork` is blacklisted per default on ubuntu lts boxes. make sure deployer doesnt emit a warning in this case [#1476]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -341,6 +342,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,8 +343,8 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-[#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1481]: https://github.com/deployphp/deployer/issues/1481
+[#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/src/Utility/Reporter.php
+++ b/src/Utility/Reporter.php
@@ -17,7 +17,7 @@ class Reporter
     public static function report(array $stats)
     {
         $pid = null;
-        if (extension_loaded('pcntl')) {
+        if (extension_loaded('pcntl') && strpos(ini_get('disable_functions'), 'pcntl_fork') === false) {
             declare(ticks = 1);
             $pid = pcntl_fork();
         }

--- a/src/Utility/Reporter.php
+++ b/src/Utility/Reporter.php
@@ -17,7 +17,8 @@ class Reporter
     public static function report(array $stats)
     {
         $pid = null;
-        if (extension_loaded('pcntl') && strpos(ini_get('disable_functions'), 'pcntl_fork') === false) {
+        // make sure function is not disabled via php.ini "disable_functions"
+        if (extension_loaded('pcntl') && function_exists('pcntl_fork')) {
             declare(ticks = 1);
             $pid = pcntl_fork();
         }


### PR DESCRIPTION
…cklist

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A 

`pcntl_fork` is blacklisted per default on ubuntu lts boxes. make sure deployer doesnt emit a warning in this case.

Without this fix you get
```
PHP Warning:  pcntl_fork() has been disabled for security reasons in phar:///usr/local/bin/dep/src/Utility/Reporter.php on line 22
```