### PR TITLE
Fix home-directory tilde-expansion (~) for paths containing a tilde

### DIFF
--- a/src/Support/Unix.php
+++ b/src/Support/Unix.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /* (c) Anton Medvedev <anton@medv.io>
  *
  * For the full copyright and license information, please view the LICENSE
@@ -10,17 +10,23 @@ namespace Deployer\Support;
 class Unix
 {
     /**
-     * Parse "~" symbol from path.
+     * Expand leading tilde (~) symbol in given path.
      *
      * @param string $path
      * @return string
      */
     public static function parseHomeDir(string $path): string
     {
-        if (isset($_SERVER['HOME'])) {
-            $path = str_replace('~', $_SERVER['HOME'], $path);
-        } elseif (isset($_SERVER['HOMEDRIVE'], $_SERVER['HOMEPATH'])) {
-            $path = str_replace('~', $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'], $path);
+        if ('~' === $path || 0 === strpos($path, '~/')) {
+            if (isset($_SERVER['HOME'])) {
+                $home = $_SERVER['HOME'];
+            } elseif (isset($_SERVER['HOMEDRIVE'], $_SERVER['HOMEPATH'])) {
+                $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
+            } else {
+                return $path;
+            }
+
+            return $home . substr($path, 1);
         }
 
         return $path;

--- a/test/src/Support/UnixTest.php
+++ b/test/src/Support/UnixTest.php
@@ -14,5 +14,8 @@ class UnixTest extends TestCase
     public function testParseHomeDir()
     {
         $this->assertStringStartsWith('/', Unix::parseHomeDir('~/path'));
+        $this->assertStringStartsWith('/', Unix::parseHomeDir('~'));
+        $this->assertStringStartsWith('~', Unix::parseHomeDir('~path'));
+        $this->assertStringEndsWith('~', Unix::parseHomeDir('path~'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1851 
