### PR TITLE
added blackfire captured metrics for subprocesses and DI calls

### DIFF
--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -13,4 +13,3 @@ metrics:
         - callee:
             selector: '=Deployer\Deployer::__get' # aggregate the costs of all Deployer::__get calls
             argument: { 1: "^" }  # but create separate nodes by the first argument value
-                        

--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -1,0 +1,16 @@
+metrics:
+  deployer.process_runner: # metric name
+    label: "ProcessRunner processes"
+    matching_calls:
+      php:
+        - callee:
+            selector: '=Deployer\Utility\ProcessRunner::run' # aggregate the costs of all ProcessRunner::run calls
+            argument: { 2: "^" }  # but create separate nodes by the second argument value
+  deployer.di_container: # metric name
+    label: "DI Container magic calls"
+    matching_calls:
+      php:
+        - callee:
+            selector: '=Deployer\Deployer::__get' # aggregate the costs of all Deployer::__get calls
+            argument: { 1: "^" }  # but create separate nodes by the first argument value
+                        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v6.1.0...master](https://github.com/deployphp/deployer/compare/v6.1.0...master)
 
+### Added
+- Support blackfire captured metrics for subprocesses and DI calls [#1564]
+
 ## v6.1.0
 [v6.0.5...v6.1.0](https://github.com/deployphp/deployer/compare/v6.0.5...v6.1.0)
 
@@ -358,6 +361,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1564]: https://github.com/deployphp/deployer/pull/1564
 [#1559]: https://github.com/deployphp/deployer/pull/1559
 [#1557]: https://github.com/deployphp/deployer/pull/1557
 [#1554]: https://github.com/deployphp/deployer/pull/1554


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No (no deployer enduser feature)
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

utilize [metrics argument capturing](https://blackfire.io/docs/reference-guide/metrics#metrics-capturing-arguments) to get a better understanding of which cli commands are actually slow. also added a profiler node per DI call.

so with this change one can get a better picture of what is going on when running blackfire profiles. 

**before this patch**
(processes)
![grafik](https://user-images.githubusercontent.com/120441/37202529-04eb4078-238b-11e8-8f27-8dbce1ee838c.png)
![grafik](https://user-images.githubusercontent.com/120441/37202623-52a9af0c-238b-11e8-9109-aa3bb4821302.png)


**after this patch**
(processes)
![grafik](https://user-images.githubusercontent.com/120441/37202537-0a10ecb0-238b-11e8-92f6-46b297a9cccc.png)
(magic DI calls)
![grafik](https://user-images.githubusercontent.com/120441/37202590-2f571fa8-238b-11e8-837e-e0df83229436.png)
