### PR TITLE
Add a configuration file for Contao

### DIFF
--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -1,0 +1,18 @@
+<?php
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer;
+
+require __DIR__.'/symfony4.php';
+
+set('bin/console', function () {
+    return parse('{{bin/php}} {{release_path}}/vendor/bin/contao-console --no-interaction');
+});
+
+set('console_options', function () {
+    return '--no-interaction --env={{symfony_env}}';
+});


### PR DESCRIPTION
This PR adds a configuration file for Contao. Contao is based on the Symfony full-stack framework, however, we are using a different console, therefore we cannot use the default Symfony4 recipe.