### PR TITLE
Escape dollar sign in shell command to be used in awk (#1844)

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -24,7 +24,7 @@ task('deploy:writable', function () {
 
     if ($httpUser === false && ! in_array($mode, ['chgrp', 'chmod'], true)) {
         // Attempt to detect http user in process list.
-        $httpUserCandidates = explode("\n", run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | awk '{print $NF}' | uniq"));
+        $httpUserCandidates = explode("\n", run("ps axo comm,user | grep -E '[a]pache|[h]ttpd|[_]www|[w]ww-data|[n]ginx' | grep -v root | sort | awk '{print \$NF}' | uniq"));
         if (count($httpUserCandidates) === 1) {
             $httpUser = $httpUserCandidates[0];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1844 

This fixes an escaping bug in the task `deploy:writable` that causes an "Undefined variable" error:

 	➤ Executing task deploy:writable
	PHP Notice:  Undefined variable: NF in /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/recipe/deploy/writable.php on line 27
	PHP Stack trace:
	PHP   1. {main}() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/bin/dep:0
	PHP   2. Deployer\Deployer::run() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/bin/dep:124
	PHP   3. Deployer\Console\Application->run() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Deployer.php:331
	PHP   4. Deployer\Console\Application->doRun() /home/gitlab-runner/builds/---redacted---/vendor/symfony/console/Application.php:149
	PHP   5. Deployer\Console\Application->doRunCommand() /home/gitlab-runner/builds/---redacted---/vendor/symfony/console/Application.php:273
	PHP   6. Deployer\Console\Application->doRunCommand() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Console/Application.php:133
	PHP   7. Deployer\Console\TaskCommand->run() /home/gitlab-runner/builds/---redacted---/vendor/symfony/console/Application.php:921
	PHP   8. Deployer\Console\TaskCommand->execute() /home/gitlab-runner/builds/---redacted---/vendor/symfony/console/Command/Command.php:255
	PHP   9. Deployer\Executor\SeriesExecutor->run() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Console/TaskCommand.php:142
	PHP  10. Deployer\Task\Task->run() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Executor/SeriesExecutor.php:60
	PHP  11. call_user_func:{/home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Task/Task.php:105}() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Task/Task.php:105
	PHP  12. Deployer\Deployer::Deployer\{closure}() /home/gitlab-runner/builds/---redacted---/vendor/deployer/deployer/src/Task/Task.php:105