### PR TITLE
Add check_remote_head option to avoid unnecessary new releases by che…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
+
 [#1758]: https://github.com/deployphp/deployer/pull/1758
 [#1755]: https://github.com/deployphp/deployer/pull/1755
 [#1709]: https://github.com/deployphp/deployer/issues/1709

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Support to define remote shell path via host-config [#1708] [#1709] [#1709]
 - Added `horizon:terminate` to the Laravel recipe
 - Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
-- Added `check_remote_head` option, by setting this to true, deployer will avoid unnecessary new releases by checking the remote git HEAD without cloning the repo [#1755].
+- Added `check_remote_head` option, by setting this to true, deployer will avoid unnecessary new releases by checking the remote git HEAD without cloning the repo [#1755]
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
@@ -420,7 +420,7 @@
 - Fixed typo3 recipe
 - Fixed remove of shared dir on first deploy
 
-
+[#1755]: https://github.com/deployphp/deployer/pull/1755
 [#1709]: https://github.com/deployphp/deployer/issues/1709
 [#1708]: https://github.com/deployphp/deployer/pull/1708
 [#1677]: https://github.com/deployphp/deployer/pull/1677

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 
 ## master
-[v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)
+[v6.3.0...master](https://github.com/deployphp/deployer/compare/v6.3.0...master)    
 
 ### Added
 - Support to define remote shell path via host-config [#1708] [#1709] [#1709]
 - Added `horizon:terminate` to the Laravel recipe
 - Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
+- Added `check_remote_head` option, by setting this to true, deployer will avoid unnecessary new releases by checking the remote git HEAD without cloning the repo [#1755].
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -56,6 +56,8 @@ set('target', function () {
  */
 
 set('keep_releases', 5);
+// By setting this to true, deployer will avoid unnecessary new release by checking the remote git HEAD without cloning the repo.
+set('check_remote_head', false);
 
 set('repository', ''); // Repository to deploy.
 

--- a/recipe/deploy/prepare.php
+++ b/recipe/deploy/prepare.php
@@ -42,8 +42,7 @@ task('deploy:prepare', function () {
     // This avoid unnecessary releases when the last commit id matches the existing one (HEAD)
     $repository  = trim(get('repository'));
     $revision    = input()->getOption('revision') ?? null;
-    $remoteHead  = $revision ? $revision :
-        run(sprintf('%s ls-remote %s HEAD | tr -d "HEAD"', get('bin/git'), $repository));
+    $remoteHead  = $revision ?? run(sprintf('%s ls-remote %s HEAD | tr -d "HEAD"', get('bin/git'), $repository));
 
     if (true === get('check_remote_head') && null == input()->getOption('tag')) {
         $headPath = trim(get('deploy_path').'/.dep/HEAD');

--- a/recipe/deploy/prepare.php
+++ b/recipe/deploy/prepare.php
@@ -46,7 +46,7 @@ task('deploy:prepare', function () {
 
     if (true === get('check_remote_head') && null == input()->getOption('tag')) {
         $headPath = trim(get('deploy_path').'/.dep/HEAD');
-        $headContents = run(sprintf('if [ -e %s ]; then cat %1$s; fi', $headPath));
+        $headContents = run(sprintf('test -e %s && cat %1$s', $headPath));
         //check if HEAD file is exists and then compare it
         if (trim($headContents) === trim($remoteHead)) {
             throw new GracefulShutdownException("Already up-to-date.");

--- a/recipe/deploy/prepare.php
+++ b/recipe/deploy/prepare.php
@@ -43,18 +43,14 @@ task('deploy:prepare', function () {
     $repository  = trim(get('repository'));
     $revision    = input()->getOption('revision') ?? null;
     $remoteHead  = $revision ? $revision :
-        trim(run(sprintf('%s ls-remote %s HEAD | tr -d "HEAD"',
-            get('bin/git'), $repository)));
+        run(sprintf('%s ls-remote %s HEAD | tr -d "HEAD"', get('bin/git'), $repository));
+
     if (true === get('check_remote_head') && null == input()->getOption('tag')) {
         $headPath = trim(get('deploy_path').'/.dep/HEAD');
-        $isRemoteHeadExists = test("[ -f $headPath ]");
-
+        $headContents = run(sprintf('if [ -e %s ]; then cat %1$s; fi', $headPath));
         //check if HEAD file is exists and then compare it
-        if (true === $isRemoteHeadExists) {
-            $headContents = run('cat '.$headPath);
-            if ($headContents === $remoteHead) {
-                throw new GracefulShutdownException("Already up-to-date.");
-            }
+        if (trim($headContents) === trim($remoteHead)) {
+            throw new GracefulShutdownException("Already up-to-date.");
         }
     }
     run("cd {{deploy_path}} && echo ".$remoteHead.' > .dep/HEAD');

--- a/recipe/deploy/prepare.php
+++ b/recipe/deploy/prepare.php
@@ -7,6 +7,7 @@
 
 namespace Deployer;
 
+use Deployer\Exception\GracefulShutdownException;
 use function Deployer\Support\str_contains;
 
 desc('Preparing host for deploy');
@@ -46,14 +47,13 @@ task('deploy:prepare', function () {
             get('bin/git'), $repository)));
     if (true === get('check_remote_head') && null == input()->getOption('tag')) {
         $headPath = trim(get('deploy_path').'/.dep/HEAD');
-        $isRemoteHeadExists = (bool) run('if [ -f '.$headPath.' ]; then echo 1; else echo 0; fi');
+        $isRemoteHeadExists = test("[ -f $headPath ]");
 
         //check if HEAD file is exists and then compare it
         if (true === $isRemoteHeadExists) {
             $headContents = run('cat '.$headPath);
             if ($headContents === $remoteHead) {
-                writeln('<info>Already up-to-date.</info>');
-                exit(0);
+                throw new GracefulShutdownException("Already up-to-date.");
             }
         }
     }

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -261,18 +261,24 @@ class Task
 
     /**
      * @param string $task
+     *
+     * @return $this
      */
     public function addBefore(string $task)
     {
         array_unshift($this->before, $task);
+        return $this;
     }
 
     /**
      * @param string $task
+     *
+     * @return $this
      */
     public function addAfter(string $task)
     {
         array_push($this->after, $task);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Checking the remote git HEAD without cloning the repo.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1755

A new option `check_remote_head` has been added, when this option sets to `true` deployer will not clone the repository if there are no changes found.

Thanks to `git ls-remote`, this command gets the `HEAD` without cloning the repository.

Revision is also checked, so if we run something like `dep deploy --revision=a69539703d917cafb1c51dad20f4ee1e317c3017` deployer will also check for the revision.

