### PR TITLE
Prevent dir creation when it is existing

### DIFF
--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -48,8 +48,10 @@ task('deploy:shared', function () {
     foreach (get('shared_files') as $file) {
         $dirname = dirname(parse($file));
 
-        // Create dir of shared file
-        run("mkdir -p $sharedPath/" . $dirname);
+        // Create dir of shared file if not existing
+        if (!test("[ -d {$sharedPath}/{$dirname} ]")) {
+            run("mkdir -p {$sharedPath}/{$dirname}");
+        }
 
         // Check if shared file does not exist in shared.
         // and file exist in release


### PR DESCRIPTION
If "shared" directory is already existing just do not call mkdir, to prevent pointless update during processing of the "shared" files just like it's checked during "shared" directories processing.