### PR TITLE
Fixed version bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
+- Fixed --version option bug. [#1351]
 
 
 ## v6.3.0
@@ -455,6 +456,7 @@
 [#1365]: https://github.com/deployphp/deployer/pull/1365
 [#1364]: https://github.com/deployphp/deployer/pull/1364
 [#1352]: https://github.com/deployphp/deployer/pull/1352
+[#1351]: https://github.com/deployphp/deployer/issues/1351
 [#1311]: https://github.com/deployphp/deployer/pull/1311
 [#1300]: https://github.com/deployphp/deployer/pull/1300
 [#1299]: https://github.com/deployphp/deployer/issues/1299

--- a/bin/dep
+++ b/bin/dep
@@ -87,7 +87,7 @@ set_include_path($includePath . PATH_SEPARATOR . get_include_path());
 // Detect version
 $version = 'master';
 
-$composerLockFile = $deployFilePath . '/composer.lock';
+$composerLockFile = __DIR__ . '/../../../../composer.lock';
 if (is_readable($composerLockFile)) {
     $lock = json_decode(file_get_contents($composerLockFile), true);
     foreach ($lock['packages'] as $package) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1351

I challenged  #1351.

deployer 's install patterm is follows.

1. phar archive
2. `composer require` (install to project local)
3. `composer require global`  (install globaly)

### 1. phar archive
This pattern has no problem

```console
$ php deployer.phar -V
Deployer 6.3.0
```

https://github.com/deployphp/deployer/blob/00e0b27/bin/build#L56

### 2. `composer require` (install to project local)
The location of `dep` command is below.
`$PROJECT_HOME/vendor/deployer/deployer/bin/dep`

The location of `composer.lock` to be referenced is below.
`$PROJECT_HOME/composer.lock`

So, dep file should refer to `./../../../../../ composer.lock`.

#### Test
```console
$ ./vendor/deployer/deployer/bin/dep --version
Deployer v6.3.0
```

### 3. `composer require global`  (install globaly)
The location of `dep` command is below.
`$HOME/.composer/vendor/deployer/deployer/bin/dep`

The location of `composer.lock` to be referenced is below.
`$HOME/.composer/composer.lock`

So, dep file should refer to `./../../../../../ composer.lock`.

#### Test
```console
$ dep --version
Deployer v6.3.0
```