### PR TITLE
Add tasks to cache a manifest of event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.4.6...master](https://github.com/deployphp/deployer/compare/v6.4.6...master)
+
+### Added
+- A task to cache the event listeners manifest in Laravel [#1893]
+
+
 ## v6.4.6
 [v6.4.5...v6.4.6](https://github.com/deployphp/deployer/compare/v6.4.5...v6.4.6)
 
@@ -488,6 +495,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1893]: https://github.com/deployphp/deployer/pull/1893
 [#1881]: https://github.com/deployphp/deployer/pull/1881
 [#1876]: https://github.com/deployphp/deployer/pull/1876
 [#1842]: https://github.com/deployphp/deployer/pull/1842

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -118,6 +118,26 @@ task('artisan:view:cache', function () {
     }
 });
 
+desc('Execute artisan event:cache');
+task('artisan:event:cache', function () {
+    $needsVersion = '5.8.9';
+    $currentVersion = get('laravel_version');
+
+    if (version_compare($currentVersion, $needsVersion, '>=')) {
+        run('{{bin/php}} {{release_path}}/artisan event:cache');
+    }
+});
+
+desc('Execute artisan event:clear');
+task('artisan:event:clear', function () {
+    $needsVersion = '5.8.9';
+    $currentVersion = get('laravel_version');
+
+    if (version_compare($currentVersion, $needsVersion, '>=')) {
+        run('{{bin/php}} {{release_path}}/artisan event:clear');
+    }
+});
+
 desc('Execute artisan optimize');
 task('artisan:optimize', function () {
     $deprecatedVersion = 5.5;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Laravel supports automatic discovery of events and listeners since
version 5.8.9. (https://laravel.com/docs/5.8/events#event-discovery)
As the documentation states, you want to cache the manifest of event
listeners in a production environment to prevent scanning the
directories on every request.

The new tasks are not added to the deploy task because automatic event
discovery is opt-in functionality in Laravel.
