### PR TITLE
reduce number of run() calls in cleanup-task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
+### Changed
+- reduce number of run() calls in cleanup-task to optimize performance [#1483]
+
 ### Added
 - Added a description to the autocomplete command [#1472]
 
@@ -22,7 +25,7 @@
 ### Changed
 - Added support for GroupTask in invoke() [#1364]
 - Magento2 recipe optimizes the autoloader after the DI compilation [#1365]
-- Host's `roles()` API now can accept arrays too 
+- Host's `roles()` API now can accept arrays too
 - Fixed bug where wrong time format is passed to touch when deploying assets [#1390]
 - Added artisan:migrate:fresh task for laravel recipe
 - Added platform config to composer.json [#1426]
@@ -39,7 +42,7 @@
 ### Changed
 - Laravel version check defaults to 5.5 if not found [#1352]
 
-### Fixed 
+### Fixed
 - Updated Laravel recipe to not run `artisan:optimize` on Laravel >= 5.5, as that command is now deprecated ([see upgrade notes](https://laravel.com/docs/5.5/upgrade)) [#1352]
 
 
@@ -341,6 +344,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1483]: https://github.com/deployphp/deployer/pull/1483
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/recipe/deploy/cleanup.php
+++ b/recipe/deploy/cleanup.php
@@ -27,6 +27,5 @@ task('cleanup', function () {
         run("$sudo rm -rf {{deploy_path}}/releases/$release");
     }
 
-    run("cd {{deploy_path}} && if [ -e release ]; then $sudo rm release; fi");
-    run("cd {{deploy_path}} && if [ -h release ]; then $sudo rm release; fi");
+    run("cd {{deploy_path}} && if [ -e release ]; then $sudo rm release; fi && if [ -h release ]; then $sudo rm release; fi");
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | I guess No
| Deprecations? | No
| Fixed tickets | N/A

optimize `cleanup` task for speed by saving a single `run()` call.
in my setup this saves up to 10% of deployment time (measured with blackfire).

`run()` is a rather expensive operation because of the network, ssh and x-process overhead. every call counts.