### PR TITLE
Install require-dev when symfony_env is set dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
+- When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process
 
 
 ## v6.5.0

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -42,6 +42,12 @@ set('env', function () {
     ];
 });
 
+set('composer_options', function () {
+    $debug = get('symfony_env') === 'dev';
+    return sprintf('{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction %s --optimize-autoloader --no-suggest', ($debug ? '--no-dev' : ''));
+});
+
+
 // Adding support for the Symfony3 directory structure
 set('bin_dir', 'app');
 set('var_dir', 'app');

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -44,7 +44,7 @@ set('env', function () {
 
 set('composer_options', function () {
     $debug = get('symfony_env') === 'dev';
-    return sprintf('{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction %s --optimize-autoloader --no-suggest', ($debug ? '--no-dev' : ''));
+    return sprintf('{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction %s --optimize-autoloader --no-suggest', (!$debug ? '--no-dev' : ''));
 });
 
 


### PR DESCRIPTION
When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A