### PR TITLE
Revert "moved symfony finder to dev-dependency (#1702)" as it breaks upload() function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
         "phpseclib/phpseclib": "~2.0",
         "pimple/pimple": "~3.0",
         "symfony/console": "~2.6|~3.0",
+        "symfony/finder": "~2.6|~3.0",
         "symfony/process": "~2.6|~3.0",
         "symfony/yaml": "~2.6|~3.0"
     },
     "require-dev": {
         "deployer/phar-update": "~2.0",
-        "phpunit/phpunit": "~5.7",
-        "symfony/finder": "~2.6|~3.0"
+        "phpunit/phpunit": "~5.7"
     },
     "suggest": {
         "ext-sockets": "For parallel deployment"


### PR DESCRIPTION
…upload() function

This reverts commit 30c7f43f

#####################################################################
I'm working on **first LTS release** of Deployer. 
Please, consider supporting Deployer development on Patreon page: 

   https://www.patreon.com/deployer

#####################################################################


| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
