### PR TITLE
fixed default header override caused by array union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
+- Fixed adding custom headers causes Httpie default header override.
 
 
 ## v6.3.0

--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -59,10 +59,10 @@ class Httpie
     {
         $http = clone $this;
         $http->body = json_encode($data, JSON_PRETTY_PRINT);
-        $http->headers += [
+        $http->headers = array_merge($http->headers, [
             'Content-Type: application/json',
             'Content-Length: ' . strlen($http->body)
-        ];
+        ]);
         return $http;
     }
 
@@ -70,10 +70,10 @@ class Httpie
     {
         $http = clone $this;
         $http->body = http_build_query($data);
-        $http->headers += [
+        $http->headers = array_merge($this->headers, [
             'Content-type: application/x-www-form-urlencoded',
             'Content-Length: ' . strlen($http->body)
-        ];
+        ]);
         return $http;
     }
 


### PR DESCRIPTION
We should use array_merge to append and reindex header array, + or union causes an issue where if we add a header, like for example Authorization, then the first item in merged header array will be skipped (Content-Type) as there will already be an item at 0 index of array. + does not replace values which keys already exist in arrays and does not append them for numeric indexes. If we add two headers then none of the headers in this class will be present in the final header array.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
