### PR TITLE
Allow configuring binaries per host 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Documented check_remote task usage
 - Speedup deploy:clear_paths
+- Allow configuring binaries per host (thanks @rvanlaak)
 
 ### Fixed
 - Fixed Silverstripe CMS recipe assets path [#1989]

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,7 +1,7 @@
 # Hosts
 
 Defining a host in Deployer is necessary to deploy your application. It can be a remote machine, a local machine or Amazon EC2 instances.
-Each host contains a hostname, a stage, one or more roles and configuration parameters. 
+Each host contains a hostname, a stage, one or more roles and configuration parameters.
 
 You can define hosts with the `host` function in `deploy.php` file. Here is an example of a host definition:
 
@@ -28,6 +28,28 @@ Then to `deploy.php`:
 ~~~php
 inventory('hosts.yml');
 ~~~
+
+### Overriding binaries
+
+Deployer on-the-fly locates binaries (like `php`, `git`, `composer`) by the help of `which`. The hosts allow
+to override binary paths.
+
+In cases where it is not possible to modify PATH or set an ALIAS to binaries, telling Deployer to override binaries
+can help.
+
+~~~yaml
+domain.com:
+  binaries:
+    php: bin/php7.4
+~~~
+
+~~~php
+host('domain.com')
+    ->binary('php', 'php7.4')
+;
+~~~
+
+### Ensure the ssh agent has access to target hosts
 
 Make sure that your `~/.ssh/config` file contains information about your domains and how to connect.
 Or you can specify that information in the `deploy.php` file itself.
@@ -68,7 +90,7 @@ Inside any task, you can get host config with the `get` function, and the host o
 ~~~php
 task('...', function () {
     $deployPath = get('deploy_path');
-    
+
     $host = host('domain.com');
     $port = $host->getPort();
 });
@@ -100,7 +122,7 @@ If you have a lot of hosts following similar patterns, you can describe them lik
 host('www[01:50].domain.com');
 ~~~
 
-For numeric patterns, leading zeros can be included or removed, as desired. Ranges are inclusive. 
+For numeric patterns, leading zeros can be included or removed, as desired. Ranges are inclusive.
 
 You can also define alphabetic ranges:
 
@@ -149,10 +171,10 @@ Often you have only one server for prod and beta stages. You can easily configur
 host('production')
     ->hostname('domain.com')
     ->set('deploy_path', '~/domain.com');
-    
+
 host('beta')
     ->hostname('domain.com')
-    ->set('deploy_path', '~/beta.domain.com');    
+    ->set('deploy_path', '~/beta.domain.com');
 ~~~
 
 Now you can deploy with these commands:
@@ -192,7 +214,7 @@ domain.com:
   extra_param: "foo {{hostname}}"
 ~~~
 
-> **Note** that, as with the `host` function in the *deploy.php* file, it's better to omit information such as 
+> **Note** that, as with the `host` function in the *deploy.php* file, it's better to omit information such as
 > *user*, *port*, *identityFile*, *forwardAgent* and use it from the `~/.ssh/config` file instead.
 
 If your inventory file contains many similar host definitions, you can use YAML extend syntax:
@@ -206,16 +228,16 @@ If your inventory file contains many similar host definitions, you can use YAML 
 www1.domain.com:
   <<: *base
   stage: production
-  
+
 beta1.domain.com:
   <<: *base
   stage: beta
-    
+
 ...
 ~~~
 
 Hosts that start with `.` (*dot*) are called hidden and are not visible outside that file.
- 
+
 To define localhost in inventory files add a `local` key:
 
 ~~~yaml

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -229,6 +229,22 @@ class Host
         return $this;
     }
 
+    public function binary(string $binary, string $path)
+    {
+        $binaries = $this->config->get('binaries', []);
+        $binaries[$binary] = $path;
+        $this->config->add('binaries', $binaries);
+
+        return $this;
+    }
+
+    public function getBinary(string $binary): ?string
+    {
+        $binaries = $this->config->get('binaries');
+
+        return $binaries[$binary] ?? null;
+    }
+
     public function roles(...$roles): self
     {
         $this->config->set('roles', []);

--- a/src/functions.php
+++ b/src/functions.php
@@ -763,6 +763,12 @@ function parse($value)
 
 function locateBinaryPath($name)
 {
+    // Allow configuring binaries per host without having to adjust PATH or add an alias
+    $hostCustomBinaries = Context::get()->getConfig()->get('binaries');
+    if (isset($hostCustomBinaries[$name])) {
+        return $hostCustomBinaries[$name];
+    }
+
     $nameEscaped = escapeshellarg($name);
 
     // Try `command`, should cover all Bourne-like shells

--- a/test/fixture/inventory.yml
+++ b/test/fixture/inventory.yml
@@ -45,3 +45,8 @@ beta.deployer.org:
     - app
     - db
   deploy_path: ~/app
+
+edge.deployer.org:
+  stage: edge
+  binaries:
+    php: php8

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -102,6 +102,18 @@ class FunctionsTest extends TestCase
         }
     }
 
+    public function testBinariesFromInventory()
+    {
+        inventory(__DIR__ . '/../fixture/inventory.yml');
+
+        $host = $this->deployer->hosts->get('edge.deployer.org');
+        self::assertInstanceOf(Host::class, $host);
+
+        $phpBinary = $host->getBinary('php');
+
+        self::assertStringContainsString('php8', $phpBinary);
+    }
+
     public function testTask()
     {
         task('task', 'pwd');

--- a/test/src/Host/FileLoaderTest.php
+++ b/test/src/Host/FileLoaderTest.php
@@ -16,13 +16,15 @@ class FileLoaderTest extends TestCase
      */
     private $hosts;
 
-    public function testLoad()
+    public function setUp(): void
     {
         $this->hosts = (new FileLoader())
             ->load(__DIR__ . '/../../fixture/inventory.yml')
             ->getHosts();
+    }
 
-
+    public function testLoad()
+    {
         // .base does not exists
         self::assertNull($this->getHost('.base'), 'Hidden hosts exists in inventory');
 
@@ -56,6 +58,12 @@ class FileLoaderTest extends TestCase
         self::assertEquals('db1.deployer.org', $db1->getHostname());
         $db2 = $this->getHost('db2.deployer.org');
         self::assertEquals('db2.deployer.org', $db2->getHostname());
+    }
+
+    public function testBinaries()
+    {
+        $edge = $this->getHost('edge.deployer.org');
+        self::assertEquals('php8', $edge->getBinary('php'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

Right now, it is not possible to modify the php / git / composer binary without having to adjust PATH or add an alias at the target host.

This PR adds functionality to override binaries per host for both `yaml` inventories as `php` configured hosts.

## Use cases

We want to test PHP7.4 on one of our edge / remote hosts without having to modify the defaults.
