### PR TITLE
Laravel recipe: added maintenance text and retry header options on artisan:down

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -62,7 +62,6 @@ task('artisan:down', function () {
     $minVersion = 5.3;
     $currentVersion = get('laravel_version');
     $output = '';
-   
     if (version_compare($currentVersion, $minVersion, '<')) {
         $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi");
     } else {
@@ -76,7 +75,6 @@ task('artisan:down', function () {
         if ($retryOption != "" && $retryOption != null) {
             $retry = '--retry=' .$retryOption;
         }
-     
         $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down $message $retry; fi");
     }
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -56,7 +56,25 @@ task('artisan:up', function () {
 
 desc('Enable maintenance mode');
 task('artisan:down', function () {
-    $output = run('if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi');
+    $minVersion = 5.3;
+    $currentVersion = get('laravel_version');
+    $output = '';
+    if (version_compare($currentVersion, $minVersion, '<')) {
+        $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi");
+    } else {
+        $messageOption = ask("Which maintenance message do you want to display?", null);
+        $retryOption = ask("What value should the Retry-After HTTP header contain?", null);
+
+        $message = $retry = '';
+        if ($messageOption != "" && $messageOption != null) {
+            $message = "--message=\"$messageOption\"";
+        }
+        if ($retryOption != "" && $retryOption != null){
+            $retry = '--retry=' .$retryOption;
+        }
+        $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down $message $retry; fi");
+    }
+
     writeln('<info>' . $output . '</info>');
 });
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -12,6 +12,9 @@ namespace Deployer;
 
 require_once __DIR__ . '/common.php';
 
+set('maintenance_message', '');
+set('retry_after', null);
+
 // Laravel shared dirs
 set('shared_dirs', [
     'storage',
@@ -59,11 +62,12 @@ task('artisan:down', function () {
     $minVersion = 5.3;
     $currentVersion = get('laravel_version');
     $output = '';
+   
     if (version_compare($currentVersion, $minVersion, '<')) {
         $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down; fi");
     } else {
-        $messageOption = ask("Which maintenance message do you want to display?", null);
-        $retryOption = ask("What value should the Retry-After HTTP header contain?", null);
+        $messageOption = (get('maintenance_message') && !empty(get('maintenance_message'))) ? get('maintenance_message') : ask("Which maintenance message do you want to display?", null);
+        $retryOption = (get('retry_after') && !empty(get('retry_after'))) ? get('retry_after') : ask("What value should the Retry-After HTTP header contain?", null);
 
         $message = $retry = '';
         if ($messageOption != "" && $messageOption != null) {
@@ -72,6 +76,7 @@ task('artisan:down', function () {
         if ($retryOption != "" && $retryOption != null) {
             $retry = '--retry=' .$retryOption;
         }
+     
         $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down $message $retry; fi");
     }
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -69,7 +69,7 @@ task('artisan:down', function () {
         if ($messageOption != "" && $messageOption != null) {
             $message = "--message=\"$messageOption\"";
         }
-        if ($retryOption != "" && $retryOption != null){
+        if ($retryOption != "" && $retryOption != null) {
             $retry = '--retry=' .$retryOption;
         }
         $output = run("if [ -f {{deploy_path}}/current/artisan ]; then {{bin/php}} {{deploy_path}}/current/artisan down $message $retry; fi");


### PR DESCRIPTION
When putting a Laravel application in maintenance mode you can set a message to display and a value to the Retry-After HTTP header. 
I've added questions when dep artisan:down and also added a check for Laravel > 5.3.
Some input validation is needed.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A