### PR TITLE
SS4 fix to new assets dir location change

### DIFF
--- a/recipe/silverstripe.php
+++ b/recipe/silverstripe.php
@@ -8,13 +8,28 @@ require_once __DIR__ . '/common.php';
  * Silverstripe configuration
  */
 
+set('shared_assets', function () {
+    $paths = [
+        'assets',
+        'public/assets'
+    ];
+    foreach ($paths as $path) {
+        if (test('[ -d {{release_path}}/'.$path.' ]')) {
+            return $path;
+        }
+    }
+});
+
+
 // Silverstripe shared dirs
 set('shared_dirs', [
-    'assets'
+    '{{shared_assets}}'
 ]);
 
 // Silverstripe writable dirs
-set('writable_dirs', ['assets']);
+set('writable_dirs', [
+    '{{shared_assets}}'
+]);
 
 // Silverstripe cli script
 set('silverstripe_cli_script', function () {


### PR DESCRIPTION
Updated for SS4. Checks to see if assets is in root or public/assets as per SS4 new directory structure

| Q             | A
| ------------- | ---
| Bug fix?      | Yes 
| New feature?  |  No
| BC breaks?    | No
| Deprecations? |  No
| Fixed tickets | N/A
