### PR TITLE
Added `writable_recursive` option (default: true) used in all writable modes (chmod, chown, chgrp, acl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Added `git_clone_dissociate` option, defaults to true; when set to false git-clone doesn't dissociate the eventual reference repository after clone, useful when using git-lfs [#1820]
+- Added `writable_recursive` option (default: true) used in all writable modes (chmod, chown, chgrp, acl) [#1822]
 
 ### Changed
 - Add lock and unlock task to flow_framework receipe
@@ -463,6 +464,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1822]: https://github.com/deployphp/deployer/issues/1822
 [#1820]: https://github.com/deployphp/deployer/pull/1820
 [#1796]: https://github.com/deployphp/deployer/pull/1796
 [#1793]: https://github.com/deployphp/deployer/pull/1793

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -67,8 +67,9 @@ set('copy_dirs', []);
 set('writable_dirs', []);
 set('writable_mode', 'acl'); // chmod, chown, chgrp or acl.
 set('writable_use_sudo', false); // Using sudo in writable commands?
+set('writable_recursive', true); // Common for all modes
 set('writable_chmod_mode', '0755'); // For chmod mode
-set('writable_chmod_recursive', true); // For chmod mode
+set('writable_chmod_recursive', true); // For chmod mode only (if is boolean, it has priority over `writable_recursive`)
 
 set('http_user', false);
 set('http_group', false);

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -43,11 +43,13 @@ task('deploy:writable', function () {
         // Create directories if they don't exist
         run("mkdir -p $dirs");
 
+        $recursive = get('writable_recursive') ? '-R' : '';
+
         if ($mode === 'chown') {
             // Change owner.
             // -R   operate on files and directories recursively
             // -L   traverse every symbolic link to a directory encountered
-            run("$sudo chown -RL $httpUser $dirs", $runOpts);
+            run("$sudo chown -L $recursive $httpUser $dirs", $runOpts);
         } elseif ($mode === 'chgrp') {
             // Change group ownership.
             // -R   operate on files and directories recursively
@@ -56,9 +58,12 @@ task('deploy:writable', function () {
             if ($httpGroup === false) {
                 throw new \RuntimeException("Please setup `http_group` config parameter.");
             }
-            run("$sudo chgrp -RH $httpGroup $dirs", $runOpts);
+            run("$sudo chgrp -H $recursive $httpGroup $dirs", $runOpts);
         } elseif ($mode === 'chmod') {
-            $recursive = get('writable_chmod_recursive') ? '-R' : '';
+            // in chmod mode, defined `writable_chmod_recursive` has priority over common `writable_recursive`
+            if (is_bool(get('writable_chmod_recursive'))) {
+                $recursive = get('writable_chmod_recursive') ? '-R' : '';
+            }
             run("$sudo chmod $recursive {{writable_chmod_mode}} $dirs", $runOpts);
         } elseif ($mode === 'acl') {
             if (strpos(run("chmod 2>&1; true"), '+a') !== false) {
@@ -68,8 +73,8 @@ task('deploy:writable', function () {
                 run("$sudo chmod +a \"`whoami` allow delete,write,append,file_inherit,directory_inherit\" $dirs", $runOpts);
             } elseif (commandExist('setfacl')) {
                 if (!empty($sudo)) {
-                    run("$sudo setfacl -RL -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs", $runOpts);
-                    run("$sudo setfacl -dRL -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs", $runOpts);
+                    run("$sudo setfacl -L $recursive -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs", $runOpts);
+                    run("$sudo setfacl -dL $recursive -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dirs", $runOpts);
                 } else {
                     // When running without sudo, exception may be thrown
                     // if executing setfacl on files created by http user (in directory that has been setfacl before).
@@ -81,8 +86,8 @@ task('deploy:writable', function () {
                         $hasfacl = run("getfacl -p $dir | grep \"^user:$httpUser:.*w\" | wc -l");
                         // Set ACL for directory if it has not been set before
                         if (!$hasfacl) {
-                            run("setfacl -RL -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
-                            run("setfacl -dRL -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
+                            run("setfacl -L $recursive -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
+                            run("setfacl -dL $recursive -m u:\"$httpUser\":rwX -m u:`whoami`:rwX $dir");
                         }
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1822

Added `writable_recursive` option (default: true) used in all writable modes (chmod, chown, chgrp, acl)
