### PR TITLE
moved symfony finder to dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
         "phpseclib/phpseclib": "~2.0",
         "pimple/pimple": "~3.0",
         "symfony/console": "~2.6|~3.0",
-        "symfony/finder": "~2.6|~3.0",
         "symfony/process": "~2.6|~3.0",
         "symfony/yaml": "~2.6|~3.0"
     },
     "require-dev": {
         "deployer/phar-update": "~2.0",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~5.7",
+        "symfony/finder": "~2.6|~3.0"
     },
     "suggest": {
         "ext-sockets": "For parallel deployment"


### PR DESCRIPTION
This is a backport of e6df0f23d861c444876c8f15480bcec310694481 for the 4.x branch.