### PR TITLE
More Symfony 5 compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - Fixed compatibility with Symfony 4.x
+- Fixed more incompatibilities with Symfony 5
 
 
 ## v6.7.1

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -68,7 +68,7 @@ class Client
             $command = escapeshellarg($command);
 
             $ssh = "ssh $sshArguments $host $command";
-            $process = new Process($ssh);
+            $process = $this->createProcess($ssh);
             $process
                 ->setTimeout($config['timeout'])
                 ->setTty(true)
@@ -89,7 +89,7 @@ class Client
             $ssh = "ssh $sshArguments $host $become '$shellCommand; printf \"[exit_code:%s]\" $?;'";
         }
 
-        $process = new Process($ssh);
+        $process = $this->createProcess($ssh);
         $process
             ->setInput($command)
             ->setTimeout($config['timeout']);
@@ -146,7 +146,7 @@ class Client
 
     private function isMultiplexingInitialized(Host $host, Arguments $sshArguments)
     {
-        $process = new Process("ssh -O check $sshArguments $host 2>&1");
+        $process = $this->createProcess("ssh -O check $sshArguments $host 2>&1");
         $process->run();
         return (bool)preg_match('/Master running/', $process->getOutput());
     }
@@ -173,5 +173,14 @@ class Client
             $exitCode = 1;
         }
         return $output;
+    }
+
+    private function createProcess($command)
+    {
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
+            return Process::fromShellCommandline($command);
+        } else {
+            return new Process($command);
+        }
     }
 }

--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -43,7 +43,11 @@ class Rsync
 
         $this->pop->command($hostname, $rsync);
 
-        $process = new Process($rsync);
+        if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($rsync);
+        } else {
+            $process = new Process($rsync);
+        }
         $process
             ->setTimeout($config['timeout'])
             ->mustRun($this->pop->callback($hostname));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  |  No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I hate to bring the bad news here after your previous efforts to support Symfony 5, but there are still incompatibilities with symfony/process` 5.x in the Rsync- and SSH-client. This PR should fix them.

> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
