### PR TITLE
Add DebugCommand to display task execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1488]: https://github.com/deployphp/deployer/issues/1488
 [#1481]: https://github.com/deployphp/deployer/issues/1481
 [#1472]: https://github.com/deployphp/deployer/pull/1472
 [#1463]: https://github.com/deployphp/deployer/pull/1463

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,8 +346,8 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-[#1488]: https://github.com/deployphp/deployer/issues/1488
 [#1513]: https://github.com/deployphp/deployer/pull/1513
+[#1488]: https://github.com/deployphp/deployer/issues/1488
 [#1481]: https://github.com/deployphp/deployer/issues/1481
 [#1476]: https://github.com/deployphp/deployer/pull/1476
 [#1472]: https://github.com/deployphp/deployer/pull/1472

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 
 ### Added
+- Added debug:task command to display the order of task execution [#1488]
 - Added a description to the autocomplete command [#1472]
 - Log unhandled exceptions into logfile [#1481]
 

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -34,7 +34,7 @@ class DebugCommand extends Command
     /**
      * @var array
      */
-    private $flatTree;
+    private $tree;
 
     /**
      * Depth of nesting (for rendering purposes)
@@ -55,7 +55,7 @@ class DebugCommand extends Command
         parent::__construct('debug:task');
         $this->setDescription('Display the task-tree for a given task');
         $this->deployer = $deployer;
-        $this->flatTree = [];
+        $this->tree = [];
     }
 
     /**
@@ -66,7 +66,7 @@ class DebugCommand extends Command
         $this->addArgument(
             'task',
             InputArgument::REQUIRED,
-            'Task to display the tree from'
+            'Task to display the tree for'
         );
     }
 
@@ -86,11 +86,11 @@ class DebugCommand extends Command
     private function buildTree($taskName)
     {
         $this->tasks = Deployer::get()->tasks;
-        $this->createTreeFromTaskName($taskName, '');
+        $this->createTreeFromTaskName($taskName, '', true);
     }
 
     /**
-     * Create tree from the given taskname
+     * Create a tree from the given taskname
      *
      * @param string $taskName
      * @param string $postfix
@@ -109,6 +109,8 @@ class DebugCommand extends Command
         }
 
         if ($task instanceof GroupTask) {
+
+            $isLast = $isLast && empty($task->getAfter());
 
             $this->addTaskToTree($task->getName() . $postfix, true, $isLast);
 
@@ -144,7 +146,7 @@ class DebugCommand extends Command
     }
 
     private function addTaskToTree($taskName, $hasChildren = false, $isLast = false) {
-        $this->flatTree[] = [
+        $this->tree[] = [
             'taskName' => $taskName,
             'depth' => $this->depth,
             'hasChildren' => $hasChildren,
@@ -157,20 +159,20 @@ class DebugCommand extends Command
     {
         $this->output->writeln("The task-tree for <fg=cyan>$taskName</fg=cyan>:");
 
-        $repeatCount = 4;
+        $REPEAT_COUNT = 4;
 
-        foreach ($this->flatTree as $treeItem) {
+        foreach ($this->tree as $treeItem) {
             $depth = $treeItem['depth'];
 
-            $startSymbol = $treeItem['isLast'] || $treeItem === end($this->flatTree) ? '└' : '├';
+            $startSymbol = $treeItem['isLast'] || $treeItem === end($this->tree) ? '└' : '├';
 
             $prefix = '';
 
             for ($i = 0; $i < $depth; $i++) {
                 if (in_array($i, $treeItem['openDepths'])) {
-                    $prefix .= '│' . str_repeat(' ', $repeatCount - 1);
+                    $prefix .= '│' . str_repeat(' ', $REPEAT_COUNT - 1);
                 } else {
-                    $prefix .= str_repeat(' ', $repeatCount);
+                    $prefix .= str_repeat(' ', $REPEAT_COUNT);
                 }
             }
 

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -103,7 +103,7 @@ class DebugCommand extends Command
         if ($task->getBefore()) {
             $beforePostfix = sprintf(' [before:%s]', $task->getName());
 
-            foreach($task->getBefore() as $beforeTask) {
+            foreach ($task->getBefore() as $beforeTask) {
                 $this->createTreeFromTaskName($beforeTask, $beforePostfix);
             }
         }
@@ -139,7 +139,7 @@ class DebugCommand extends Command
         if ($task->getAfter()) {
             $afterPostfix = sprintf(' [after:%s]', $task->getName());
 
-            foreach($task->getAfter() as $afterTask) {
+            foreach ($task->getAfter() as $afterTask) {
                 $this->createTreeFromTaskName($afterTask, $afterPostfix);
             }
         }

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -109,7 +109,6 @@ class DebugCommand extends Command
         }
 
         if ($task instanceof GroupTask) {
-
             $isLast = $isLast && empty($task->getAfter());
 
             $this->addTaskToTree($task->getName() . $postfix, true, $isLast);
@@ -131,7 +130,6 @@ class DebugCommand extends Command
             }
 
             $this->depth--;
-
         } else {
             $this->addTaskToTree($task->getName() . $postfix, false, $isLast);
         }
@@ -145,7 +143,8 @@ class DebugCommand extends Command
         }
     }
 
-    private function addTaskToTree($taskName, $hasChildren = false, $isLast = false) {
+    private function addTaskToTree($taskName, $hasChildren = false, $isLast = false)
+    {
         $this->tree[] = [
             'taskName' => $taskName,
             'depth' => $this->depth,

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -110,7 +110,7 @@ class DebugCommand extends Command
 
         if ($task instanceof GroupTask) {
 
-            $this->addTaskToTree($task->getName(), true, $isLast);
+            $this->addTaskToTree($task->getName() . $postfix, true, $isLast);
 
             if (!$isLast) {
                 $this->openGroupDepths[] = $this->depth;

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -1,0 +1,113 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console;
+
+use Deployer\Deployer;
+use Deployer\Exception\Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\OutputInterface as Output;
+
+class DebugCommand extends Command
+{
+    /**
+     * @var Deployer
+     */
+    private $deployer;
+
+    /**
+     * @param Deployer $deployer
+     */
+    public function __construct(Deployer $deployer)
+    {
+        parent::__construct('debug:task');
+        $this->setDescription('Display the task-tree for a given task');
+        $this->deployer = $deployer;
+    }
+
+    /**
+     * Configures the command
+     */
+    protected function configure()
+    {
+        $this->addArgument(
+            'task',
+            InputArgument::REQUIRED,
+            'Task to display the tree from'
+        );
+        $this->addArgument(
+            'stage',
+            InputArgument::OPTIONAL,
+            'Stage or hostname'
+        );
+        $this->addOption(
+            'hosts',
+            null,
+            Option::VALUE_REQUIRED,
+            'Host to show the task-tree for, comma separated, supports ranges [:]'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(Input $input, Output $output)
+    {
+        $rootTask = $input->getArgument('task');
+        $stage = $input->hasArgument('stage') ? $input->getArgument('stage') : null;
+        $hosts = $input->getOption('hosts');
+
+        if (!empty($hosts)) {
+            $hosts = $this->deployer->hostSelector->getByHostnames($hosts);
+        } else {
+            $hosts = $this->deployer->hostSelector->getHosts($stage);
+        }
+
+        if (empty($hosts)) {
+            throw new Exception('No host selected');
+        }
+
+        $tasks = Deployer::get()->scriptManager->getTasks($rootTask, $hosts);
+
+        if (empty($tasks)) {
+            throw new Exception('No task to be shown, because the selected hosts do not meet the conditions of the tasks');
+        }
+
+        $output->writeln("The task-tree for <fg=cyan>$rootTask</fg=cyan>:");
+
+        $beforeMap = [];
+        $afterMap = [];
+
+        //index the before and after tasks
+        foreach($tasks as $task) {
+            $currentTaskName = $task->getName();
+
+            foreach($task->getBefore() as $beforeTaskName) {
+                $beforeMap[$beforeTaskName] = $currentTaskName;
+            }
+            foreach($task->getAfter() as $afterTaskName) {
+                $afterMap[$afterTaskName] = $currentTaskName;
+            }
+        }
+
+        foreach($tasks as $task) {
+            $currentTaskName = $task->getName();
+            $beforeAfterString = '';
+
+            if (array_key_exists($currentTaskName, $beforeMap)) {
+                $beforeAfterString = sprintf('[before: %s]', $beforeMap[$currentTaskName]);
+            } elseif (array_key_exists($currentTaskName, $afterMap)) {
+                $beforeAfterString = sprintf('[after: %s]', $afterMap[$currentTaskName]);
+            }
+
+            $output->writeln(sprintf(' - %s %s', $currentTaskName, $beforeAfterString));
+        }
+    }
+}

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -10,6 +10,7 @@ namespace Deployer\Console;
 use Deployer\Deployer;
 use Deployer\Exception\Exception;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
@@ -80,6 +81,7 @@ class DebugCommand extends Command
             throw new Exception('No task to be shown, because the selected hosts do not meet the conditions of the tasks');
         }
 
+        $output->writeln('');
         $output->writeln("The task-tree for <fg=cyan>$rootTask</fg=cyan>:");
 
         $beforeMap = [];
@@ -97,17 +99,22 @@ class DebugCommand extends Command
             }
         }
 
+        $rows = [];
         foreach($tasks as $task) {
             $currentTaskName = $task->getName();
-            $beforeAfterString = '';
 
-            if (array_key_exists($currentTaskName, $beforeMap)) {
-                $beforeAfterString = sprintf('[before: %s]', $beforeMap[$currentTaskName]);
-            } elseif (array_key_exists($currentTaskName, $afterMap)) {
-                $beforeAfterString = sprintf('[after: %s]', $afterMap[$currentTaskName]);
-            }
-
-            $output->writeln(sprintf(' - %s %s', $currentTaskName, $beforeAfterString));
+            $rows[] = [
+                count($rows),
+                $currentTaskName,
+                array_key_exists($currentTaskName, $beforeMap) ? $beforeMap[$currentTaskName] : null,
+                array_key_exists($currentTaskName, $afterMap) ? $afterMap[$currentTaskName] : null
+            ];
         }
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Index', 'Task', 'Before', 'After'])
+            ->setRows($rows);
+        $table->render();
     }
 }

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -88,19 +88,19 @@ class DebugCommand extends Command
         $afterMap = [];
 
         //index the before and after tasks
-        foreach($tasks as $task) {
+        foreach ($tasks as $task) {
             $currentTaskName = $task->getName();
 
-            foreach($task->getBefore() as $beforeTaskName) {
+            foreach ($task->getBefore() as $beforeTaskName) {
                 $beforeMap[$beforeTaskName] = $currentTaskName;
             }
-            foreach($task->getAfter() as $afterTaskName) {
+            foreach ($task->getAfter() as $afterTaskName) {
                 $afterMap[$afterTaskName] = $currentTaskName;
             }
         }
 
         $rows = [];
-        foreach($tasks as $task) {
+        foreach ($tasks as $task) {
             $currentTaskName = $task->getName();
 
             $rows[] = [

--- a/src/Console/DebugCommand.php
+++ b/src/Console/DebugCommand.php
@@ -83,6 +83,12 @@ class DebugCommand extends Command
         $this->outputTree($rootTaskName);
     }
 
+    /**
+     * Build the tree based on the given taskName
+     * @param $taskName
+     *
+     * @return void
+     */
     private function buildTree($taskName)
     {
         $this->tasks = Deployer::get()->tasks;
@@ -95,6 +101,8 @@ class DebugCommand extends Command
      * @param string $taskName
      * @param string $postfix
      * @param bool $isLast
+     *
+     * @return void
      */
     private function createTreeFromTaskName($taskName, $postfix = '', $isLast = false)
     {
@@ -111,7 +119,7 @@ class DebugCommand extends Command
         if ($task instanceof GroupTask) {
             $isLast = $isLast && empty($task->getAfter());
 
-            $this->addTaskToTree($task->getName() . $postfix, true, $isLast);
+            $this->addTaskToTree($task->getName() . $postfix, $isLast);
 
             if (!$isLast) {
                 $this->openGroupDepths[] = $this->depth;
@@ -131,7 +139,7 @@ class DebugCommand extends Command
 
             $this->depth--;
         } else {
-            $this->addTaskToTree($task->getName() . $postfix, false, $isLast);
+            $this->addTaskToTree($task->getName() . $postfix, $isLast);
         }
 
         if ($task->getAfter()) {
@@ -143,21 +151,34 @@ class DebugCommand extends Command
         }
     }
 
-    private function addTaskToTree($taskName, $hasChildren = false, $isLast = false)
+    /**
+     * Add the (formatted) taskName to the rendertree, with some additional information
+     *
+     * @param string $taskName formatted with prefixes if needed
+     * @param bool $isLast indication for what symbol to use for rendering
+     */
+    private function addTaskToTree($taskName, $isLast = false)
     {
         $this->tree[] = [
             'taskName' => $taskName,
             'depth' => $this->depth,
-            'hasChildren' => $hasChildren,
             'isLast' => $isLast,
             'openDepths' => $this->openGroupDepths
         ];
     }
 
+    /**
+     * Render the tree, after everything is build
+     *
+     * @param $taskName
+     */
     private function outputTree($taskName)
     {
         $this->output->writeln("The task-tree for <fg=cyan>$taskName</fg=cyan>:");
 
+        /**
+         * @var $REPEAT_COUNT number of spaces for each depth increase
+         */
         $REPEAT_COUNT = 4;
 
         foreach ($this->tree as $treeItem) {

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -11,6 +11,7 @@ use Deployer\Collection\Collection;
 use Deployer\Console\Application;
 use Deployer\Console\AutocompleteCommand;
 use Deployer\Console\CommandEvent;
+use Deployer\Console\DebugCommand;
 use Deployer\Console\InitCommand;
 use Deployer\Console\Output\Informer;
 use Deployer\Console\Output\OutputWatcher;
@@ -224,6 +225,7 @@ class Deployer extends Container
         $this->getConsole()->add($this['init_command']);
         $this->getConsole()->add(new SshCommand($this));
         $this->getConsole()->add(new RunCommand($this));
+        $this->getConsole()->add(new DebugCommand($this));
         $this->getConsole()->add(new AutocompleteCommand());
         $this->getConsole()->afterRun([$this, 'collectAnonymousStats']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1488 

Not sure if this was the correct route, to create a command for it. I noticed (after creating the command) that some other utilities (like the `config/hosts.php`) were just written as tasks.
If I need to rewrite this - let me know.