### PR TITLE
Added trim function to the changelog parser tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed Range expansion when hosts.yml is loaded. [#1671]
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
+- Fixed parser errors by adding the trim function to the changelog parser tokens
 
 
 ## v6.3.0

--- a/src/Support/Changelog/Parser.php
+++ b/src/Support/Changelog/Parser.php
@@ -31,7 +31,7 @@ class Parser
 
     public function __construct(string $changelog, bool $strict = true)
     {
-        $this->tokens = preg_split("/\n/", $changelog);
+        $this->tokens = array_map('trim', explode("\n", $changelog));
         $this->strict = $strict;
     }
 


### PR DESCRIPTION
Fixed parser errors by adding the trim function to the changelog parser tokens.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1755