### PR TITLE
Don't touch files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,7 +349,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1540]: https://github.com/deployphp/deployer/issues/1540
 [#1521]: https://github.com/deployphp/deployer/pull/1521
 [#1513]: https://github.com/deployphp/deployer/pull/1513
 [#1481]: https://github.com/deployphp/deployer/issues/1481

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Throw meaningfull exception on errors in cd() [#1480]
 - Make sure Context::pop() is called when Callback errors in on(...) function [#1513]
 - Update silverstripe recipe to support silverstripe 4
+- Don't create shared files automatically when they do not exist yet [#1540]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -64,9 +64,6 @@ task('deploy:shared', function () {
         // Ensure dir is available in release
         run("if [ ! -d $(echo {{release_path}}/$dirname) ]; then mkdir -p {{release_path}}/$dirname;fi");
 
-        // Touch shared
-        run("touch $sharedPath/$file");
-
         // Symlink shared dir to release dir
         run("{{bin/symlink}} $sharedPath/$file {{release_path}}/$file");
     }


### PR DESCRIPTION
Fixes #1540

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes or No
| Deprecations? | No
| Fixed tickets | #1540

Removes the `touch` so that non-existing files are not created, possibly in an invalid format.
