### PR TITLE
Fix task(...)->once() with --parallel and --limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed Laravel `laravel_version` failure
 - Fixed parser errors by adding the trim function to the changelog parser tokens
 - Fixed arguments for rsync to be properly escaped
+- Prevent multiple execution of task()->once() with --parallel and --limit option [#1419]
 
 
 ## v6.3.0

--- a/src/Executor/ParallelExecutor.php
+++ b/src/Executor/ParallelExecutor.php
@@ -126,7 +126,7 @@ class ParallelExecutor implements ExecutorInterface
             if ($task->shouldBePerformed($host)) {
                 $processes[$host->getHostname()] = $this->getProcess($host, $task);
                 if ($task->isOnce()) {
-                    break;
+                    $task->setHasRun();
                 }
             }
         }

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -319,4 +319,14 @@ class Task
     {
         return $this->shallow;
     }
+
+    /**
+     * @internal this is used by ParallelExecutor and prevent multiple run
+     */
+    public function setHasRun()
+    {
+        if ($this->isOnce()) {
+            $this->hasRun = true;
+        }
+    }
 }

--- a/test/fixture/recipe/parallel.php
+++ b/test/fixture/recipe/parallel.php
@@ -11,7 +11,7 @@ require 'recipe/common.php';
 
 // Hosts
 
-localhost('host[1:2]')
+localhost('host[1:4]')
     ->set('deploy_path', __DIR__ . '/tmp/localhost');
 
 

--- a/test/recipe/ParallelOnceTest.php
+++ b/test/recipe/ParallelOnceTest.php
@@ -33,5 +33,23 @@ class ParallelOnceTest extends DepCase
 
         self::assertFileExists(self::$currentPath . '/deployed-host1');
         self::assertFileNotExists(self::$currentPath . '/deployed-host2');
+        self::assertFileNotExists(self::$currentPath . '/deployed-host3');
+        self::assertFileNotExists(self::$currentPath . '/deployed-host4');
+    }
+
+    public function testOnceWithLimit()
+    {
+        $output = $this->start('deploy', [
+            '--parallel' => true,
+            '--limit' => 2,
+            '--file' => DEPLOYER_FIXTURES . '/recipe/parallel.php'
+        ], [
+            'verbosity' => OutputInterface::VERBOSITY_DEBUG
+        ]);
+
+        self::assertFileExists(self::$currentPath . '/deployed-host1');
+        self::assertFileNotExists(self::$currentPath . '/deployed-host2');
+        self::assertFileNotExists(self::$currentPath . '/deployed-host3');
+        self::assertFileNotExists(self::$currentPath . '/deployed-host4');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1419 

# Description

Prevent multiple execution of tasks marked as `once()` when the `--parallel` and `--limit` option are used
