### PR TITLE
Feature: "--skip-task" option for Task Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.4.5...master](https://github.com/deployphp/deployer/compare/v6.4.5...master)
+
+### Added
+- --skip-task flag for task commands
+
+
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,6 +56,7 @@ Options:
       --roles=ROLES          Roles to deploy
       --hosts=HOSTS          Host to deploy, comma separated, supports ranges [:]
   -o, --option=OPTION        Sets configuration option (multiple values allowed)
+      --skip-task=SKIP-TASK  Skip one or more tasks (multiple values allowed)
   -h, --help                 Display this help message
   -q, --quiet                Do not output any message
   -V, --version              Display this application version

--- a/src/Console/TaskCommand.php
+++ b/src/Console/TaskCommand.php
@@ -93,6 +93,12 @@ class TaskCommand extends Command
             Option::VALUE_REQUIRED | Option::VALUE_IS_ARRAY,
             'Sets configuration option'
         );
+        $this->addOption(
+            'skip-task',
+            null,
+            Option::VALUE_REQUIRED | Option::VALUE_IS_ARRAY,
+            'Skip one or more tasks'
+        );
     }
 
     /**
@@ -104,6 +110,7 @@ class TaskCommand extends Command
         $roles = $input->getOption('roles');
         $hosts = $input->getOption('hosts');
         $this->parseOptions($input->getOption('option'));
+        $skip = $input->getOption('skip-task');
 
         $hooksEnabled = !$input->getOption('no-hooks');
         if (!empty($input->getOption('log'))) {
@@ -122,6 +129,10 @@ class TaskCommand extends Command
             throw new Exception('No host selected');
         }
 
+        if (in_array($this->getName(), $skip)) {
+            throw new Exception('Cannot skip the task you are trying to run');
+        }
+
         $tasks = $this->deployer->scriptManager->getTasks(
             $this->getName(),
             $hosts,
@@ -130,6 +141,10 @@ class TaskCommand extends Command
 
         if (empty($tasks)) {
             throw new Exception('No task will be executed, because the selected hosts do not meet the conditions of the tasks');
+        }
+
+        if (!empty($skip)) {
+            $tasks = array_values(array_diff($tasks, $skip));
         }
 
         if ($input->getOption('parallel')) {

--- a/test/src/Console/TaskCommandTest.php
+++ b/test/src/Console/TaskCommandTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Console;
+
+use Deployer\Collection\Collection;
+use Deployer\Deployer;
+use Deployer\Executor\SeriesExecutor;
+use Deployer\Host\HostSelector;
+use Deployer\Logger\Logger;
+use Deployer\Task\ScriptManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+class TaskCommandTest extends TestCase
+{
+    /**
+     * @var Deployer
+     */
+    protected $deployer;
+
+    /**
+     * @var TaskCommand
+     */
+    protected $command;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    protected function setUp()
+    {
+        // Create app tester
+        $console = new Application();
+        $console->setAutoExit(false);
+        $console->setCatchExceptions(false);
+        $this->tester = new ApplicationTester($console);
+
+        // Prepare Deployer
+        $input = $this->createMock(Input::class);
+        $this->output = $this->createMock(Output::class);
+        $this->deployer = new Deployer($console, $input, $this->output);
+        $this->deployer->hostSelector = $this->createConfiguredMock(HostSelector::class, ['getHosts' => ['production']]);
+        $this->deployer->logger = $this->createMock(Logger::class);
+        $this->deployer->fail = new Collection();
+
+        // Prepare command
+        $this->command = new TaskCommand('deploy', '', $this->deployer);
+    }
+
+    protected function tearDown()
+    {
+        unset($this->deployer);
+        unset($this->command);
+        unset($this->output);
+    }
+
+    public function testCannotSkipSelfTask()
+    {
+        $this->expectExceptionMessage('Cannot skip the task you are trying to run');
+
+        $input = new StringInput('deploy --skip-task deploy');
+
+        $this->command->run($input, $this->output);
+    }
+
+    public function testIgnoreNotExistingTaskToSkip()
+    {
+        $manager = $this->createConfiguredMock(ScriptManager::class, ['getTasks' => ['first', 'second']]);
+        $this->deployer->scriptManager = $manager;
+        $input = new StringInput('deploy --skip-task third');
+
+        $executor = $this->createMock(SeriesExecutor::class);
+        $executor
+            ->expects($this->once())
+            ->method('run')
+            ->with(
+                ['first', 'second'],
+                $this->anything()
+            );
+        $this->deployer->seriesExecutor = $executor;
+
+        $this->command->run($input, $this->output);
+    }
+
+    public function skipTasksProvider()
+    {
+        return [
+            'normal' => [
+                ['one', 'two', 'three'],
+                '--skip-task two',
+                ['one', 'three']
+            ],
+            'duplicate skips' => [
+                ['first', 'second', 'last'],
+                '--skip-task first --skip-task first',
+                ['second', 'last']
+            ],
+            'multiple' => [
+                ['deploy:prepare', 'deploy:update','deploy:build', 'deploy:symlink', 'cleanup'],
+                '--skip-task deploy:build --skip-task deploy:symlink --skip-task deploy:prepare',
+                ['deploy:update', 'cleanup']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider skipTasksProvider
+     */
+    public function testSkipsTasks($tasks, $skipInput, $expected)
+    {
+        $manager = $this->createConfiguredMock(ScriptManager::class, ['getTasks' => $tasks]);
+        $this->deployer->scriptManager = $manager;
+
+        $input = new StringInput('deploy ' . $skipInput);
+
+        $executor = $this->createMock(SeriesExecutor::class);
+        $executor
+            ->expects($this->once())
+            ->method('run')
+            ->with(
+                $expected,
+                $this->anything()
+            );
+        $this->deployer->seriesExecutor = $executor;
+
+        $this->command->run($input, $this->output);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

# Feature
This PR introduce a new feature:
In so called task commands it is now possible to skip multiple task by using the `--skip-task <taskname>` option. Of course you cannot skip the task you are currently running.

E.g.
```sh
$ dep deploy --skip-task build --skip-task cleanup
```

## Benefit
Instead of using roles or a custom deployment task you can simply skip certain task. For example, one uses a CI which is split into certain steps (e.g. build, test and deploy).

## Changes
Please check the UnitTest first. I'm not 100% sure if I mocked the `Deployer\Deployer` class correctly.

There was no other Command test so I didn't know whether to use [Symfony's `CommandTester`](https://symfony.com/doc/current/console.html#testing-commands) or not.

Furthermore I just updated the CLI documentation. Maybe this feature should be mentioned somewhere else, too.