### PR TITLE
locate binary with less subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Make used shell configurable via `shellCommand` [#1536]
 - Added `cleanup_tty` option for `deploy:cleanup`
 
+### Changed
+- Optimize locateBinaryPath() to create less subprocesses [#1634]
+
 ### Fixed
 - Fixed that long http user name is not detected correctly [#1580]
 - Fixed missing `var/sessions` in Symfony 4 shared_dirs
@@ -372,6 +375,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+[#1634]: https://github.com/deployphp/deployer/pull/1634
 [#1603]: https://github.com/deployphp/deployer/issues/1603
 [#1583]: https://github.com/deployphp/deployer/issues/1583
 [#1580]: https://github.com/deployphp/deployer/pull/1580

--- a/src/functions.php
+++ b/src/functions.php
@@ -754,23 +754,12 @@ function locateBinaryPath($name)
     $nameEscaped = escapeshellarg($name);
 
     // Try `command`, should cover all Bourne-like shells
-    if (commandExist("command")) {
-        return run("command -v $nameEscaped");
-    }
-
     // Try `which`, should cover most other cases
-    if (commandExist("which")) {
-        return run("which $nameEscaped");
-    }
-
     // Fallback to `type` command, if the rest fails
-    if (commandExist("type")) {
-        $result = run("type -p $nameEscaped");
-
-        if ($result) {
-            // Deal with issue when `type -p` outputs something like `type -ap` in some implementations
-            return trim(str_replace("$name is", "", $result));
-        }
+    $path = run("command -v $nameEscaped || which $nameEscaped || type -p $nameEscaped");
+    if ($path) {
+        // Deal with issue when `type -p` outputs something like `type -ap` in some implementations
+        return trim(str_replace("$name is", "", $path));
     }
 
     throw new \RuntimeException("Can't locate [$nameEscaped] - neither of [command|which|type] commands are available");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

to optimize resource consumption.

before this change, the number of subprocesses required to locate a binary was 2 in the best case and 6 in the worst case.

after this change it always requires 1 process, no matter which command will be used at the end (whether `command -v`, `which` or `type -p`)