### PR TITLE
Minor tweak to docs to clarify deploy_stage variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
 - Update symfony4 recipe
-- In documentation, small clarification of `deploy_stage` variable [#1866]
+- In documentation, small clarification of `deploy_stage` variable #1866
 
 
 ## v6.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]
 - Update symfony4 recipe
+- In documentation, small clarification of `deploy_stage` variable [#1866]
 
 
 ## v6.5.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,13 +140,13 @@ set('ssh_multiplexing', true);
 
 ### default\_stage
 
-If the hosts declaration has stages, this option allows you to select the default stage to deploy with `dep deploy`.
+This option allows you to select the default stage to deploy with `dep deploy`. Note that your Deployer script must have at least one stage and you must specify a stage, even if you are just running [local-only tasks](https://deployer.org/docs/tasks.html#local-tasks). Therefore it is recommended you use this command to always set a default stage.
 
 ~~~php
-set('default_stage', 'prod');
+set('default_stage', 'staging');
 
 host(...)
-    ->stage('prod');
+    ->stage('staging');
 ~~~
 
 You can also set callable as an argument if you need some more complex ways to determine default stage.


### PR DESCRIPTION
Addresses issue #1866

Clarified that you need to set a `default_stage` in your Deployer script, and also changed the default in the example code to `staging` since I think that is a more likely real-world default setting than `production`.

| Q             | A
| ------------- | ---
| Bug fix?      |  No
| New feature?  | No
| BC breaks?    |  No
| Deprecations? |  No
| Fixed tickets | 1866
