### PR TITLE
Add current_date to retrieve current release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Added doc page with sample "real-world" Deployer script
+- Added current_date to retrieve the current release date
 
 ### Fixed
 - Parameters -f or --file now are accepted also without the equal sign [#1479]

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -99,6 +99,17 @@ set('current_path', function () {
     return substr($link, 0, 1) === '/' ? $link : get('deploy_path') . '/' . $link;
 });
 
+/**
+ * Return current release date.
+ */
+set('current_date', function () {
+    $releaseDate = run("find {{deploy_path}}/current -printf '%TY-%Tm-%Td %TH:%TM:%.2TS %Tz\n'");
+    if (empty($releaseDate)) {
+        return null;
+    }
+
+    return \DateTimeImmutable::createFromFormat('Y-m-d H:i:s O', $releaseDate);
+});
 
 /**
  * Custom bins

--- a/recipe/config/current.php
+++ b/recipe/config/current.php
@@ -24,10 +24,12 @@ task('config:current', function () {
             $rows[] = [
                 $host->getHostname(),
                 basename($host->get('current_path')),
+                $host->get('current_date')->format('Y-m-d H:i:s O'),
             ];
         } catch (\Throwable $e) {
             $rows[] = [
                 $host->getHostname(),
+                'unknown',
                 'unknown',
             ];
         }
@@ -35,7 +37,7 @@ task('config:current', function () {
 
     $table = new Table(output());
     $table
-        ->setHeaders(['Host', 'Current',])
+        ->setHeaders(['Host', 'Current', 'Release date'])
         ->setRows($rows);
     $table->render();
 })->local();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This adds a simple release date info for the config:current command.
