### PR TITLE
Update Laravel View Cache commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Change the default shared files in the Symfony4 recipe. The .env file is versionned now and not the .env.local [#1881]
 - Change the `artisan:view:cache` task to only run the `view:cache` command
 
+
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 ## master
 [v6.4.5...master](https://github.com/deployphp/deployer/compare/v6.4.5...master)
 
+### Added
+- Re-added the `artisan:view:clear` task
+
 ### Changed
 - Change the default shared files in the Symfony4 recipe. The .env file is versionned now and not the .env.local [#1881]
-
+- Change the `artisan:view:cache` task to only run the `view:cache` command
 
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -103,6 +103,11 @@ task('artisan:route:cache', function () {
     run('{{bin/php}} {{release_path}}/artisan route:cache');
 });
 
+desc('Execute artisan view:clear');
+task('artisan:view:clear', function () {
+    run('{{bin/php}} {{release_path}}/artisan view:clear');
+});
+
 desc('Execute artisan view:cache');
 task('artisan:view:cache', function () {
     $needsVersion = 5.6;
@@ -110,8 +115,6 @@ task('artisan:view:cache', function () {
 
     if (version_compare($currentVersion, $needsVersion, '>=')) {
         run('{{bin/php}} {{release_path}}/artisan view:cache');
-    } else {
-        run('{{bin/php}} {{release_path}}/artisan view:clear');
     }
 });
 


### PR DESCRIPTION
- Re-added the `artisan:view:clear` task 
- Change the `artisan:view:cache` task to only run the `view:cache` command, as `view:clear` is already executed in the `view:cache` command in the framework (https://github.com/laravel/framework/blob/e6c8aa0e39d8f91068ad1c299546536e9f25ef63/src/Illuminate/Foundation/Console/ViewCacheCommand.php#L33)

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A
