### PR TITLE
[MOD] Constructor argument types of Process

### DIFF
--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -180,7 +180,7 @@ class Client
         if (method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')) {
             return Process::fromShellCommandline($command);
         } else {
-            return new Process($command);
+            return new Process(explode(' ', $command));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | **Yes** or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

First argument on Symfony\Component\Process\Process constructor must be of type array
> Do not forget to add notes about your changes to CHANGELOG.md
>
> Easiest way to do it, by running next command:
>
>     php bin/changelog
>
