### PR TITLE
Pass-through the quiet mode into the git commands for updating code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
+- Pass-through the quiet mode into the git commands for updating code
 
 ### Fixed
 - Fixed Range expansion when hosts.yml is loaded. [#1671]

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -51,6 +51,7 @@ task('deploy:update_code', function () {
     $git = get('bin/git');
     $gitCache = get('git_cache');
     $recursive = get('git_recursive', true) ? '--recursive' : '';
+    $quiet = isQuiet() ? '-q' : '';
     $depth = $gitCache ? '' : '--depth 1';
     $options = [
         'tty' => get('git_tty', false),
@@ -84,14 +85,14 @@ task('deploy:update_code', function () {
 
     if ($gitCache && has('previous_release')) {
         try {
-            run("$git clone $at $recursive -q --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);
+            run("$git clone $at $recursive $quiet --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);
         } catch (\Throwable $exception) {
             // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
-            run("$git clone $at $recursive -q $repository {{release_path}} 2>&1", $options);
+            run("$git clone $at $recursive $quiet $repository {{release_path}} 2>&1", $options);
         }
     } else {
         // if we're using git cache this would be identical to above code in catch - full clone. If not, it would create shallow clone.
-        run("$git clone $at $depth $recursive -q $repository {{release_path}} 2>&1", $options);
+        run("$git clone $at $depth $recursive $quiet $repository {{release_path}} 2>&1", $options);
     }
 
     if (!empty($revision)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

When you define some output verbosity level for deployer, you also want to pass-through this option into the git commands, so I've made this option dynamic based on the verbosity level.
