### PR TITLE
Remove magento:enable from Magento 2 recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed that long http user name is not detected correctly [#1580]
 - Fixed missing `var/sessions` in Symfony 4 shared_dirs
 - Fixed warning with host without configuration [#1583]
+- Removed the `magento:enable` task from the Magento 2 recipe since the module states are defined in `app/etc/config.php` and this task overwrote that.
 
 ## v6.1.0
 [v6.0.5...v6.1.0](https://github.com/deployphp/deployer/compare/v6.0.5...v6.1.0)

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -24,11 +24,6 @@ set('clear_paths', [
 ]);
 
 // Tasks
-desc('Enable all modules');
-task('magento:enable', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento module:enable --all");
-});
-
 desc('Compile magento di');
 task('magento:compile', function () {
     run("{{bin/php}} {{release_path}}/bin/magento setup:di:compile");
@@ -62,7 +57,6 @@ task('magento:cache:flush', function () {
 
 desc('Magento2 deployment operations');
 task('deploy:magento', [
-    'magento:enable',
     'magento:compile',
     'magento:deploy:assets',
     'magento:maintenance:enable',


### PR DESCRIPTION
Magento's module states are stored in app/etc/config.php. This task ignored that and blindly enabled all installed modules.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes? If anyone relied on that task. Don't know why they would have though.
| Deprecations? | No
| Fixed tickets | N/A