### PR TITLE
Add artisan:optimize:clear to Laravel recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 - Add lock and unlock task to flow_framework receipe
+- Updated `artisan:optimize` to run for Laravel 5.7 and above, since [it got added back](https://github.com/laravel/framework/commit/fe1cbdf3b51ce1235b8c91f5e603f1e9306e4f6f) last year. It still doesn't run for 5.5 and below.
 
 ### Fixed
 - Fix rsync upload honor become option for host [#1796]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Added `git_clone_dissociate` option, defaults to true; when set to false git-clone doesn't dissociate the eventual reference repository after clone, useful when using git-lfs [#1820]
 - Added `writable_recursive` option (default: true) used in all writable modes (chmod, chown, chgrp, acl) [#1822]
+- Added `artisan:optimize:clear` task for Laravel 5.7 and above
 
 ### Changed
 - Add lock and unlock task to flow_framework receipe

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -118,6 +118,16 @@ task('artisan:optimize', function () {
     }
 });
 
+desc('Execute artisan optimize:clear');
+task('artisan:optimize:clear', function () {
+    $needsVersion = 5.7;
+    $currentVersion = get('laravel_version');
+
+    if (version_compare($currentVersion, $needsVersion, '>=')) {
+        run('{{bin/php}} {{release_path}}/artisan optimize:clear');
+    }
+});
+
 desc('Execute artisan queue:restart');
 task('artisan:queue:restart', function () {
     run('{{bin/php}} {{release_path}}/artisan queue:restart');

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -111,9 +111,13 @@ task('artisan:view:clear', function () {
 desc('Execute artisan optimize');
 task('artisan:optimize', function () {
     $deprecatedVersion = 5.5;
+    $readdedInVersion = 5.7;
     $currentVersion = get('laravel_version');
 
-    if (version_compare($currentVersion, $deprecatedVersion, '<')) {
+    if (
+        version_compare($currentVersion, $deprecatedVersion, '<') ||
+        version_compare($currentVersion, $readdedInVersion, '>=')
+    ) {
         run('{{bin/php}} {{release_path}}/artisan optimize');
     }
 });


### PR DESCRIPTION
| Q | A
| - | -
| Bug fix? | No
| New feature? | Yes
| BC breaks? | No
| Deprecations? | No
| Fixed tickets | N/A

This PR adds `artisan:optimize:clear` task to the Laravel recipe. It's available for versions 5.7 and up. 
I did not add it to the deploy script. 

I've also readded support for `artisan:optimize` for versions 5.7 and up. This command was deprecated in 5.5, removed in 5.6 and readded in 5.7 with different functionality. 

The previous version (<5.5) optimized composers autoload files.
The new version (>5.7) caches the app config and routes. It's the same as running `config:cache` and `route:cache`.