### PR TITLE
Show regular output when errorOutput is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Throw meaningfull exception on errors in cd() [#1480]
 - Make sure Context::pop() is called when Callback errors in on(...) function [#1513]
 - Update silverstripe recipe to support silverstripe 4
+- Show standard output in exceptions when error output is empty [#1554]
 
 ## v6.0.5
 [v6.0.4...v6.0.5](https://github.com/deployphp/deployer/compare/v6.0.4...v6.0.5)
@@ -349,7 +350,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1554]: https://github.com/deployphp/deployer/pull/1554
 [#1521]: https://github.com/deployphp/deployer/pull/1521
 [#1513]: https://github.com/deployphp/deployer/pull/1513
 [#1481]: https://github.com/deployphp/deployer/issues/1481

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -47,7 +47,7 @@ class RuntimeException extends Exception
 
         $message .= sprintf(
             "\n\n================\n%s",
-            $errorOutput
+            trim($errorOutput) ? $errorOutput : $output
         );
 
         parent::__construct($message, $exitCode);


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Issue Type        | Feature Request
| Deployer Version  | N/A
| Local Machine OS  | N/A
| Remote Machine OS | N/A

Some applications throw errors without correctly logging the output to `stderr`. This is probably an error with the framework, but it makes it hard to debug errors. I've encountered this with both Magento2 and Laravel, the only solution is to re-run the deployment with -vvv to see the error.

Proposed solution:
Show the regular output in RuntimeException, when the error output is empty. 
