### PR TITLE
Added view:cache and auth:clear-resets commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Changelog
 
 ## master
-[v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
+[v6.3.1...master](https://github.com/deployphp/deployer/compare/v6.3.1...master)
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 
+## v6.3.1
+[v6.3.0...v6.3.1](https://github.com/deployphp/deployer/compare/v6.3.0...v6.3.1)
+
+### Added
+- Added `artisan:view:cache` command
+- Added `auth:clear-resets` command
 
 ## v6.3.0
-[v6.2.0...v6.3.0](https://github.com/deployphp/deployer/compare/v6.2.0...v6.3.0)
 
 ### Added
 - Added cache clear/warmup task for symfony4 recipe [#1575]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,12 @@
 ## master
 [v6.3.1...master](https://github.com/deployphp/deployer/compare/v6.3.1...master)
 
-### Changed
-- Laravel recipe should not run `artisan:cache:clear` in `deploy` task
-
-## v6.3.1
-[v6.3.0...v6.3.1](https://github.com/deployphp/deployer/compare/v6.3.0...v6.3.1)
-
 ### Added
 - Added `artisan:view:cache` command
 - Added `auth:clear-resets` command
+
+### Changed
+- Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 
 ## v6.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master
-[v6.3.1...master](https://github.com/deployphp/deployer/compare/v6.3.1...master)
+[v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
 
 ### Added
 - Added `artisan:view:cache` command

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -88,6 +88,12 @@ task('artisan:db:seed', function () {
     writeln('<info>' . $output . '</info>');
 });
 
+desc('Execute artisan auth:clear-resets');
+task('artisan:auth:clear-resets', function () {
+    $output = run('{{bin/php}} {{release_path}}/artisan auth:clear-resets');
+    writeln('<info>' . $output . '</info>');
+});
+
 desc('Execute artisan cache:clear');
 task('artisan:cache:clear', function () {
     run('{{bin/php}} {{release_path}}/artisan cache:clear');
@@ -101,6 +107,11 @@ task('artisan:config:cache', function () {
 desc('Execute artisan route:cache');
 task('artisan:route:cache', function () {
     run('{{bin/php}} {{release_path}}/artisan route:cache');
+});
+
+desc('Execute artisan view:cache');
+task('artisan:view:cache', function () {
+    run('{{bin/php}} {{release_path}}/artisan view:cache');
 });
 
 desc('Execute artisan view:clear');

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -90,8 +90,7 @@ task('artisan:db:seed', function () {
 
 desc('Execute artisan auth:clear-resets');
 task('artisan:auth:clear-resets', function () {
-    $output = run('{{bin/php}} {{release_path}}/artisan auth:clear-resets');
-    writeln('<info>' . $output . '</info>');
+    run('{{bin/php}} {{release_path}}/artisan auth:clear-resets');
 });
 
 desc('Execute artisan cache:clear');


### PR DESCRIPTION
Added the view:cache command as added in Laravel [v5.6.13](https://github.com/laravel/framework/blob/5.6/CHANGELOG-5.6.md#v5613-2018-03-26) and the auth:clear-resets artisan command too.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A