### PR TITLE
Speedup deploy:clear_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Documented check_remote task usage
+- Speedup deploy:clear_paths
 
 ### Fixed
 - Fixed Silverstripe CMS recipe assets path

--- a/recipe/deploy/clear_paths.php
+++ b/recipe/deploy/clear_paths.php
@@ -11,8 +11,14 @@ desc('Cleaning up files and/or directories');
 task('deploy:clear_paths', function () {
     $paths = get('clear_paths');
     $sudo = get('clear_use_sudo') ? 'sudo' : '';
+    $batch = 100;
 
+    $commands = [];
     foreach ($paths as $path) {
-        run("$sudo rm -rf {{release_path}}/$path");
+        $commands[] = "$sudo rm -rf {{release_path}}/$path";
+    }
+    $chunks = array_chunk($commands, $batch);
+    foreach ($chunks as $chunk) {
+        run(implode('; ', $chunk));
     }
 });


### PR DESCRIPTION
One run much faster than several. 

For example, we have 13 items for delete and it took ✔ Ok [4s 374ms], with one run it takes ✔ Ok [307ms]

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

