### PR TITLE
Recipe Magento 2 > Change the shared folders

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -28,7 +28,7 @@ set('writable_dirs', [
     'pub/media',
     'generation'
 ]);
-set('clear_paths', [   
+set('clear_paths', [
     'generation/*',
     'pub/static/_cache/*',
     'var/generation/*',

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -9,18 +9,32 @@ set('shared_files', [
     'var/.maintenance.ip',
 ]);
 set('shared_dirs', [
+    'var/composer_home',
     'var/log',
+    'var/cache',
+    'var/export',
+    'var/report',
+    'var/import_history',
+    'var/session',
+    'var/importexport',
     'var/backups',
-    'pub/media',
+    'var/tmp',
+    'pub/sitemaps',
+    'pub/media'
 ]);
 set('writable_dirs', [
     'var',
     'pub/static',
     'pub/media',
+    'generation'
 ]);
-set('clear_paths', [
+set('clear_paths', [   
+    'generation/*',
+    'pub/static/_cache/*',
     'var/generation/*',
     'var/cache/*',
+    'var/page_cache/*',
+    'var/view_preprocessed/*'
 ]);
 
 // Tasks


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I improve the list of the files/folders shared and etc. These changes add the new folders extremely required in both version (e.g. `var/session`), also add new folders to be compatible with the Magento ^2.2 (e.g. `generation`), but keeping the old folders to keep the compatibility (e.g. `var/generation`).

If you have any question, please let me know!
