### PR TITLE
Laravel deploy task should not call cache:clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## master
 [v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
 
+### Changed
+- Laravel recipe should not run `artisan:cache:clear` in `deploy` task
+
 
 ## v6.3.0
 [v6.2.0...v6.3.0](https://github.com/deployphp/deployer/compare/v6.2.0...v6.3.0)

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -168,7 +168,6 @@ task('deploy', [
     'deploy:writable',
     'artisan:storage:link',
     'artisan:view:clear',
-    'artisan:cache:clear',
     'artisan:config:cache',
     'artisan:optimize',
     'deploy:symlink',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? |  No
| Fixed tickets | N/A

`cache:clear` command will clear users' sessions if CACHE_DRIVER is the same as SESSION_DRIVER, I think users should call this task on demand instead of putting it in default deploy task.