### PR TITLE
improve ParallelExecutor::generateOptions to manage all types of InputOption

### DIFF
--- a/src/Console/Input/Argument.php
+++ b/src/Console/Input/Argument.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console\Input;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class Argument
+{
+    public static function toString(
+        InputInterface $input,
+        InputArgument $argument
+    ): string {
+        return $input->getArgument($argument->getName());
+    }
+}

--- a/src/Console/Input/Option.php
+++ b/src/Console/Input/Option.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console\Input;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+final class Option
+{
+    public static function toString(
+        InputInterface $input,
+        InputOption $option
+    ): string {
+        $name = $option->getName();
+
+        if (!$option->acceptValue()) {
+            return \sprintf(
+                '--%s',
+                $name
+            );
+        }
+
+        if (!$option->isArray()) {
+            return self::generatePartialOption(
+                $option,
+                $name,
+                $input->getOption($name)
+            );
+        }
+
+        /** @var string[] $outputs */
+        $outputs = [];
+        foreach ($input->getOption($name) as $value) {
+            $value = self::generatePartialOption(
+                $option,
+                $name,
+                $value
+            );
+
+            if ($value === '') {
+                continue;
+            }
+
+            $outputs[] = $value;
+        }
+
+        return \implode(' ', $outputs);
+    }
+
+    /**
+     * @param null|string $value
+     */
+    private static function generatePartialOption(
+        InputOption $option,
+        string $name,
+        $value
+    ): string {
+        if (\null !== $value && \strlen($value) !== 0) {
+            return \sprintf(
+                '--%s=%s',
+                $name,
+                $value
+            );
+        }
+
+        if ($option->isValueOptional()) {
+            return \sprintf(
+                '--%s',
+                $name
+            );
+        }
+
+        return '';
+    }
+}

--- a/src/Console/Output/VerbosityString.php
+++ b/src/Console/Output/VerbosityString.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* (c) Anton Medvedev <anton@medv.io>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -16,44 +16,29 @@ class VerbosityString
      */
     private $output;
 
-    /**
-     * @param OutputInterface $output
-     */
     public function __construct(OutputInterface $output)
     {
         $this->output = $output;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         switch ($this->output->getVerbosity()) {
-            case OutputInterface::VERBOSITY_NORMAL:
-                $verbosity = '';
-                break;
-
             case OutputInterface::VERBOSITY_VERBOSE:
-                $verbosity = '-v';
-                break;
+                return '-v';
 
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
-                $verbosity = '-vv';
-                break;
+                return '-vv';
 
             case OutputInterface::VERBOSITY_DEBUG:
-                $verbosity = '-vvv';
-                break;
+                return '-vvv';
 
             case OutputInterface::VERBOSITY_QUIET:
-                $verbosity = '-q';
-                break;
+                return '-q';
 
+            case OutputInterface::VERBOSITY_NORMAL:
             default:
-                $verbosity = '';
+                return '';
         }
-
-        return $verbosity;
     }
 }

