### PR TITLE
Changes to .env for symfony4 recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Fix rsync upload honor become option for host [#1796]
 - Fixed bug to execute ssh command on windows [#1775]
+- Changes to .env for symfony4 recipe
 
 
 ## v6.4.3

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -10,7 +10,7 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
-set('shared_files', ['.env']);
+set('shared_files', ['.env.local']);
 set('writable_dirs', ['var']);
 set('migrations_config', '');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | Yes
| Fixed tickets | N/A

Why ? https://symfony.com/doc/current/configuration/dot-env-changes.html

`.env` is commited and now `.env.local` override `.env`