### PR TITLE
Fix the use of a branch or tag name containing a single quote

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -60,14 +60,14 @@ task('deploy:update_code', function () {
 
     $at = '';
     if (!empty($branch)) {
-        $at = "-b $branch";
+        $at = "-b \"$branch\"";
     }
 
     // If option `tag` is set
     if (input()->hasOption('tag')) {
         $tag = input()->getOption('tag');
         if (!empty($tag)) {
-            $at = "-b $tag";
+            $at = "-b \"$tag\"";
         }
     }
 


### PR DESCRIPTION
If you are using a branch named with a single quote, you will get the next error `bash: line 1: unexpected EOF while looking for matching `''`

This pull request fixes it.