### PR TITLE
Symfony4: add a task to clear doctrine caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Added doc page with sample "real-world" Deployer script
+- Added `doctrine:cache:clear` task to symfony4 recipe, clearing the doctrine caches [#1918]
 
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
@@ -519,6 +520,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#1918]: https://github.com/deployphp/deployer/pull/1918
 [#1899]: https://github.com/deployphp/deployer/pull/1899
 [#1893]: https://github.com/deployphp/deployer/pull/1893
 [#1881]: https://github.com/deployphp/deployer/pull/1881

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -33,6 +33,12 @@ task('deploy:cache:clear', function () {
     run('{{bin/console}} cache:clear --no-warmup');
 });
 
+task('doctrine:cache:clear', function () {
+    run('{{bin/console}} doctrine:cache:clear-metadata');
+    run('{{bin/console}} doctrine:cache:clear-result');
+    run('{{bin/console}} doctrine:cache:clear-query');
+});
+
 desc('Warm up cache');
 task('deploy:cache:warmup', function () {
     run('{{bin/console}} cache:warmup');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

`bin/console cache:clear` in Symfony does not automatically clear the caches of Doctrine. That is problematic if there is a migration, adding or removing fields to entities. If doctrine caches the relations between the tables and the entities, calling `clear-metadata` is necessary, as otherwise the app might break.

I only added the task and did not add it to the deploy chain (as `database:migrate` is also not); however, every time that `database:migrate` is called, it should be safe (and probably advisable) to call this.