### PR TITLE
http_user detection command could return wrong user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -427,6 +427,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1778]: https://github.com/deployphp/deployer/issues/1778
 [#1764]: https://github.com/deployphp/deployer/pull/1764
 [#1758]: https://github.com/deployphp/deployer/pull/1758
 [#1709]: https://github.com/deployphp/deployer/issues/1709

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 - Laravel recipe should not run `artisan:cache:clear` in `deploy` task
 - Pass-through the quiet mode into the git commands for updating code
+- `deploy:writable` will no longer be able to automatically detect http_user if there are multiple candidates for the role [#1778]
 
 ### Fixed
 - Fixed Range expansion when hosts.yml is loaded. [#1671]

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -23,8 +23,10 @@ task('deploy:writable', function () {
     }
 
     if ($httpUser === false && ! in_array($mode, ['chgrp', 'chmod'], true)) {
-        // Detect http user in process list.
-        $httpUser = run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | head -1 | awk '{print $2}'");
+        // Attempt to detect http user in process list.
+        if (test("[ $(ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | uniq | wc -l) -eq 1 ]")) {
+            $httpUser = run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | uniq | head -1 | awk '{print $2}'");
+        }
 
         if (empty($httpUser)) {
             throw new \RuntimeException(

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -24,8 +24,9 @@ task('deploy:writable', function () {
 
     if ($httpUser === false && ! in_array($mode, ['chgrp', 'chmod'], true)) {
         // Attempt to detect http user in process list.
-        if (test("[ $(ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | uniq | wc -l) -eq 1 ]")) {
-            $httpUser = run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | uniq | head -1 | awk '{print $2}'");
+        $httpUserCandidates = explode("\n", run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | uniq | awk '{print $2}'"));
+        if (count($httpUserCandidates) === 1) {
+            $httpUser = $httpUserCandidates[0];
         }
 
         if (empty($httpUser)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes 
| Deprecations? | No
| Fixed tickets | #1778 

My Bash is really bad, so I would highlight the fact that this needs reviewing. I tried deploying on three servers (with 0/1/3 http_user candidates) and it worked as expected - only the server with a single unique candidate detected http_user. Of the three servers, two were ubuntu servers and one was my local machine which is macOS.

Another important note is that this will break BC for users who were lucky to have multiple http_user candidates, and the first one from the list was the correct one - so consider maybe delaying this for the next major release.

If there is anything else I can help please let me know :)