### PR TITLE
Make used shell configurable

### DIFF
--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -53,6 +53,7 @@ class FileLoader
                     'multiplexing',
                     'sshOptions',
                     'sshFlags',
+                    'shellCommand',
                 ];
 
                 foreach ($methods as $method) {

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -25,6 +25,7 @@ class Host
     private $forwardAgent = true;
     private $multiplexing = null;
     private $sshArguments;
+    private $shellCommand = 'bash -s';
 
     /**
      * @param string $hostname
@@ -236,6 +237,21 @@ class Host
     public function addSshFlag(string $flag, string $value = null) : Host
     {
         $this->sshArguments = $this->sshArguments->withFlag($flag, $value);
+        return $this;
+    }
+
+    public function getShellCommand() : string
+    {
+        return $this->shellCommand;
+    }
+
+    /**
+     * @param string $shellCommand
+     * @return $this
+     */
+    public function shellCommand(string $shellCommand)
+    {
+        $this->shellCommand = $shellCommand;
         return $this;
     }
 

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -80,7 +80,9 @@ class Client
             $sshArguments = $this->initMultiplexing($host);
         }
 
-        $ssh = "ssh $sshArguments $host $become 'bash -s; printf \"[exit_code:%s]\" $?;'";
+        $shellCommand = $host->getShellCommand();
+
+        $ssh = "ssh $sshArguments $host $become '$shellCommand; printf \"[exit_code:%s]\" $?;'";
 
         $process = new Process($ssh);
         $process


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1171

I added the property "shellCommand" to the Host-class to change the shell used for commands over SSH. This is handy if the remote server has a non-standard location of the bash-binary or if some additional arguments are required.

My server sets some important environment-variables in "/etc/profile", which is not loaded for non-login-shells. So I use this feature to add the flag "-l" to start an login-shell:

```php
host('example.com')
    ->shellCommand('bash -ls')
```