### PR TITLE
Removed `sudo: false` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 php:
   - 7.0
   - 7.1
@@ -18,6 +16,7 @@ cache:
 
 addons:
   apt:
+    update: true
     packages:
       - acl
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1731

I changed `.travis.yml`. Because `sudo: false` is deprecated.

I checked this article and doc.

- `sodo false` is deprecated. ( Travis CI moves from build by container to build by vm)
  - https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
- installing apt-package and `apt update`
  - https://docs.travis-ci.com/user/installing-dependencies/
