### PR TITLE
Laravel view cache task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Add lock and unlock task to flow_framework receipe
 - Updated `artisan:optimize` to run for Laravel 5.7 and above, since [it got added back](https://github.com/laravel/framework/commit/fe1cbdf3b51ce1235b8c91f5e603f1e9306e4f6f) last year. It still doesn't run for 5.5 and below.
+- View:clear command to a new view:cache command
 
 ### Fixed
 - Fix rsync upload honor become option for host [#1796]

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -105,7 +105,14 @@ task('artisan:route:cache', function () {
 
 desc('Execute artisan view:cache');
 task('artisan:view:cache', function () {
-    run('{{bin/php}} {{release_path}}/artisan view:cache');
+    $needsVersion = 5.6;
+    $currentVersion = get('laravel_version');
+
+    if (version_compare($currentVersion, $needsVersion, '>=')) {
+        run('{{bin/php}} {{release_path}}/artisan view:cache');
+    } else {
+        run('{{bin/php}} {{release_path}}/artisan view:clear');
+    }
 });
 
 desc('Execute artisan optimize');

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -103,9 +103,9 @@ task('artisan:route:cache', function () {
     run('{{bin/php}} {{release_path}}/artisan route:cache');
 });
 
-desc('Execute artisan view:clear');
-task('artisan:view:clear', function () {
-    run('{{bin/php}} {{release_path}}/artisan view:clear');
+desc('Execute artisan view:cache');
+task('artisan:view:cache', function () {
+    run('{{bin/php}} {{release_path}}/artisan view:cache');
 });
 
 desc('Execute artisan optimize');
@@ -186,7 +186,7 @@ task('deploy', [
     'deploy:vendors',
     'deploy:writable',
     'artisan:storage:link',
-    'artisan:view:clear',
+    'artisan:view:cache',
     'artisan:config:cache',
     'artisan:optimize',
     'deploy:symlink',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Instead of only calling view:clear command, starting from 5.6 laravel version it is possible to cache views