### PR TITLE
Update symfony4 recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
+- Update symfony4 recipe
 
 
 ## v6.5.0

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -10,7 +10,7 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
-set('shared_files', ['.env']);
+set('shared_files', ['.env.local.php', '.env.local']);
 set('writable_dirs', ['var']);
 set('migrations_config', '');
 


### PR DESCRIPTION
Fix wrong change introduced in https://github.com/deployphp/deployer/commit/62db938884cb0cc43e85af67a300bcf9f58807dd

`.env` file should not be shared because it's release-specific. On the other hand, `.env.local` and `.env.local.php` files are specific to deployment environment and should be shared between releases.

See for details: https://github.com/deployphp/deployer/pull/1907#issuecomment-533779139

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
