### PR TITLE
Extend deploy:cleanup with tty allocation when using sudo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added cache clear/warmup task for symfony4 recipe [#1575]
 - Added ability to use config params in host variables [#1508]
 - Make used shell configurable via `shellCommand` [#1536]
+- Added `cleanup_tty` option for `deploy:cleanup`
 
 ### Fixed
 - Fixed that long http user name is not detected correctly [#1580]

--- a/recipe/deploy/cleanup.php
+++ b/recipe/deploy/cleanup.php
@@ -12,6 +12,10 @@ task('cleanup', function () {
     $releases = get('releases_list');
     $keep = get('keep_releases');
     $sudo  = get('cleanup_use_sudo') ? 'sudo' : '';
+    $runOpts = [];
+    if ($sudo) {
+        $runOpts['tty'] = get('cleanup_tty', false);
+    }
 
     if ($keep === -1) {
         // Keep unlimited releases.
@@ -24,7 +28,7 @@ task('cleanup', function () {
     }
 
     foreach ($releases as $release) {
-        run("$sudo rm -rf {{deploy_path}}/releases/$release");
+        run("$sudo rm -rf {{deploy_path}}/releases/$release", $runOpts);
     }
 
     run("cd {{deploy_path}} && if [ -e release ]; then $sudo rm release; fi");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I couldn't enter a password using the option _cleanup_use_sudo_. I added the function cleanup_tty similar to writable_tty.