### PR TITLE
Fix laravel set version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
+- Fixed Laravel `laravel_version` failure
 
 
 ## v6.3.0

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -36,7 +36,7 @@ set('writable_dirs', [
 ]);
 
 set('laravel_version', function () {
-    $result = run('{{bin/php}} {{release_path}}/artisan --version');
+    $result = run('cd {{release_path}} && {{bin/php}} artisan --version');
 
     preg_match_all('/(\d+\.?)+/', $result, $matches);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Laravel recipes failing while remote deploy being unable to complete `set('laravel_version'..)`.
Change directory before `{{bin/php}} artisan --version`.
```
  [Deployer\Exception\RuntimeException (1)]                                                             
  The command "/usr/local/bin/php /var/www/mir24-app/mir24.tv/releases/2/artisan storage:link" failed.  
                                                                                                        
  Exit Code: 1 (General error)                                                                          
                                                                                                        
  Host Name: example-host                                                                              
                                                                                                        
  ================                                                                                      
  fatal: Not a git repository (or any parent up to mount point /home)    
```