### PR TITLE
Handle asterisk wildcard in shared files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 - A task to cache the event listeners manifest in Laravel [#1893]
 - Added `check_remote_head` option, by setting this to true, deployer will avoid unnecessary new releases by checking the remote git HEAD without cloning the repo [#1755]
+- Handling asterisk wildcard in shared files [#374]
+
 
 ## v6.4.6
 [v6.4.5...v6.4.6](https://github.com/deployphp/deployer/compare/v6.4.5...v6.4.6)
@@ -608,4 +610,5 @@
 [#914]: https://github.com/deployphp/deployer/pull/914
 [#911]: https://github.com/deployphp/deployer/pull/911
 [#381]: https://github.com/deployphp/deployer/pull/381
+[#374]: https://github.com/deployphp/deployer/issues/374
 [#330]: https://github.com/deployphp/deployer/pull/330

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -48,6 +48,9 @@ task('deploy:shared', function () {
     foreach (get('shared_files') as $file) {
         $dirname = dirname(parse($file));
 
+        // Check if file name has a wildcard * (e.g. config/parameters_*.yml)
+        $hasWildcard = strpos(str_replace($dirname, '', parse($file)), '*') !== false;
+
         // Create dir of shared file if not existing
         if (!test("[ -d {$sharedPath}/{$dirname} ]")) {
             run("mkdir -p {$sharedPath}/{$dirname}");
@@ -58,6 +61,9 @@ task('deploy:shared', function () {
         if (!test("[ -f $sharedPath/$file ]") && test("[ -f {{release_path}}/$file ]")) {
             // Copy file in shared dir if not present
             run("cp -rv {{release_path}}/$file $sharedPath/$file");
+        } elseif ($hasWildcard) {
+            // Copy files in shared dir if not present (does not overwrite an existing file)
+            run("cp -nrv {{release_path}}/$file $sharedPath/$dirname");
         }
 
         // Remove from source.
@@ -70,6 +76,6 @@ task('deploy:shared', function () {
         run("touch $sharedPath/$file");
 
         // Symlink shared dir to release dir
-        run("{{bin/symlink}} $sharedPath/$file {{release_path}}/$file");
+        run("{{bin/symlink}} $sharedPath/$file {{release_path}}/" . ($hasWildcard ? $dirname : $file));
     }
 });

--- a/test/fixture/recipe/deploy.php
+++ b/test/fixture/recipe/deploy.php
@@ -18,9 +18,11 @@ set('http_user', getenv('USER'));
 
 set('media_dir', 'public/media');
 set('parameters.yml', 'app/config/parameters.yml');
+set('parameters_wildcard.yml', 'app/config/parameters_*.yml');
 
 set('shared_files', [
     '{{parameters.yml}}',
+    '{{parameters_wildcard.yml}}',
 ]);
 
 set('shared_dirs', [

--- a/test/fixture/repository/app/config/parameters_dev.yml
+++ b/test/fixture/repository/app/config/parameters_dev.yml
@@ -1,0 +1,1 @@
+example: parameters

--- a/test/fixture/repository/app/config/parameters_prod.yml
+++ b/test/fixture/repository/app/config/parameters_prod.yml
@@ -1,0 +1,1 @@
+example: parameters

--- a/test/recipe/DeployTest.php
+++ b/test/recipe/DeployTest.php
@@ -33,6 +33,8 @@ class DeployTest extends DepCase
         self::assertFileExists(self::$currentPath . '/current/composer.json');
         self::assertFileExists(self::$currentPath . '/shared/public/media/.gitkeep');
         self::assertFileExists(self::$currentPath . '/shared/app/config/parameters.yml');
+        self::assertFileExists(self::$currentPath . '/shared/app/config/parameters_dev.yml');
+        self::assertFileExists(self::$currentPath . '/shared/app/config/parameters_prod.yml');
         self::assertEquals(1, exec("ls -1 releases | wc -l"));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | https://github.com/deployphp/deployer/issues/374

There are cases where sharing directory does not work and many dynamic files must be shared across releases. For example symfony configuration does not load properly from symlinked folders (here `config/dynamic` is a shared dir):
```
In FileLoader.php line 168:

The file "../config.yml" does not exist (in: /var/www/project/releases/10/src/../config/dynamic) in ../config.yml (which is being imported from "/var/www/project/releases/10/src/../config/dynamic/config_a6gr2.yml"). 


In FileLocator.php line 71:

The file "../config.yml" does not exist (in: /var/www/project/releases/10/src/../config/dynamic).
```

`/var/www/project/releases/10/src/../config/dynamic/../config.yml` - not found
`/var/www/project/releases/10/src/../config/config.yml` - exists

We are already using a custom task like that in our deployment and it works like a charm. I guess it might be useful for many fellow developers out there ;)