### PR TITLE
[HOTFIX] - magento2 recipe - Properly handle 'generated' and not 'generation' directory for >= 2.2.x Magento versions

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -26,10 +26,10 @@ set('writable_dirs', [
     'var',
     'pub/static',
     'pub/media',
-    'generation'
+    'generated'
 ]);
 set('clear_paths', [
-    'generation/*',
+    'generated/*',
     'pub/static/_cache/*',
     'var/generation/*',
     'var/cache/*',


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

