### PR TITLE
Update config:hosts and config:current task recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - fixed invalid magic-property phpdoc in Deployer\Deployer class [#1899]
+- Updated `config:hosts` and `config:current` tasks to output only the selected stage
 
 
 ## v6.4.6

--- a/recipe/config/current.php
+++ b/recipe/config/current.php
@@ -13,13 +13,17 @@ use Symfony\Component\Console\Helper\Table;
 desc('Show current paths');
 task('config:current', function () {
     $rows = [];
-    $hosts = Deployer::get()->hosts;
+    $selectedStage = Deployer::get()->getInput()->getArgument('stage');
 
-    on($hosts, function (Host $host) use (&$rows) {
+    on($hosts, function (Host $host) use (&$rows, $selectedStage) {
+        if ($host->get('stage') !== $selectedStage) {
+            return;
+        }
+
         try {
             $rows[] = [
                 $host->getHostname(),
-                basename($host->getConfig()->get('current_path')),
+                basename($host->get('current_path')),
             ];
         } catch (\Throwable $e) {
             $rows[] = [

--- a/recipe/config/current.php
+++ b/recipe/config/current.php
@@ -15,7 +15,7 @@ task('config:current', function () {
     $rows = [];
     $selectedStage = Deployer::get()->getInput()->getArgument('stage');
 
-    on($hosts, function (Host $host) use (&$rows, $selectedStage) {
+    on(Deployer::get()->hosts, function (Host $host) use (&$rows, $selectedStage) {
         if ($host->get('stage') !== $selectedStage) {
             return;
         }

--- a/recipe/config/hosts.php
+++ b/recipe/config/hosts.php
@@ -11,10 +11,15 @@ use Symfony\Component\Console\Helper\Table;
 
 desc('Print all hosts');
 task('config:hosts', function () {
-    $hosts = [];
+    $rows = [];
+    $selectedStage = Deployer::get()->getInput()->getArgument('stage');
 
     foreach (Deployer::get()->hosts as $host) {
-        $hosts[] = [
+        if ($host->get('stage') !== $selectedStage) {
+            continue;
+        }
+
+        $rows[] = [
             $host->getHostname(),
             $host->getRealHostname(),
             $host->get('stage', ''),

--- a/recipe/config/hosts.php
+++ b/recipe/config/hosts.php
@@ -31,6 +31,6 @@ task('config:hosts', function () {
     $table = new Table(output());
     $table
         ->setHeaders(['Host', 'Hostname', 'Stage', 'Roles', 'Deploy path'])
-        ->setRows($hosts);
+        ->setRows($rows);
     $table->render();
 })->once();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Updated the `config:hosts` and `config:current` tasks so they only output content for the stage given in the command, just like `config:dump` does.

EDIT: I said yes to the bugfix question, but I guess I'm not sure it really qualifies as a bug. Sorry if that's not the case.