### PR TITLE
Set custom user for CI environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make used shell configurable via `shellCommand` [#1536]
 - Added `cleanup_tty` option for `deploy:cleanup`
 - Added Prestashop 1.6 recipe
+- Set dedicated user variable under CI environments, if not provided by git-config
 
 ### Changed
 - Optimize locateBinaryPath() to create less subprocesses [#1634]

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -39,6 +39,10 @@ set('user', function () {
     try {
         return runLocally('git config --get user.name');
     } catch (\Throwable $exception) {
+        if (false !== getenv('CI')) {
+            return 'Continuous Integration';
+        }
+
         return 'no_user';
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

`CI` environment variable is set in all the major CI environments:

* https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
* https://docs.gitlab.com/ee/ci/variables/#predefined-variables-environment-variables
* https://confluence.atlassian.com/bitbucket/environment-variables-794502608.html
* https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

And in those CI envs git user is almost always not set.

This patch helps when using and auto-deploy strategy to identify the automated deploy.

For the records: :rocket: :champagne: Deployer :heart: 