### PR TITLE
Dev/add custom key to fileloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 ## master
 [v6.5.0...master](https://github.com/deployphp/deployer/compare/v6.5.0...master)
 
-### Added
-- Functionality to get hosts form a custom key in the yaml file [#1917]
-
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## master
 [v6.5.0...master](https://github.com/deployphp/deployer/compare/v6.5.0...master)
 
+### Added
+- Functionality to get hosts form a custom key in the yaml file [#1917]
+
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
 

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -49,9 +49,11 @@ class FileLoader
         }
 
         $data = Yaml::parse(file_get_contents($file));
-        if($key !== null && $key !== ''){
+
+        if ($key !== null && $key !== '') {
             $data = $data[$key];
         }
+
         $data = $this->expandOnLoad($data);
 
         if (!is_array($data)) {

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -37,16 +37,20 @@ class FileLoader
     }
     /**
      * @param string $file
+     * @param string|null $key
      * @return $this
      * @throws Exception
      */
-    public function load($file)
+    public function load($file, $key = null)
     {
         if (!file_exists($file) || !is_readable($file)) {
             throw new Exception("File `$file` doesn't exists or isn't readable.");
         }
 
         $data = Yaml::parse(file_get_contents($file));
+        if($key !== null && $key !== ''){
+            $data = $data[$key];
+        }
         $data = $this->expandOnLoad($data);
 
         if (!is_array($data)) {

--- a/src/Host/FileLoader.php
+++ b/src/Host/FileLoader.php
@@ -35,6 +35,7 @@ class FileLoader
 
         return $dataout;
     }
+
     /**
      * @param string $file
      * @param string|null $key

--- a/src/functions.php
+++ b/src/functions.php
@@ -92,13 +92,14 @@ function localhost(...$hostnames)
  * Load list of hosts from file
  *
  * @param string $file
+ * @param string|null $key
  * @return Proxy
  */
-function inventory($file)
+function inventory($file, $key = null)
 {
     $deployer = Deployer::get();
     $fileLoader = new FileLoader();
-    $fileLoader->load($file);
+    $fileLoader->load($file, $key);
 
     $hosts = $fileLoader->getHosts();
     foreach ($hosts as $host) {

--- a/test/fixture/inventory-with-custom-key.yml
+++ b/test/fixture/inventory-with-custom-key.yml
@@ -1,0 +1,48 @@
+.base: &base
+  deploy_path: path
+  roles:
+    - a
+    - b
+    - c
+  param: param
+
+custom-key:
+  foo:
+    <<: *base
+    extra: extra
+
+  bar:
+    hostname: bar.com
+    user: user
+    port: 22
+    configFile: configFile
+    identityFile: identityFile
+    forwardAgent: true
+    multiplexing: false
+    sshOptions:
+      Option: Value
+    sshFlags:
+      -f:
+      -someFlag: value
+    param: param
+
+  local:
+    local: -
+    deploy_to: /var/local
+    param: local
+
+  app.deployer.org:
+    stage: production
+    roles: app
+    deploy_path: ~/app
+
+  db[1:2].deployer.org:
+    stage: production
+    roles: db
+
+  beta.deployer.org:
+    stage: beta
+    roles:
+      - app
+      - db
+    deploy_path: ~/app

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -58,6 +58,45 @@ class FileLoaderTest extends TestCase
         self::assertEquals('db2.deployer.org', $db2->getHostname());
     }
 
+    public function testLoadFromCustomKey()
+    {
+        $this->hosts = (new FileLoader())
+            ->load(__DIR__ . '/../../fixture/inventory-with-custom-key.yml', 'custom-key')
+            ->getHosts();
+
+
+        // foo extends .base
+        $foo = $this->getHost('foo');
+        self::assertInstanceOf(Host::class, $foo);
+        self::assertEquals(['a', 'b', 'c'], $foo->get('roles'));
+
+        // local is Localhost
+        $local = $this->getHost('local');
+        self::assertInstanceOf(Localhost::class, $local);
+        self::assertEquals('/var/local', $local->get('deploy_to'));
+
+        // bar configured properly
+        $bar = $this->getHost('bar');
+        self::assertEquals('bar', $bar->getHostname());
+        self::assertEquals('user@bar.com', "$bar");
+        self::assertEquals('user', $bar->getUser());
+        self::assertEquals(22, $bar->getPort());
+        self::assertEquals('configFile', $bar->getConfigFile());
+        self::assertEquals('identityFile', $bar->getIdentityFile());
+        self::assertTrue($bar->isForwardAgent());
+        self::assertFalse($bar->isMultiplexing());
+        self::assertEquals('param', $bar->get('param'));
+        self::assertEquals(
+            '-f -A -someFlag value -p 22 -F configFile -i identityFile -o Option=Value',
+            $bar->getSshArguments()->getCliArguments()
+        );
+
+        $db1 = $this->getHost('db1.deployer.org');
+        self::assertEquals('db1.deployer.org', $db1->getHostname());
+        $db2 = $this->getHost('db2.deployer.org');
+        self::assertEquals('db2.deployer.org', $db2->getHostname());
+    }
+
     /**
      * @param $name
      * @return Host|null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No

This PR adds an optional second parameter to the inventory function. This parameter gets piped to the FileLoader's load method (optional as well). It is to specify a custom key under which the hosts definition can be found in the yaml file. 

Currently this is just for one level. Because this enough for my use case.

