### PR TITLE
More accurate mapping from v4 server to v5 host

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,7 +41,7 @@
 
 1. Servers to Hosts
    
-   * `server($name, $hostname)` to `host($hostname)`
+   * `server($hostname)` to `host($hostname)`, and `server($name, $hostname)` to `host($name)->hostname($hostname)`
    * `localServer($name)` to `localhost()`
    * `cluster($name, $nodes, $port)` to `hosts(...$hodes)`
    * `serverList($file)` to `inventory($file)`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This is just a suggested change to a readme, no code change.

---

In the "Upgrade from 4.x to 5.x," section,
previously, the suggested mapping for `server($name, $hostname)` to `host($hostname)` silently dropped the $name, which will not retain the same command line calling argument.

There's no need to drop the $name, moving from 4.x to 5.x just changes the way it's declared. So this PR adds more precise suggested mapping, so that users will have smoother transition when upgrading.

