### PR TITLE
Make new data directory writable

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -30,6 +30,7 @@ set('writable_dirs', [
     'storage/app/public',
     'storage/framework',
     'storage/framework/cache',
+    'storage/framework/cache/data',
     'storage/framework/sessions',
     'storage/framework/views',
     'storage/logs',


### PR DESCRIPTION
Laravel 5.7 added a cache/data directory.  This needs to be writable.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
