### PR TITLE
Git: add option to disable --dissociate flag on cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## master
 [v6.4.3...master](https://github.com/deployphp/deployer/compare/v6.4.3...master)
 
+### Added
+- Added `git_clone_dissociate` option, defaults to true; when set to false git-clone doesn't dissociate the eventual reference repository after clone, useful when using git-lfs [#1820]
+
 ### Changed
 - Add lock and unlock task to flow_framework receipe
 
@@ -460,6 +463,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1820]: https://github.com/deployphp/deployer/pull/1820
 [#1796]: https://github.com/deployphp/deployer/pull/1796
 [#1793]: https://github.com/deployphp/deployer/pull/1793
 [#1792]: https://github.com/deployphp/deployer/pull/1792

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -51,6 +51,7 @@ task('deploy:update_code', function () {
     $git = get('bin/git');
     $gitCache = get('git_cache');
     $recursive = get('git_recursive', true) ? '--recursive' : '';
+    $dissociate = get('git_clone_dissociate', true) ? '--dissociate' : '';
     $quiet = isQuiet() ? '-q' : '';
     $depth = $gitCache ? '' : '--depth 1';
     $options = [
@@ -85,7 +86,7 @@ task('deploy:update_code', function () {
 
     if ($gitCache && has('previous_release')) {
         try {
-            run("$git clone $at $recursive $quiet --reference {{previous_release}} --dissociate $repository  {{release_path}} 2>&1", $options);
+            run("$git clone $at $recursive $quiet --reference {{previous_release}} $dissociate $repository  {{release_path}} 2>&1", $options);
         } catch (\Throwable $exception) {
             // If {{deploy_path}}/releases/{$releases[1]} has a failed git clone, is empty, shallow etc, git would throw error and give up. So we're forcing it to act without reference in this situation
             run("$git clone $at $recursive $quiet $repository {{release_path}} 2>&1", $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

PR https://github.com/deployphp/deployer/pull/352 introduced `--reference` and `--dissociate` flags while cloning the repo.

But [git-lfs](https://github.com/git-lfs/git-lfs/) needs the reference after the clone in order to download the files from the reference, and so getting the benefits of the previous clone seen as a cache.

Disabling `--dissociate` accomplish the git-lfs download from previous release.

Ping @johnny-bit as original author