### PR TITLE
fix backward compatibility of bin/console for symfony4 recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed Silverstripe CMS recipe assets path [#1989]
 - Fixed check_remote task errors [#1990]
 - Fixed check_remote task revision resolution [#1994]
+- Fixed backward compatibility of bin/console for symfony4 recipe
 
 
 ## v6.7.3

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -15,7 +15,11 @@ set('writable_dirs', ['var']);
 set('migrations_config', '');
 
 set('bin/console', function () {
-    return parse('{{bin/php}} {{release_path}}/bin/console --no-interaction');
+    return parse('{{release_path}}/bin/console');
+});
+
+set('console_options', function () {
+    return '--no-interaction';
 });
 
 desc('Migrate database');
@@ -25,17 +29,17 @@ task('database:migrate', function () {
         $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
     }
 
-    run(sprintf('{{bin/console}} doctrine:migrations:migrate %s', $options));
+    run(sprintf('{{bin/php}} {{bin/console}} doctrine:migrations:migrate %s {{console_options}}', $options));
 });
 
 desc('Clear cache');
 task('deploy:cache:clear', function () {
-    run('{{bin/console}} cache:clear --no-warmup');
+    run('{{bin/php}} {{bin/console}} cache:clear {{console_options}} --no-warmup');
 });
 
 desc('Warm up cache');
 task('deploy:cache:warmup', function () {
-    run('{{bin/console}} cache:warmup');
+    run('{{bin/php}} {{bin/console}} cache:warmup {{console_options}}');
 });
 
 desc('Deploy project');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | https://github.com/deployphp/deployer/issues/1944

Unfortunately, the symfony4 recipe is not compatible with tasks for symfony3 recipe, because the `bin/console` includes the `bin/php` and there are no `console_options` defined.
Therefore we changed the definition of `bin/console`!
