### PR TITLE
Added `migrations_config` option to the Symfony recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Support to define remote shell path via host-config [#1708] [#1709] [#1709]
 - Added `horizon:terminate` to the Laravel recipe
+- Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -57,6 +57,9 @@ set('console_options', function () {
     return get('symfony_env') !== 'prod' ? $options : sprintf('%s --no-debug', $options);
 });
 
+// Migrations configuration file
+set('migrations_config', '');
+
 
 /**
  * Create cache dir
@@ -124,7 +127,12 @@ task('deploy:cache:warmup', function () {
  * Migrate database
  */
 task('database:migrate', function () {
-    run('{{bin/php}} {{bin/console}} doctrine:migrations:migrate {{console_options}} --allow-no-migration');
+    $options = '{{console_options}} --allow-no-migration';
+    if (get('migrations_config') !== '') {
+        $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
+    }
+
+    run(sprintf('{{bin/php}} {{bin/console}} doctrine:migrations:migrate %s', $options));
 })->desc('Migrate database');
 
 

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -12,6 +12,7 @@ require_once 'recipe/common.php';
 set('shared_dirs', ['var/log', 'var/sessions']);
 set('shared_files', ['.env']);
 set('writable_dirs', ['var']);
+set('migrations_config', '');
 
 set('bin/console', function () {
     return parse('{{bin/php}} {{release_path}}/bin/console --no-interaction');
@@ -19,7 +20,12 @@ set('bin/console', function () {
 
 desc('Migrate database');
 task('database:migrate', function () {
-    run('{{bin/console}} doctrine:migrations:migrate --allow-no-migration');
+    $options = '--allow-no-migration';
+    if (get('migrations_config') !== '') {
+        $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
+    }
+
+    run(sprintf('{{bin/console}} doctrine:migrations:migrate %s', $options));
 });
 
 desc('Clear cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This PR add `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use.