### PR TITLE
speedup file-logging by buffer log-writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Added a description to the autocomplete command [#1472]
 - Added a log buffer to the FileHandler loggin to reduce overhead [#1485]
 - Log unhandled exceptions into logfile [#1481]
-- Added a log buffer to the FileHandler loggin to reduce overhead [#1485]
 
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
@@ -348,7 +347,6 @@
 [#1485]: https://github.com/deployphp/deployer/pull/1485
 [#1481]: https://github.com/deployphp/deployer/issues/1481
 [#1476]: https://github.com/deployphp/deployer/pull/1476
-[#1485]: https://github.com/deployphp/deployer/pull/1485
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
-- `pcntl_fork` is blacklisted per default on ubuntu lts boxes. make sure deployer doesnt emit a warning in this case [#1476]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -346,7 +345,6 @@
 
 [#1485]: https://github.com/deployphp/deployer/pull/1485
 [#1481]: https://github.com/deployphp/deployer/issues/1481
-[#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
+- `pcntl_fork` is blacklisted per default on ubuntu lts boxes. make sure deployer doesnt emit a warning in this case [#1476]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -343,6 +344,7 @@
 - Fixed remove of shared dir on first deploy
 
 [#1481]: https://github.com/deployphp/deployer/issues/1481
+[#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Added a description to the autocomplete command [#1472]
 - Log unhandled exceptions into logfile [#1481]
+- Added a log buffer to the FileHandler loggin to reduce overhead [#1485]
 
 ### Fixed
 - fix within() to also restore the working-path when the given callback throws a Exception [#1463]
@@ -345,6 +346,7 @@
 
 [#1481]: https://github.com/deployphp/deployer/issues/1481
 [#1476]: https://github.com/deployphp/deployer/pull/1476
+[#1485]: https://github.com/deployphp/deployer/pull/1485
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463
 [#1455]: https://github.com/deployphp/deployer/pull/1455

--- a/src/Logger/Handler/FileHandler.php
+++ b/src/Logger/Handler/FileHandler.php
@@ -25,7 +25,7 @@ class FileHandler implements HandlerInterface
         $this->buffer = '';
 
         // write remaining buffer to the log when php shuts down
-        register_shutdown_function(function() {
+        register_shutdown_function(function () {
             $this->flush();
         });
     }
@@ -39,7 +39,8 @@ class FileHandler implements HandlerInterface
         }
     }
 
-    private function flush() {
+    private function flush()
+    {
         file_put_contents($this->filePath, $this->buffer, FILE_APPEND);
         $this->buffer = '';
     }

--- a/src/Logger/Handler/FileHandler.php
+++ b/src/Logger/Handler/FileHandler.php
@@ -14,13 +14,33 @@ class FileHandler implements HandlerInterface
      */
     private $filePath;
 
+    /**
+     * @var string
+     */
+    private $buffer;
+
     public function __construct(string $filePath)
     {
         $this->filePath = $filePath;
+        $this->buffer = '';
+
+        // write remaining buffer to the log when php shuts down
+        register_shutdown_function(function() {
+            $this->flush();
+        });
     }
 
     public function log(string $message)
     {
-        file_put_contents($this->filePath, $message, FILE_APPEND);
+        $this->buffer .= $message;
+
+        if (strlen($this->buffer) > 4096) {
+            $this->flush();
+        }
+    }
+
+    private function flush() {
+        file_put_contents($this->filePath, $this->buffer, FILE_APPEND);
+        $this->buffer = '';
     }
 }

--- a/src/Utility/Reporter.php
+++ b/src/Utility/Reporter.php
@@ -17,7 +17,8 @@ class Reporter
     public static function report(array $stats)
     {
         $pid = null;
-        if (extension_loaded('pcntl')) {
+        // make sure function is not disabled via php.ini "disable_functions"
+        if (extension_loaded('pcntl') && function_exists('pcntl_fork')) {
             declare(ticks = 1);
             $pid = pcntl_fork();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

log-writting was the second most consumer of time before this change when using the `--log` option.
after this change `file_put_contents` is no longer visible in perf profiles, which in my case reduces deployment time by ~30seconds.

`/usr/bin/php ../tools/deployer/bin/dep deploy ci --log deployer.log`

See the profiles (these links are valid for 30 days, starting on 29.12.2017):

Before
https://blackfire.io/profiles/d7e7bf13-7056-4c95-8946-08967b8aab22/graph
After
https://blackfire.io/profiles/d78167a4-dea0-47d7-ae12-b847d08d09b3/graph
Delta
https://blackfire.io/profiles/compare/fa05f5b7-21f6-473f-922f-ae4e3e86ae50/graph