### PR TITLE
Output with parallel task execution was garbled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Documented check_remote task usage
 - Speedup deploy:clear_paths
 
+### Changed
+- Ssh\Client does no longer use tty unless config option 'forceSshTty' is enabled
+- ParallelExecutor task output is prefixed with host index
+
 ### Fixed
 - Fixed Silverstripe CMS recipe assets path [#1989]
 - Fixed check_remote task errors [#1990]

--- a/src/Ssh/Client.php
+++ b/src/Ssh/Client.php
@@ -49,9 +49,11 @@ class Client
     {
         $hostname = $host->getHostname();
         $defaults = [
-            'timeout' => Deployer::getDefault('default_timeout', 300),
-            'tty' => false,
+            'timeout'     => Deployer::getDefault('default_timeout', 300),
+            'tty'         => false,
+            'forceSshTty' => false,
         ];
+
         $config = array_merge($defaults, $config);
 
         $this->pop->command($hostname, $command);
@@ -69,10 +71,17 @@ class Client
 
             $ssh = "ssh $sshArguments $host $command";
             $process = $this->createProcess($ssh);
-            $process
-                ->setTimeout($config['timeout'])
-                ->setTty(true)
-                ->mustRun();
+            $process->setTimeout($config['timeout']);
+
+            if ($config['forceSshTty']) {
+                $process->setTty(true);
+            }
+
+            $process->mustRun(
+                function (string $type, string $message) {
+                    echo $message;
+                }
+            );
 
             return $process->getOutput();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | Not sure
| Deprecations? | No
| Fixed tickets | N/A
| Client OS | macOS 10.15.3
| Host OS |  Ubuntu 16.04.6 LTS


Hi!

When i'm deploying to multiple servers i use the `-p`, but most of the time due to task output containing control characters causes the terminal output to be garbled.

When the symfony process is created with tty enabled it causes to use my local machines /dev/tty 
this renders all output handling useless (nofi).
The `$process->getOutput()` does not return anything because there is nothing to return.

So i disabled it tty and added a closure that outputs the process, i could imagine this is not ideal so added an config option where the old behaviour can be forced. 
I'm only seeing my view on the problem so and i don't need the tty option to be enabled, but imagine this can be crucial to other users.

Maybe there is a better solution for this problem but did not find any.

Also i added some output formatting to better show which host is outputting what.



