### PR TITLE
Support default wordpress implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Fix rsync upload honor become option for host [#1796]
 - Fixed bug to execute ssh command on windows [#1775]
 
+### Removed
+- Deploy:vendors from the wordpress recipe
+
 
 ## v6.4.3
 [v6.4.2...v6.4.3](https://github.com/deployphp/deployer/compare/v6.4.2...v6.4.3)

--- a/recipe/wordpress.php
+++ b/recipe/wordpress.php
@@ -20,7 +20,6 @@ task('deploy', [
     'deploy:release',
     'deploy:update_code',
     'deploy:shared',
-    'deploy:vendors',
     'deploy:writable',
     'deploy:symlink',
     'deploy:unlock',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | xx

A default wordpress project doesn't include an composer.json file, which causes it to crash.
There is however a community project, only isn't this officially supported from wordpress.

I think a package like php deployer should support the official implementation.