### PR TITLE
Ask to remove current release dir if the 'release' symlink links to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.6.1
+[v6.6.0...v6.6.1](https://github.com/deployphp/deployer/compare/v6.6.0...v6.6.1)
+
+### Added
+- Added check to make sure the user doesn't remove the current release folder by accident
 
 ## v6.6.0
 [v6.5.0...v6.6.0](https://github.com/deployphp/deployer/compare/v6.5.0...v6.6.0)

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -8,7 +8,6 @@
 namespace Deployer;
 
 use Deployer\Type\Csv;
-use Deployer\Exception\GracefulShutdownException;
 
 set('release_name', function () {
     $list = get('releases_list');


### PR DESCRIPTION
Added check to make sure the user doesn't remove the current release folder by accident. This happened to a customer of ours after they finished a release by hand because it failed at the last stage and they didn't want to wait until they fixed the issue and a new deployment would be finished. On the next deployment the latest release folder was removed because the 'release' symlink was linking to this folder where the live site was located after the failed previous release. This mistake took the downtime from a few seconds to around an hour. So I thought it would be nice to warn others before making the same or a similar mistake.

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A