### PR TITLE
Sleep between process status calls to prevent 100% CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Removed the `magento:enable` task from the Magento 2 recipe since the module states are defined in `app/etc/config.php` and this task overwrote that.
 - Allow to set template file path in Drupal 7 recipe [#1603]
 - Fixed once() tasks that where being run multiple times with ParallelExecutor
+- Fixed high CPU usage when running in paralell
 
 ## v6.1.0
 [v6.0.5...v6.1.0](https://github.com/deployphp/deployer/compare/v6.0.5...v6.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Removed the `magento:enable` task from the Magento 2 recipe since the module states are defined in `app/etc/config.php` and this task overwrote that.
 - Allow to set template file path in Drupal 7 recipe [#1603]
 - Fixed once() tasks that where being run multiple times with ParallelExecutor
-- Fixed high CPU usage when running in paralell
+- Fixed high CPU usage when running in parallel
 
 ## v6.1.0
 [v6.0.5...v6.1.0](https://github.com/deployphp/deployer/compare/v6.0.5...v6.1.0)

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -146,6 +146,8 @@ class ParallelExecutor implements ExecutorInterface
 
         while ($this->areRunning($processes)) {
             $this->gatherOutput($processes, $callback);
+            
+            usleep(1000);
         }
         $this->gatherOutput($processes, $callback);
 

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -145,8 +145,7 @@ class ParallelExecutor implements ExecutorInterface
         $this->startProcesses($processes);
 
         while ($this->areRunning($processes)) {
-            $this->gatherOutput($processes, $callback);
-            
+            $this->gatherOutput($processes, $callback);            
             usleep(1000);
         }
         $this->gatherOutput($processes, $callback);

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -145,7 +145,7 @@ class ParallelExecutor implements ExecutorInterface
         $this->startProcesses($processes);
 
         while ($this->areRunning($processes)) {
-            $this->gatherOutput($processes, $callback);            
+            $this->gatherOutput($processes, $callback);
             usleep(1000);
         }
         $this->gatherOutput($processes, $callback);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

When running deployer in parallel, we noticed the server that manages the deployments is running with 100% CPU usage. Debugging this issue we noticed that the `OarallelExecutor` is checking the process status in a while loop until the task is finished. However, as this is executed that much with no sleep in between, the CPU usage goes to 100% as it's constantly checking the status.

This PR add's a small usleep between every run which is neglectable for task performance, as a task can only take 1000 microseconds longer. The same logic is used in the Symfony Process class for the `wait` function. CPU drops to +/- 10% on my local machine with this fix.