### PR TITLE
Added horizon:terminate to the Laravel recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Support to define remote shell path via host-config [#1708] [#1709] [#1709]
+- Added `horizon:terminate` to the Laravel recipe
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -123,6 +123,11 @@ task('artisan:queue:restart', function () {
     run('{{bin/php}} {{release_path}}/artisan queue:restart');
 });
 
+desc('Execute artisan horizon:terminate');
+task('artisan:horizon:terminate', function () {
+    run('{{bin/php}} {{release_path}}/artisan horizon:terminate');
+});
+
 desc('Execute artisan storage:link');
 task('artisan:storage:link', function () {
     $needsVersion = 5.3;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Hi,

This pull request adds the `horizon:terminate` command to the Laravel recipe. This is typically used in deployments when using Laravel Horizon.
