### PR TITLE
Let rsync honor 'become' option for host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
 - Fixed parser errors by adding the trim function to the changelog parser tokens
+- Uploads using rsync did not honor the 'become' option set for a host
 
 
 ## v6.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `migrations_config` option to the Symfony recipes to specify Doctrine migration configuration to use
 - Added recipe for sulu 2.0 [#1758]
 - Added recipe for sulu 1.x and improve sulu 2.0 recipe [#1764]
+- Added `become` option for rsync upload
 
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
@@ -20,7 +21,6 @@
 - Fixed usage (only if present) of deploy_path config setting. [#1677]
 - Fixed adding custom headers causes Httpie default header override.
 - Fixed parser errors by adding the trim function to the changelog parser tokens
-- Uploads using rsync did not honor the 'become' option set for a host
 
 
 ## v6.3.0

--- a/src/functions.php
+++ b/src/functions.php
@@ -461,13 +461,19 @@ function download($source, $destination, array $config = [])
     if ($host instanceof Localhost) {
         $rsync->call($host->getHostname(), $source, $destination, $config);
     } else {
+        if (!isset($config['options']) || !is_array($config['options'])) {
+            $config['options'] = [];
+        }
+
         $sshArguments = $host->getSshArguments()->getCliArguments();
         if (empty($sshArguments) === false) {
-            if (!isset($config['options']) || !is_array($config['options'])) {
-                $config['options'] = [];
-            }
             $config['options'][] = "-e 'ssh $sshArguments'";
         }
+
+        if ($host->has("become")) {
+            $config['options'][]  = "--rsync-path='sudo -H -u " . $host->get('become') . " rsync'";
+        }
+
         $rsync->call($host->getHostname(), "$host:$source", $destination, $config);
     }
 }


### PR DESCRIPTION
If a host has a 'become' option set, it seems sensible that rsync uploads
should also be performed as that same user, which is currently not the case.
This change makes rsync run as the 'become' user by running sudo on the
remote side, just like how 'become' is implemented for normal SSH commands.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
