### PR TITLE
Only share the local file

### DIFF
--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -10,7 +10,7 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
-set('shared_files', ['.env']);
+set('shared_files', ['.env.local']);
 set('writable_dirs', ['var']);
 set('migrations_config', '');
 


### PR DESCRIPTION
https://symfony.com/doc/current/configuration/dot-env-changes.html

Recent changes mean that .env should no longer be shared. It is the fallback if no .env.local exists. Instead we should share the .env.local files.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
