### PR TITLE
Keep consistency with deployer executable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed check_remote task errors [#1990]
 - Fixed check_remote task revision resolution [#1994]
 - Fixed backward compatibility of bin/console for symfony4 recipe
+- Keep consistency with executable naming in lock recipe
 
 
 ## v6.7.3

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -18,7 +18,7 @@ task('deploy:lock', function () {
 
         throw new GracefulShutdownException(
             "Deploy locked.\n" .
-            sprintf('Execute "dep deploy:unlock%s" to unlock.', $stage)
+            sprintf('Execute "'.  Deployer::getCalledScript() .' deploy:unlock%s" to unlock.', $stage)
         );
     } else {
         run("touch {{deploy_path}}/.dep/deploy.lock");

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -396,4 +396,20 @@ class Deployer extends Container
             });
         }
     }
+
+    /**
+     * @return string
+     * @codeCoverageIgnore
+     */
+    public static function getCalledScript(): string
+    {
+        $executable = !empty($_SERVER['_']) ? $_SERVER['_'] : $_SERVER['PHP_SELF'];
+        $shortcut = false !== strpos(getenv('PATH'), dirname($executable)) ? basename($executable) : $executable;
+
+        if ($executable !== $_SERVER['PHP_SELF']) {
+            return sprintf('%s %s', $shortcut, $_SERVER['PHP_SELF']);
+        }
+
+        return $shortcut;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This minor change guesses the local name of the `deployed.phar` script (or `./vendor/bin/dep`) for using in console output.

Example with a locked deployment:

```bash
$ dep deploy 

Deploy locked.                                        
  Execute "dep deploy:unlock dev" to unlock.
```

```bash
$ ./vendor/bin/dep deploy 

Deploy locked.                                        
  Execute "./vendor/bin/dep deploy:unlock dev" to unlock.
```

```bash
$ php vendor/bin/dep deploy 

Deploy locked.                                        
  Execute "php vendor/bin/dep deploy:unlock dev" to unlock.
```

```bash
$ php deployer.phar deploy 

Deploy locked.                                        
  Execute "php deployer.phar deploy:unlock dev" to unlock.
```

```bash
$ ./bin/deployer deploy 

Deploy locked.                                        
  Execute "./bin/deployer deploy:unlock dev" to unlock.
```

If called script is found in `PATH`, a `basename()` is applied to avoid showing full path (like `/usr/local/bin/php` or `/home/user/.composer/vendor/bin/dep`, for instance).
This will help people unfamiliar with the tool to just copy/paste suggestions. 