### PR TITLE
[Travis] Test againt PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 env:
   matrix:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Stated that the community seems to already trust the state of art of the PHP 7.4 branch (see e.g. [Ocramius/ProxyManager](https://github.com/Ocramius/ProxyManager/blob/2.3.1/composer.json#L22)), I suggest to start right now to test PHP 7.4 and require green builds (so no `allow_failures`)