### PR TITLE
Always update shared folder from git

### DIFF
--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -27,11 +27,11 @@ task('deploy:shared', function () {
         if (!test("[ -d $sharedPath/$dir ]")) {
             // Create shared dir if it does not exist.
             run("mkdir -p $sharedPath/$dir");
+        }
 
-            // If release contains shared dir, copy that dir from release to shared.
-            if (test("[ -d $(echo {{release_path}}/$dir) ]")) {
-                run("cp -rv {{release_path}}/$dir $sharedPath/" . dirname(parse($dir)));
-            }
+        // If release contains shared dir, copy that dir from release to shared.
+        if (test("[ -d $(echo {{release_path}}/$dir) ]")) {
+            run("cp -rv {{release_path}}/$dir $sharedPath/" . dirname(parse($dir)));
         }
 
         // Remove from source.


### PR DESCRIPTION
Right now `deployer shared` would install the shared directory
once; when the first deployment of e.g. a branch is running.

Adding items to a shared resource in git will not update the
deployments shared folder. This is often confusing for our devs
who are required to add some assets sometimes.

I'd suggest this simple "fix" to always update the shared folder
from the git repository.

Signed-off-by: Mark Kusch <mark.kusch@transfermarkt.de>

#####################################################################
I'm working on **first LTS release** of Deployer. 
Please, consider supporting Deployer development on Patreon page: 

   https://www.patreon.com/deployer

#####################################################################


| Q             | A
| ------------- | ---
| Bug fix?      | Yes and No
| New feature?  | Yes and No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
