### PR TITLE
Code style fixes

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -34,7 +34,7 @@ $app->register('update')->setCode(function () use ($io) {
 
     $item = new Item();
 
-    $message = $io->ask("What is " . strtolower($type) . '?');
+    $message = $io->ask('What is ' . strtolower($type) . '?');
     $message = ucfirst($message);
     $message = trim(rtrim($message, '.'));
 
@@ -78,7 +78,7 @@ $app->register('release')->setCode(function () use ($io) {
     do {
         $v = $io->ask("What version to release? (latest {$latest->getVersion()})");
         if (!preg_match('/^\d+\.\d+\.\d+(-[\d\w\.]+)?$/', $v)) {
-            $io->warning("Version number must follow semantic versioning.");
+            $io->warning('Version number must follow semantic versioning.');
             continue;
         }
         break;

--- a/bin/changelog
+++ b/bin/changelog
@@ -45,14 +45,14 @@ $app->register('update')->setCode(function () use ($io) {
         $url = $io->ask('Closed issues/pulls url', $noop);
         if ($url === $noop) {
             break;
+        }
+
+        if (preg_match('#^https\://github\.com/deployphp/deployer/(issues|pull)/(\d+)$#', $url, $m)) {
+            $ref = (int)$m[2];
+            $item->addReference($ref);
+            $changelog->addReferences($ref, $url);
         } else {
-            if (preg_match('#^https\://github\.com/deployphp/deployer/(issues|pull)/(\d+)$#', $url, $m)) {
-                $ref = (int)$m[2];
-                $item->addReference($ref);
-                $changelog->addReferences($ref, $url);
-            } else {
-                $io->warning('Url should be link to GitHub issue or pull page of deployphp/deployer repo.');
-            }
+            $io->warning('Url should be link to GitHub issue or pull page of deployphp/deployer repo.');
         }
     } while (true);
 

--- a/bin/changelog
+++ b/bin/changelog
@@ -58,7 +58,7 @@ $app->register('update')->setCode(function () use ($io) {
 
     $changelog->findMaster()->{"add$type"}($item);
 
-    file_put_contents(CHANGELOG, "$changelog");
+    file_put_contents(CHANGELOG, (string)$changelog);
 
     $io->success(CHANGELOG . ' updated');
 });
@@ -66,7 +66,7 @@ $app->register('update')->setCode(function () use ($io) {
 $app->register('fix')->setCode(function () use ($io) {
     $parser = new Parser(file_get_contents(CHANGELOG), false);
     $changelog = $parser->parse();
-    file_put_contents(CHANGELOG, "$changelog");
+    file_put_contents(CHANGELOG, (string)$changelog);
 });
 
 $app->register('release')->setCode(function () use ($io) {
@@ -86,7 +86,7 @@ $app->register('release')->setCode(function () use ($io) {
 
     $changelog->findMaster()->setVersion('v' . $v);
 
-    file_put_contents(CHANGELOG, "$changelog");
+    file_put_contents(CHANGELOG, (string)$changelog);
     $io->success(CHANGELOG . " updated to v$v");
 });
 

--- a/bin/changelog
+++ b/bin/changelog
@@ -77,7 +77,7 @@ $app->register('release')->setCode(function () use ($io) {
 
     do {
         $v = $io->ask("What version to release? (latest {$latest->getVersion()})");
-        if (!preg_match('/^\d+\.\d+\.\d+(-[\d\w\.]+)?$/', $v)) {
+        if (!preg_match('/^\d+\.\d+\.\d+(-[\w\.]+)?$/', $v)) {
             $io->warning('Version number must follow semantic versioning.');
             continue;
         }

--- a/src/Support/Changelog/Item.php
+++ b/src/Support/Changelog/Item.php
@@ -21,7 +21,7 @@ class Item
     {
         sort($this->references, SORT_NUMERIC);
 
-        $references = join('', array_map(function ($ref) {
+        $references = implode('', array_map(function ($ref) {
             return " [#$ref]";
         }, $this->references));
 

--- a/src/Support/Changelog/ParseException.php
+++ b/src/Support/Changelog/ParseException.php
@@ -9,7 +9,7 @@ namespace Deployer\Support\Changelog;
 
 class ParseException extends \Exception
 {
-    public function __construct(string $message = "", $code = "")
+    public function __construct(string $message = '', $code = '')
     {
         parent::__construct("$message\n\n{$code}\n\n");
     }

--- a/src/Support/Changelog/Parser.php
+++ b/src/Support/Changelog/Parser.php
@@ -96,7 +96,7 @@ class Parser
             $this->next();
         }
 
-        return new ParseException($message, join("\n", $this->span));
+        return new ParseException($message, implode("\n", $this->span));
     }
 
     public function parse(): Changelog

--- a/src/Support/Changelog/Parser.php
+++ b/src/Support/Changelog/Parser.php
@@ -182,7 +182,7 @@ class Parser
         throw $this->error('Expected version');
     }
 
-    private function parseItems()
+    private function parseItems(): array
     {
         $items = [];
         while (preg_match('/^\- (.+) $/x', $this->current(), $m)) {
@@ -204,7 +204,7 @@ class Parser
         return $items;
     }
 
-    private function parseReferences()
+    private function parseReferences(): array
     {
         $refs = [];
         while (preg_match('/^\[/', $this->current())) {

--- a/src/Support/Changelog/Parser.php
+++ b/src/Support/Changelog/Parser.php
@@ -38,7 +38,7 @@ class Parser
     private function current(): string
     {
         if (count($this->tokens) === 0) {
-            return "";
+            return '';
         }
         return $this->tokens[0];
     }
@@ -64,8 +64,8 @@ class Parser
     private function acceptEmptyLine()
     {
         if ($this->strict) {
-            if ("" !== $this->next()) {
-                throw $this->error("Expected an empty line");
+            if ('' !== $this->next()) {
+                throw $this->error('Expected an empty line');
             }
         } else {
             while (preg_match('/^\s*$/', $this->current()) && count($this->tokens) > 0) {
@@ -78,7 +78,7 @@ class Parser
     {
         if (count($this->tokens) !== 0) {
             $this->next();
-            throw $this->error("Expected EOF");
+            throw $this->error('Expected EOF');
         }
     }
 
@@ -128,7 +128,7 @@ class Parser
             return $c;
         }
 
-        throw $this->error("Expected title");
+        throw $this->error('Expected title');
     }
 
     private function parseVersion(): Version
@@ -139,7 +139,7 @@ class Parser
 
             $compareLink = $this->next();
             if (!preg_match('/^\[/', $compareLink)) {
-                throw $this->error("Expected link to compare page with previous version");
+                throw $this->error('Expected link to compare page with previous version');
             }
 
             $prev = 'v\d+\.\d+\.\d+(-[\d\w\.]+)?';
@@ -151,7 +151,7 @@ class Parser
             if (preg_match($regexp, $compareLink, $m)) {
                 $version->setPrevious($m[1]);
             } else {
-                throw $this->error("Error in compare link syntax");
+                throw $this->error('Error in compare link syntax');
             }
 
             $this->acceptEmptyLine();
@@ -179,7 +179,7 @@ class Parser
             return $version;
         }
 
-        throw $this->error("Expected version");
+        throw $this->error('Expected version');
     }
 
     private function parseItems()

--- a/src/Support/Changelog/Parser.php
+++ b/src/Support/Changelog/Parser.php
@@ -84,7 +84,7 @@ class Parser
 
     private function matchVersion($line, &$m = null)
     {
-        return preg_match('/^\#\# \s ( v\d+\.\d+\.\d+(-[\d\w\.]+)? | master )$/x', $line, $m);
+        return preg_match('/^\#\# \s ( v\d+\.\d+\.\d+(-[\w\.]+)? | master )$/x', $line, $m);
     }
 
     private function error($message): ParseException

--- a/src/Support/Changelog/Version.php
+++ b/src/Support/Changelog/Version.php
@@ -50,19 +50,19 @@ class Version
         $fixed = '';
         $removed = '';
         if (!empty($this->added)) {
-            $added = join("\n", array_map($f, $this->added));
+            $added = implode("\n", array_map($f, $this->added));
             $added = "### Added\n$added\n\n";
         }
         if (!empty($this->changed)) {
-            $changed = join("\n", array_map($f, $this->changed));
+            $changed = implode("\n", array_map($f, $this->changed));
             $changed = "### Changed\n$changed\n\n";
         }
         if (!empty($this->fixed)) {
-            $fixed = join("\n", array_map($f, $this->fixed));
+            $fixed = implode("\n", array_map($f, $this->fixed));
             $fixed = "### Fixed\n$fixed\n\n";
         }
         if (!empty($this->removed)) {
-            $removed = join("\n", array_map($f, $this->removed));
+            $removed = implode("\n", array_map($f, $this->removed));
             $removed = "### Removed\n$removed\n\n";
         }
 

--- a/src/Support/Changelog/Version.php
+++ b/src/Support/Changelog/Version.php
@@ -45,10 +45,10 @@ class Version
             return "- $item";
         };
 
-        $added = "";
-        $changed = "";
-        $fixed = "";
-        $removed = "";
+        $added = '';
+        $changed = '';
+        $fixed = '';
+        $removed = '';
         if (!empty($this->added)) {
             $added = join("\n", array_map($f, $this->added));
             $added = "### Added\n$added\n\n";

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -78,6 +78,10 @@ function str_contains(string $haystack, string $needle)
  * Take array of key/value and create string of it.
  *
  * This function used for create environment string.
+ *
+ * @param array $array
+ *
+ * @return string
  */
 function array_to_string(array $array): string
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Some small code styles fixes:
1. Update missing argument in PHPDoc.
1. Splits the IF-statement/workflow(s) for readability
1. Replace double quotes to single quotes.
1. Replaced alias functions by original functions.
1. Define return types.
1. Type casting can be used
1. Non-optimal regular expression, \d is a subset of \w.
