### PR TITLE
Allow the remote shell path to be overridden by host config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## master
 [v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
 
+### Added
+- Support to define remote shell path via host-config [#1708] [#1709] [#1709]
+
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 
@@ -413,6 +416,8 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1709]: https://github.com/deployphp/deployer/issues/1709
+[#1708]: https://github.com/deployphp/deployer/pull/1708
 [#1677]: https://github.com/deployphp/deployer/pull/1677
 [#1671]: https://github.com/deployphp/deployer/issues/1671
 [#1663]: https://github.com/deployphp/deployer/issues/1663

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -79,11 +79,16 @@ class SshCommand extends Command
                 $host = $this->deployer->hosts->get($hostname);
             }
         }
-
+        
+        $shell_path = 'exec $SHELL -l';
+        if ($host->has('shell_path')) {
+            $shell_path = 'exec '.$host->get('shell_path').' -l';
+        }
+        
         Context::push(new Context($host, $input, $output));
         $options = $host->getSshArguments();
         $deployPath = $host->get('deploy_path', '~');
 
-        passthru("ssh -t $options $host 'cd '''$deployPath/current'''; exec \$SHELL -l'");
+        passthru("ssh -t $options $host 'cd '''$deployPath/current'''; $shell_path'");
     }
 }

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -84,7 +84,7 @@ class SshCommand extends Command
         if ($host->has('shell_path')) {
             $shell_path = 'exec '.$host->get('shell_path').' -l';
         }
-        
+
         Context::push(new Context($host, $input, $output));
         $options = $host->getSshArguments();
         $deployPath = $host->get('deploy_path', '~');

--- a/src/Console/SshCommand.php
+++ b/src/Console/SshCommand.php
@@ -79,7 +79,7 @@ class SshCommand extends Command
                 $host = $this->deployer->hosts->get($hostname);
             }
         }
-        
+
         $shell_path = 'exec $SHELL -l';
         if ($host->has('shell_path')) {
             $shell_path = 'exec '.$host->get('shell_path').' -l';


### PR DESCRIPTION
Allow the remote shell path to be overridden by host config -> right now i have the case that $SHELL is incorrect on the remote but I can't fix it (shared hosting). Secondly with this implementation I can explicitly select the shell via Host Config

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1709

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
