### PR TITLE
Added recipe for sulu 1.x and improve sulu 2.x recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `horizon:terminate` to the Laravel recipe
 - Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
 - Added recipe for sulu 2.0 [#1758]
+- Added recipe for sulu 1.x [#1764]
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
@@ -422,6 +423,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1764]: https://github.com/deployphp/deployer/pull/1764
 [#1758]: https://github.com/deployphp/deployer/pull/1758
 [#1709]: https://github.com/deployphp/deployer/issues/1709
 [#1708]: https://github.com/deployphp/deployer/pull/1708

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added `horizon:terminate` to the Laravel recipe
 - Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
 - Added recipe for sulu 2.0 [#1758]
-- Added recipe for sulu 1.x [#1764]
+- Added recipe for sulu 1.x and improve sulu 2.0 recipe [#1764]
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task

--- a/recipe/sulu.php
+++ b/recipe/sulu.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Deployer;
+
+require_once __DIR__ . '/symfony3.php';
+
+set('shared_dirs', ['var/indexes', 'var/logs', 'var/sessions', 'var/sitemaps', 'var/uploads', 'web/uploads']);
+
+set('writable_dirs', ['var/indexes', 'var/logs', 'var/sessions', 'var/sitemaps', 'var/uploads', 'web/uploads', 'var/cache']);
+
+set('bin/websiteconsole', function () {
+    return parse('{{bin/php}} {{release_path}}/bin/websiteconsole --no-interaction');
+});
+
+desc('Migrate PHPCR');
+task(
+    'phpcr:migrate',
+    function () {
+        run('{{bin/php}} {{bin/console}} phpcr:migrations:migrate {{console_options}}');
+    }
+);
+
+desc('Clear cache');
+task('deploy:website:cache:clear', function () {
+    run('{{bin/websiteconsole}} cache:clear {{console_options}} --no-warmup');
+});
+
+desc('Warm up cache');
+task('deploy:website:cache:warmup', function () {
+    run('{{bin/websiteconsole}} cache:warmup {{console_options}}');
+});
+
+after('deploy:cache:clear', 'deploy:website:cache:clear');
+after('deploy:website:cache:clear', 'deploy:website:cache:warmup');

--- a/recipe/sulu.php
+++ b/recipe/sulu.php
@@ -4,9 +4,9 @@ namespace Deployer;
 
 require_once __DIR__ . '/symfony3.php';
 
-set('shared_dirs', ['var/indexes', 'var/logs', 'var/sessions', 'var/sitemaps', 'var/uploads', 'web/uploads']);
+add('shared_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'web/uploads']);
 
-set('writable_dirs', ['var/indexes', 'var/logs', 'var/sessions', 'var/sitemaps', 'var/uploads', 'web/uploads', 'var/cache']);
+add('writable_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'web/uploads']);
 
 set('bin/websiteconsole', function () {
     return parse('{{bin/php}} {{release_path}}/bin/websiteconsole --no-interaction');

--- a/recipe/sulu2.php
+++ b/recipe/sulu2.php
@@ -4,9 +4,9 @@ namespace Deployer;
 
 require_once __DIR__ . '/symfony4.php';
 
-set('shared_dirs', ['var/indexes', 'var/log', 'var/sessions', 'var/sitemaps', 'var/uploads', 'public/uploads']);
+add('shared_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'public/uploads']);
 
-set('writable_dirs', ['var', 'public/uploads']);
+add('writable_dirs', ['public/uploads']);
 
 set('bin/websiteconsole', function () {
     return parse('{{bin/php}} {{release_path}}/bin/websiteconsole --no-interaction');

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -7,7 +7,7 @@
 
 namespace Deployer;
 
-require_once 'recipe/common.php';
+require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
 set('shared_files', ['.env']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No

Added recipe for sulu 1.x and uses `add` function instead of duplicate the `writable_dirs` and `shared_dirs` from symfony in sulu 2.x recipe.

Related to #1758