### PR TITLE
Update silverstripe recipe to support silverstripe 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- Update silverstripe recipe to support silverstripe 4
+
 ## master
 [v6.0.5...master](https://github.com/deployphp/deployer/compare/v6.0.5...master)
 

--- a/recipe/silverstripe.php
+++ b/recipe/silverstripe.php
@@ -16,15 +16,28 @@ set('shared_dirs', [
 // Silverstripe writable dirs
 set('writable_dirs', ['assets']);
 
+// Silverstripe cli script
+set('silverstripe_cli_script', function () {
+    $paths = [
+        'framework/cli-script.php',
+        'vendor/silverstripe/framework/cli-script.php'
+    ];
+    foreach ($paths as $path) {
+        if (test('[ -f {{release_path}}/'.$path.' ]')) {
+            return $path;
+        }
+    }
+});
+
 /**
  * Helper tasks
  */
 task('silverstripe:build', function () {
-    return run('{{bin/php}} {{release_path}}/framework/cli-script.php /dev/build');
+    return run('{{bin/php}} {{release_path}}/{{silverstripe_cli_script}} /dev/build');
 })->desc('Run /dev/build');
 
 task('silverstripe:buildflush', function () {
-    return run('{{bin/php}} {{release_path}}/framework/cli-script.php /dev/build flush=all');
+    return run('{{bin/php}} {{release_path}}/{{silverstripe_cli_script}} /dev/build flush=all');
 })->desc('Run /dev/build?flush=all');
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  |  No
| BC breaks?    |  No
| Deprecations? | No
| Fixed tickets | N/A

SIlverstripe 4 has moved their framework from the project root to the /vendor/ folder.

This pull requests fixes an issue where deployer attempts to call the SilverStripe 3 tasks on a Silverstripe 4 installation  
