### PR TITLE
Update symfony4.php

### DIFF
--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -10,7 +10,7 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
-set('shared_files', ['.env.local']);
+set('shared_files', ['.env']);
 set('writable_dirs', ['var']);
 set('migrations_config', '');
 


### PR DESCRIPTION
The .env and .env.<environment> files should be committed to the shared repository because they are the same for all developers and machines. However, the env files ending in .local (.env.local and .env.<environment>.local) should not be committed because only you will use them. In fact, the .gitignore file that comes with Symfony prevents them from being committed.

https://symfony.com/doc/current/configuration.html#managing-multiple-env-files

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
