### PR TITLE
Check for opcache.enable_cli and apc.enable_cli 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 - Pass-through the quiet mode into the git commands for updating code
+- Check for opcache.enable_cli and apc.enable_cli [#1385]
 
 ### Fixed
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
@@ -453,6 +454,7 @@
 [#1413]: https://github.com/deployphp/deployer/pull/1413
 [#1403]: https://github.com/deployphp/deployer/pull/1403
 [#1390]: https://github.com/deployphp/deployer/pull/1390
+[#1385]: https://github.com/deployphp/deployer/issues/1385
 [#1365]: https://github.com/deployphp/deployer/pull/1365
 [#1364]: https://github.com/deployphp/deployer/pull/1364
 [#1352]: https://github.com/deployphp/deployer/pull/1352

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Support to define remote shell path via host-config [#1708] [#1709] [#1709]
 - Added `horizon:terminate` to the Laravel recipe
+- Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/bin/dep
+++ b/bin/dep
@@ -12,11 +12,13 @@ define('DEPLOYER_BIN', __FILE__);
 
 // Check for php7
 if (!defined('PHP_MAJOR_VERSION') || PHP_MAJOR_VERSION < 7) {
-    die(
+    fwrite(
+        STDERR,
         'Upgrade to php7' . PHP_EOL .
         'Deployer 5.x supports only php7 and above.' . PHP_EOL .
         'If you want to use older php version use Deployer 4.x' . PHP_EOL
     );
+    exit(1);
 }
 
 // Detect deploy.php script
@@ -74,11 +76,13 @@ for ($i = 0; $i < count($autoload); $i++) {
 }
 
 if (!$loaded) {
-    die(
+    fwrite(
+        STDERR,
         'You need to set up the project dependencies using the following commands:' . PHP_EOL .
         'wget http://getcomposer.org/composer.phar' . PHP_EOL .
         'php composer.phar install' . PHP_EOL
     );
+    exit(1);
 }
 
 // Setup include path
@@ -104,7 +108,8 @@ if (is_readable($composerLockFile)) {
 
 $method = new ReflectionMethod('Deployer\Deployer', 'run');
 if (!$method->isStatic()) {
-    die(
+    fwrite(
+        STDERR,
         'You need to update Deployer to the latest version:' . PHP_EOL .
         PHP_EOL .
         '  dep self-update' . PHP_EOL .
@@ -115,6 +120,7 @@ if (!$method->isStatic()) {
         PHP_EOL
 
     );
+    exit(1);
 }
 
 \Deployer\Deployer::run($version, $deployFile);

--- a/bin/dep
+++ b/bin/dep
@@ -21,6 +21,16 @@ if (!defined('PHP_MAJOR_VERSION') || PHP_MAJOR_VERSION < 7) {
     exit(1);
 }
 
+// Check for opcache.enable_cli
+if (ini_get('opcache.enable_cli')) {
+    echo('Disable opcache.enable_cli' . PHP_EOL);
+};
+
+// Check for apc.enable_cli
+if (ini_get('apc.enable_cli')) {
+    echo('Disable apc.enable_cli' . PHP_EOL);
+};
+
 // Detect deploy.php script
 $options = getopt('f::', ['file::']);
 $userSpecifiedFile = null;

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -57,6 +57,9 @@ set('console_options', function () {
     return get('symfony_env') !== 'prod' ? $options : sprintf('%s --no-debug', $options);
 });
 
+// Migrations configuration file
+set('migrations_config', '');
+
 
 /**
  * Create cache dir
@@ -124,7 +127,12 @@ task('deploy:cache:warmup', function () {
  * Migrate database
  */
 task('database:migrate', function () {
-    run('{{bin/php}} {{bin/console}} doctrine:migrations:migrate {{console_options}} --allow-no-migration');
+    $options = '{{console_options}} --allow-no-migration';
+    if (get('migrations_config') !== '') {
+        $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
+    }
+
+    run(sprintf('{{bin/php}} {{bin/console}} doctrine:migrations:migrate %s', $options));
 })->desc('Migrate database');
 
 

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -12,6 +12,7 @@ require_once 'recipe/common.php';
 set('shared_dirs', ['var/log', 'var/sessions']);
 set('shared_files', ['.env']);
 set('writable_dirs', ['var']);
+set('migrations_config', '');
 
 set('bin/console', function () {
     return parse('{{bin/php}} {{release_path}}/bin/console --no-interaction');
@@ -19,7 +20,12 @@ set('bin/console', function () {
 
 desc('Migrate database');
 task('database:migrate', function () {
-    run('{{bin/console}} doctrine:migrations:migrate --allow-no-migration');
+    $options = '--allow-no-migration';
+    if (get('migrations_config') !== '') {
+        $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
+    }
+
+    run(sprintf('{{bin/console}} doctrine:migrations:migrate %s', $options));
 });
 
 desc('Clear cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1385

I resolved #1385 . 

### 1. Output message to STDERR and exit(1)
If an error occurs in `dep`, output a message to STDERR, set the error code to 1 . 
example : if user use php 5.x.

```console
$ ./bin/dep
Upgrade to php7
Deployer 5.x supports only php7 and above.
If you want to use older php version use Deployer 4.x
$ echo $?
1
```

I think this is good way to end script by error.

commit : https://github.com/deployphp/deployer/commit/3f44148c4672ac7ae94bdc1dafdfb218b8a86be9

### 2. Check for opcache.enable_cli and apc.enable_cli
if user set opcache.enable_cli or apc.enable_cli, Inform user to disable these config.

#### Question
Now in this case, `dep` just print message.

commit : https://github.com/deployphp/deployer/commit/978ca0af92b80f1c95ba2f1ad326e7f953839436

```console
$ ./bin/dep -V
Disable opcache.enable_cli

... runnning script ...

```

As with using php 5.x, should I end the script ? 