### PR TITLE
Fix rsync upload honor become option for host

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -433,13 +433,19 @@ function upload($source, $destination, array $config = [])
     if ($host instanceof Localhost) {
         $rsync->call($host->getHostname(), $source, $destination, $config);
     } else {
+        if (!isset($config['options']) || !is_array($config['options'])) {
+            $config['options'] = [];
+        }
+
         $sshArguments = $host->getSshArguments()->getCliArguments();
         if (empty($sshArguments) === false) {
-            if (!isset($config['options']) || !is_array($config['options'])) {
-                $config['options'] = [];
-            }
             $config['options'][] = "-e 'ssh $sshArguments'";
         }
+
+        if ($host->has("become")) {
+            $config['options'][]  = "--rsync-path='sudo -H -u " . $host->get('become') . " rsync'";
+        }
+
         $rsync->call($host->getHostname(), $source, "$host:$destination", $config);
     }
 }


### PR DESCRIPTION
v 6.4.0 introduced the option for rsync to honor the `become` option on a host, however that code was placed only on the `download` function and not the `upload` function. This fixes that and allows rsync upload to honor `become`

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
