### PR TITLE
Add database:rollback to symfony recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.6.0...master](https://github.com/deployphp/deployer/compare/v6.6.0...master)
+
+### Added
+- Added `database:rollback` to the symfony4 recipe for have the ability to rolling back the database
+
+
 ## v6.6.0
 [v6.5.0...v6.6.0](https://github.com/deployphp/deployer/compare/v6.5.0...v6.6.0)
 

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -28,6 +28,11 @@ task('database:migrate', function () {
     run(sprintf('{{bin/console}} doctrine:migrations:migrate %s', $options));
 });
 
+desc('Rollback database');
+task('database:rollback', function () {
+    run('{{bin/console}} doctrine:migrations:migrate prev');
+});
+
 desc('Clear cache');
 task('deploy:cache:clear', function () {
     run('{{bin/console}} cache:clear --no-warmup');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Hi, I suggest this feature for add the ability to rollback the database in the Symfony4 recipe.
