### PR TITLE
Added horizon:terminate for Laravel recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `cleanup_tty` option for `deploy:cleanup`
 - Added Prestashop 1.6 recipe
 - Set dedicated user variable under CI environments, if not provided by git-config
+- Added artisan:horizon:terminate task for laravel recipe
 
 ### Changed
 - Optimize locateBinaryPath() to create less subprocesses [#1634]

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -133,6 +133,11 @@ task('artisan:storage:link', function () {
     }
 });
 
+desc('Execute artisan horizon:terminate');
+task('artisan:horizon:terminate', function () {
+    run('{{bin/php}} {{release_path}}/artisan horizon:terminate');
+});
+
 /**
  * Task deploy:public_disk support the public disk.
  * To run this task automatically, please add below line to your deploy.php file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Laravel has a dashboard package for Redis queue jobs. Most typical configuration is to run php artisan horizon through supervisor and you are supposed to restart the process during deployment by running php artisan horizon:terminate. This PR adds this command.

There is no easy and clean way to determine whether the project is using Horizon or not, so the end user has to add the artisan:horizon:terminate after deploy:symlink.

https://laravel.com/docs/5.6/horizon#deploying-horizon
