### PR TITLE
Fix 1666

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed `deploy:writable` no need to specify http_user when using chgrp writable_mode
 - Fixed `deploy:shared` missing from some recipes [#1663]
 - Fixed missing `deploy:writable` entries in recipes [#1661]
+- Fixed implicit `composer_action` [#1666]
 
 ## v6.1.0
 [v6.0.5...v6.1.0](https://github.com/deployphp/deployer/compare/v6.0.5...v6.1.0)

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -86,7 +86,7 @@ set('use_atomic_symlink', function () {
 });
 
 set('composer_action', 'install');
-set('composer_options', '{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
+set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
 
 set('env', []); // Run command environment (for example, SYMFONY_ENV=prod)
 

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -12,5 +12,5 @@ task('deploy:vendors', function () {
     if (!commandExist('unzip')) {
         writeln('<comment>To speed up composer installation setup "unzip" command with PHP zip extension https://goo.gl/sxzFcD</comment>');
     }
-    run('cd {{release_path}} && {{bin/composer}} {{composer_options}}');
+    run('cd {{release_path}} && {{bin/composer}} {{composer_action}} {{composer_options}}');
 });

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -12,5 +12,12 @@ task('deploy:vendors', function () {
     if (!commandExist('unzip')) {
         writeln('<comment>To speed up composer installation setup "unzip" command with PHP zip extension https://goo.gl/sxzFcD</comment>');
     }
+
+    $options = trim(get('composer_options'));
+    $action  = trim(get('composer_action'));
+    if (strpos($options, $action) === 0) {
+        set('composer_options', substr_replace($options, '', 0, strlen($action)));
+    }
+
     run('cd {{release_path}} && {{bin/composer}} {{composer_action}} {{composer_options}}');
 });

--- a/test/fixture/recipe/deploy.php
+++ b/test/fixture/recipe/deploy.php
@@ -82,5 +82,5 @@ fail('deploy_fail', 'deploy:unlock');
 // Dummy
 
 task('deploy:vendors', function () {
-    run('echo {{bin/composer}} {{composer_options}}');
+    run('echo {{bin/composer}} {{composer_action}} {{composer_options}}');
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Maybe
| Deprecations? | No
| Fixed tickets | #1666 

### Possible BC break

I've added a check if `composer_options` contains `composer_action`, here is where I potentially see a  problem: if a user has added the composer action as a string to their `composer_options` variable the detection in https://github.com/deployphp/deployer/compare/master...alpipego:fix-1666#diff-8f884efdf2b864c9ee15854766038c1eR19 will still probably fail.
