### PR TITLE
Fixes issue #1671, Range expansion in FileLoader when host.yml is loa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,15 @@
 # Changelog
 
 
-
 ## master
 [v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
 
-
 ### Changed
-- Updated db1.deployer.org and db2.deployer.org to db[1:2].deployer.org in test/fixture/inventory.yml.
-- Updated testInventory from FileLoadTest.php to test for db1.deployer.org and db2.deployer.org expansion when loaded from file.
-- Updated FileLoaderTest testLoad to validate db1.deployer.org and db2.deployer.org are expanded.
-
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
-
-### Added
-- expandOnLoad function which expands ranges and rebuilds the array created by the Yaml parser.
 
 ### Fixed
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
+
 
 ## v6.3.0
 [v6.2.0...v6.3.0](https://github.com/deployphp/deployer/compare/v6.2.0...v6.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+
+
 ## master
 [v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
+- Added a function to Deployer\Host\FileLoader, expandOnLoad, which rebuilds the parsed yaml array with expanded hostnames. 
+- Updated deployer/test/fixtures/inventory.xml by combining db1.deployer.org and db2.deployer.org into db[1:2].deployer.org in order to test file loading with range.
+- Added tests for db1.deployer.org and db2.deployer.org in FileLoaderTest testLoad(). 
+- Added tests in FunctionTest testInventory() function to test for db1.deployer.org and db2.deployer.org because the bug report referenced inventory().
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@
 
 ## master
 [v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
-- Added a function to Deployer\Host\FileLoader, expandOnLoad, which rebuilds the parsed yaml array with expanded hostnames. 
-- Updated deployer/test/fixtures/inventory.xml by combining db1.deployer.org and db2.deployer.org into db[1:2].deployer.org in order to test file loading with range.
-- Added tests for db1.deployer.org and db2.deployer.org in FileLoaderTest testLoad(). 
-- Added tests in FunctionTest testInventory() function to test for db1.deployer.org and db2.deployer.org because the bug report referenced inventory().
+
 
 ### Changed
+- Updated db1.deployer.org and db2.deployer.org to db[1:2].deployer.org in test/fixture/inventory.yml.
+- Updated testInventory from FileLoadTest.php to test for db1.deployer.org and db2.deployer.org expansion when loaded from file.
+- Updated FileLoaderTest testLoad to validate db1.deployer.org and db2.deployer.org are expanded.
+
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 
+### Added
+- expandOnLoad function which expands ranges and rebuilds the array created by the Yaml parser.
+
+### Fixed
+- Fixed Range expansion when hosts.yml is loaded. [#1671]
 
 ## v6.3.0
 [v6.2.0...v6.3.0](https://github.com/deployphp/deployer/compare/v6.2.0...v6.3.0)
@@ -409,7 +415,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1671]: https://github.com/deployphp/deployer/issues/1671
 [#1663]: https://github.com/deployphp/deployer/issues/1663
 [#1661]: https://github.com/deployphp/deployer/pull/1661
 [#1634]: https://github.com/deployphp/deployer/pull/1634

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -20,17 +20,18 @@ class FileLoader
      * @param array $datain
      * @return array $dataexp
      */
-    public function expandOnLoad($datain) {
+    public function expandOnLoad($datain) 
+    {
         $dataout = [];
         foreach ($datain as $hostname => $config) {
             if (preg_match('/\[(.+?)\]/', $hostname)) {
-                foreach(Range::expand([$hostname]) as $splithost) {
+                foreach (Range::expand([$hostname]) as $splithost) {
                     $dataout["$splithost"] = $config;
                 }
                 
-                } else {
-			        $dataout["$hostname"] = $config;
-                }
+        } else {
+			    $dataout["$hostname"] = $config;
+        }
 
         }
 

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -28,9 +28,8 @@ class FileLoader
                 foreach (Range::expand([$hostname]) as $splithost) {
                     $dataout["$splithost"] = $config;
                 }
-                
             } else {
-			    $dataout["$hostname"] = $config;
+                $dataout["$hostname"] = $config;
             }
 
         }

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -31,7 +31,6 @@ class FileLoader
             } else {
                 $dataout["$hostname"] = $config;
             }
-
         }
 
         return $dataout;
@@ -49,7 +48,7 @@ class FileLoader
 
         $data = Yaml::parse(file_get_contents($file));
         $data = $this->expandOnLoad($data);
-	
+
         if (!is_array($data)) {
             throw new Exception("Hosts file `$file` should contains array of hosts.");
         }

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -20,7 +20,7 @@ class FileLoader
      * @param array $datain
      * @return array $dataexp
      */
-    public function expandOnLoad($datain) 
+    public function expandOnLoad($datain)
     {
         $dataout = [];
         foreach ($datain as $hostname => $config) {
@@ -29,9 +29,9 @@ class FileLoader
                     $dataout["$splithost"] = $config;
                 }
                 
-        } else {
+            } else {
 			    $dataout["$hostname"] = $config;
-        }
+            }
 
         }
 
@@ -49,7 +49,7 @@ class FileLoader
         }
 
         $data = Yaml::parse(file_get_contents($file));
-	    $data = $this->expandOnLoad($data);
+        $data = $this->expandOnLoad($data);
 	
         if (!is_array($data)) {
             throw new Exception("Hosts file `$file` should contains array of hosts.");

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -16,7 +16,25 @@ class FileLoader
      * @var Host[]
      */
     private $hosts = [];
+   /**
+    * @param array $datain
+    * @return array $dataexp
+    */
+    public function expandOnLoad($datain) {
+        $dataout = array();
+        foreach ($datain as $hostname => $config) {
+                if (preg_match('/\[(.+?)\]/', $hostname)) {
+                        foreach(Range::expand([$hostname]) as $splithost) {
+                        	$dataout["$splithost"] = $config;
+                        }
+                } else {
+			$dataout["$hostname"] = $config;
+                }
 
+        }
+
+        return $dataout;
+   }
     /**
      * @param string $file
      * @return $this
@@ -29,7 +47,8 @@ class FileLoader
         }
 
         $data = Yaml::parse(file_get_contents($file));
-
+	$data = $this->expandOnLoad($data);
+	
         if (!is_array($data)) {
             throw new Exception("Hosts file `$file` should contains array of hosts.");
         }

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -16,25 +16,26 @@ class FileLoader
      * @var Host[]
      */
     private $hosts = [];
-   /**
-    * @param array $datain
-    * @return array $dataexp
-    */
+    /**
+     * @param array $datain
+     * @return array $dataexp
+     */
     public function expandOnLoad($datain) {
-        $dataout = array();
+        $dataout = [];
         foreach ($datain as $hostname => $config) {
-                if (preg_match('/\[(.+?)\]/', $hostname)) {
-                        foreach(Range::expand([$hostname]) as $splithost) {
-                        	$dataout["$splithost"] = $config;
-                        }
+            if (preg_match('/\[(.+?)\]/', $hostname)) {
+                foreach(Range::expand([$hostname]) as $splithost) {
+                    $dataout["$splithost"] = $config;
+                }
+                
                 } else {
-			$dataout["$hostname"] = $config;
+			        $dataout["$hostname"] = $config;
                 }
 
         }
 
         return $dataout;
-   }
+    }
     /**
      * @param string $file
      * @return $this
@@ -47,7 +48,7 @@ class FileLoader
         }
 
         $data = Yaml::parse(file_get_contents($file));
-	$data = $this->expandOnLoad($data);
+	    $data = $this->expandOnLoad($data);
 	
         if (!is_array($data)) {
             throw new Exception("Hosts file `$file` should contains array of hosts.");

--- a/test/fixture/inventory.yml
+++ b/test/fixture/inventory.yml
@@ -35,11 +35,7 @@ app.deployer.org:
   roles: app
   deploy_path: ~/app
 
-db1.deployer.org:
-  stage: production
-  roles: db
-
-db2.deployer.org:
+db[1:2].deployer.org:
   stage: production
   roles: db
 

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -98,7 +98,7 @@ class FunctionsTest extends TestCase
     {
         inventory(__DIR__ . '/../fixture/inventory.yml');
 
-        foreach (['app.deployer.org', 'beta.deployer.org'] as $hostname) {
+        foreach (['app.deployer.org', 'beta.deployer.org', 'db1.deployer.org', 'db2.deployer.org'] as $hostname) {
             self::assertInstanceOf(Host::class, $this->deployer->hosts->get($hostname));
         }
     }

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -52,10 +52,10 @@ class FileLoaderTest extends TestCase
             $bar->getSshArguments()->getCliArguments()
         );
 	
-	    $db1 = $this->getHost('db1.deployer.org');
-	    self::assertEquals('db1.deployer.org', $db1->getHostname());
-	    $db2 = $this->getHost('db2.deployer.org');
-	    self::assertEquals('db2.deployer.org', $db2->getHostname());
+	     $db1 = $this->getHost('db1.deployer.org');
+	     self::assertEquals('db1.deployer.org', $db1->getHostname());
+	     $db2 = $this->getHost('db2.deployer.org');
+	     self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
     /**

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -51,7 +51,7 @@ class FileLoaderTest extends TestCase
             '-f -A -someFlag value -p 22 -F configFile -i identityFile -o Option=Value',
             $bar->getSshArguments()->getCliArguments()
         );
-	
+
         $db1 = $this->getHost('db1.deployer.org');
         self::assertEquals('db1.deployer.org', $db1->getHostname());
         $db2 = $this->getHost('db2.deployer.org');

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -52,10 +52,10 @@ class FileLoaderTest extends TestCase
             $bar->getSshArguments()->getCliArguments()
         );
 	
-	 $db1 = $this->getHost('db1.deployer.org');
-	 self::assertEquals('db1.deployer.org', $db1->getHostname());
-	 $db2 = $this->getHost('db2.deployer.org');
-	 self::assertEquals('db2.deployer.org', $db2->getHostname());
+	    $db1 = $this->getHost('db1.deployer.org');
+	    self::assertEquals('db1.deployer.org', $db1->getHostname());
+	    $db2 = $this->getHost('db2.deployer.org');
+	    self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
     /**

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -51,6 +51,11 @@ class FileLoaderTest extends TestCase
             '-f -A -someFlag value -p 22 -F configFile -i identityFile -o Option=Value',
             $bar->getSshArguments()->getCliArguments()
         );
+	
+	$db1 = $this->getHost('db1.deployer.org');
+	self::assertEquals('db1.deployer.org', $db1->getHostname());
+	$db2 = $this->getHost('db2.deployer.org');
+	self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
     /**

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -52,10 +52,10 @@ class FileLoaderTest extends TestCase
             $bar->getSshArguments()->getCliArguments()
         );
 	
-	$db1 = $this->getHost('db1.deployer.org');
-	self::assertEquals('db1.deployer.org', $db1->getHostname());
-	$db2 = $this->getHost('db2.deployer.org');
-	self::assertEquals('db2.deployer.org', $db2->getHostname());
+	 $db1 = $this->getHost('db1.deployer.org');
+	 self::assertEquals('db1.deployer.org', $db1->getHostname());
+	 $db2 = $this->getHost('db2.deployer.org');
+	 self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
     /**

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -52,10 +52,10 @@ class FileLoaderTest extends TestCase
             $bar->getSshArguments()->getCliArguments()
         );
 	
-	     $db1 = $this->getHost('db1.deployer.org');
-	     self::assertEquals('db1.deployer.org', $db1->getHostname());
-	     $db2 = $this->getHost('db2.deployer.org');
-	     self::assertEquals('db2.deployer.org', $db2->getHostname());
+        $db1 = $this->getHost('db1.deployer.org');
+        self::assertEquals('db1.deployer.org', $db1->getHostname());
+        $db2 = $this->getHost('db2.deployer.org');
+        self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
     /**


### PR DESCRIPTION
Fixes issue #1671, Range expansion in FileLoader when host.yml is loaded.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | [https://github.com/deployphp/deployer/issues/1671](url)


New Function and corrected Behavior
Added a function to Deployer\Host\FileLoader, expandOnLoad, which rebuilds the parsed yaml array with expanded hostnames. 

Updated Tests
Updated deployer/test/fixtures/inventory.xml by combining db1.deployer.org and db2.deployer.org into db[1:2].deployer.org in order to test file loading with range.
Added tests for db1.deployer.org and db2.deployer.org in FileLoaderTest testLoad(). 
Added tests in FunctionTest testInventory() function to test for db1.deployer.org and db2.deployer.org because the bug report referenced inventory().


> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/deployer/blob/master/CHANGELOG.md)
> * Add description under added/changed/fixed section.
> * Add reference to closed issues `[#000]`.
> * Add link to issue in the end of document.