--- a/test/src/Console/Input/ArgumentTest.php
+++ b/test/src/Console/Input/ArgumentTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console\Input;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+
+final class ArgumentTest extends TestCase
+{
+    public function toStringProvider(): \Generator
+    {
+        foreach ([
+                     ['fooBar', 'fooBar'],
+                     ['0', '0'],
+                     ['1', '1'],
+                     ['foo\-%&Bar', 'foo\-%&Bar'],
+                     ['\'', '\''],
+                     ['ù+ì', 'ù+ì'],
+                 ] as list($expectedValue, $inputValue)) {
+            $input = $this->createMock(InputInterface::class);
+            $input->expects($this->once())
+                ->method('getArgument')
+                ->willReturn($inputValue);
+
+            $argument = $this->createMock(InputArgument::class);
+            $argument->expects($this->once())
+                ->method('getName')
+                ->willReturn('argumentName');
+
+            yield [
+                $expectedValue,
+                $input,
+                $argument,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider toStringProvider
+     *
+     * @return void
+     */
+    public function testToString(
+        string $expectedValue,
+        InputInterface $input,
+        InputArgument $argument
+    ) {
+        $this->assertEquals(
+            $expectedValue,
+            Argument::toString($input, $argument)
+        );
+    }
+}

--- a/test/src/Console/Input/OptionTest.php
+++ b/test/src/Console/Input/OptionTest.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console\Input;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+final class OptionTest extends TestCase
+{
+    public function toStringProvider(): \Generator
+    {
+        // InputOption::VALUE_NONE
+        foreach ([
+                     ['--fooBar', 'fooBar'],
+                     ['--0', '0'],
+                     ['--1', '1'],
+                     ['--foo\-%&Bar', 'foo\-%&Bar'],
+                     ['--ù+ì', 'ù+ì'],
+                 ] as list($expectedValue, $optionName)) {
+            $input = $this->createMock(InputInterface::class);
+
+            $option = $this->createMock(InputOption::class);
+            $option->expects($this->once())
+                ->method('getName')
+                ->willReturn($optionName);
+
+            $option->expects($this->once())
+                ->method('acceptValue')
+                ->willReturn(\false);
+
+            yield [
+                $expectedValue,
+                $input,
+                $option,
+            ];
+        }
+
+        // InputOption::VALUE_REQUIRED
+        foreach ([
+                     ['--fooBar=ciao', 'fooBar', 'ciao'],
+                     ['', 'fooBar', \null],
+                     ['', 'fooBar', ''],
+                     ['--fooBar=0', 'fooBar', '0'],
+                     ['--foo\-%&Bar=test', 'foo\-%&Bar', 'test'],
+                     ['--ù+ì=omg', 'ù+ì', 'omg'],
+                 ] as list($expectedValue, $optionName, $optionValue)) {
+            $input = $this->createMock(InputInterface::class);
+            $input->expects($this->once())
+                ->method('getOption')
+                ->willReturn($optionValue);
+
+            $option = $this->createMock(InputOption::class);
+            $option->expects($this->once())
+                ->method('getName')
+                ->willReturn($optionName);
+
+            $option->expects($this->once())
+                ->method('acceptValue')
+                ->willReturn(\true);
+
+            $option->expects($this->once())
+                ->method('isArray')
+                ->willReturn(\false);
+
+            $option->expects($this->any())
+                ->method('isValueOptional')
+                ->willReturn(\false);
+
+            yield [
+                $expectedValue,
+                $input,
+                $option,
+            ];
+        }
+
+        // InputOption::VALUE_OPTIONAL
+        foreach ([
+                     ['--fooBar=ciao', 'fooBar', 'ciao'],
+                     ['--fooBar', 'fooBar', \null],
+                     ['--fooBar', 'fooBar', ''],
+                     ['--fooBar=0', 'fooBar', '0'],
+                     ['--foo\-%&Bar=test', 'foo\-%&Bar', 'test'],
+                     ['--ù+ì=omg', 'ù+ì', 'omg'],
+                 ] as list($expectedValue, $optionName, $optionValue)) {
+            $input = $this->createMock(InputInterface::class);
+            $input->expects($this->once())
+                ->method('getOption')
+                ->willReturn($optionValue);
+
+            $option = $this->createMock(InputOption::class);
+            $option->expects($this->once())
+                ->method('getName')
+                ->willReturn($optionName);
+
+            $option->expects($this->once())
+                ->method('acceptValue')
+                ->willReturn(\true);
+
+            $option->expects($this->once())
+                ->method('isArray')
+                ->willReturn(\false);
+
+            $option->expects($this->any())
+                ->method('isValueOptional')
+                ->willReturn(\true);
+
+            yield [
+                $expectedValue,
+                $input,
+                $option,
+            ];
+        }
+
+        // InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY
+        foreach ([
+                     ['--fooBar=ciao --fooBar=Привет', 'fooBar', ['ciao', 'Привет']],
+                     ['--fooBar=ciao --fooBar=Привет', 'fooBar', ['ciao', \null, 'Привет']],
+                     ['', 'fooBar', [\null, '']],
+                     ['', 'fooBar', [\null]],
+                     ['', 'fooBar', ['']],
+                     ['--fooBar=0 --fooBar=1 --fooBar=2 --fooBar=...', 'fooBar', ['0', '1', '2', '...']],
+                 ] as list($expectedValue, $optionName, $optionValue)) {
+            $input = $this->createMock(InputInterface::class);
+            $input->expects($this->once())
+                ->method('getOption')
+                ->willReturn($optionValue);
+
+            $option = $this->createMock(InputOption::class);
+            $option->expects($this->once())
+                ->method('getName')
+                ->willReturn($optionName);
+
+            $option->expects($this->once())
+                ->method('acceptValue')
+                ->willReturn(\true);
+
+            $option->expects($this->once())
+                ->method('isArray')
+                ->willReturn(\true);
+
+            $option->expects($this->any())
+                ->method('isValueOptional')
+                ->willReturn(\false);
+
+            yield [
+                $expectedValue,
+                $input,
+                $option,
+            ];
+        }
+
+        // InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY
+        foreach ([
+                     ['--fooBar=ciao --fooBar=Привет', 'fooBar', ['ciao', 'Привет']],
+                     ['--fooBar=ciao --fooBar --fooBar=Привет', 'fooBar', ['ciao', \null, 'Привет']],
+                     ['--fooBar --fooBar', 'fooBar', [\null, '']],
+                     ['--fooBar', 'fooBar', [\null]],
+                     ['--fooBar', 'fooBar', ['']],
+                     ['--fooBar=0 --fooBar=1 --fooBar=2 --fooBar=...', 'fooBar', ['0', '1', '2', '...']],
+                 ] as list($expectedValue, $optionName, $optionValue)) {
+            $input = $this->createMock(InputInterface::class);
+            $input->expects($this->once())
+                ->method('getOption')
+                ->willReturn($optionValue);
+
+            $option = $this->createMock(InputOption::class);
+            $option->expects($this->once())
+                ->method('getName')
+                ->willReturn($optionName);
+
+            $option->expects($this->once())
+                ->method('acceptValue')
+                ->willReturn(\true);
+
+            $option->expects($this->once())
+                ->method('isArray')
+                ->willReturn(\true);
+
+            $option->expects($this->any())
+                ->method('isValueOptional')
+                ->willReturn(\true);
+
+            yield [
+                $expectedValue,
+                $input,
+                $option,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider toStringProvider
+     *
+     * @return void
+     */
+    public function testToString(
+        string $expectedValue,
+        InputInterface $input,
+        InputOption $option
+    ) {
+        $this->assertEquals(
+            $expectedValue,
+            Option::toString($input, $option)
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | https://github.com/deployphp/deployer/pull/1721#issuecomment-453936737