### PR TITLE
Escape arguments passed to rsync shell command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
 - Fixed parser errors by adding the trim function to the changelog parser tokens
+- Arguments to rsync were not properly escaped
 
 
 ## v6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
 - Fixed parser errors by adding the trim function to the changelog parser tokens
-- Arguments to rsync were not properly escaped
+- Fixed arguments for rsync to be properly escaped
 
 
 ## v6.3.0

--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -37,7 +37,9 @@ class Rsync
         ];
         $config = array_merge($defaults, $config);
 
-        $rsync = "rsync -azP " . implode(' ', $config['options']) . " $source $destination";
+        $escapedSource = escapeshellarg($source);
+        $escapedDestination = escapeshellarg($destination);
+        $rsync = "rsync -azP " . implode(' ', $config['options']) . " $escapedSource $escapedDestination";
 
         $this->pop->command($hostname, $rsync);
 


### PR DESCRIPTION
This fixes errors when attempting to upload a path containing spaces.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

