### PR TITLE
Fix comment in common recipe

### DIFF
--- a/recipe/common.php
+++ b/recipe/common.php
@@ -74,7 +74,7 @@ set('writable_chmod_recursive', true); // For chmod mode only (if is boolean, it
 set('http_user', false);
 set('http_group', false);
 
-set('clear_paths', []);         // Relative path from deploy_path
+set('clear_paths', []);         // Relative path from release_path
 set('clear_use_sudo', false);    // Using sudo in clean commands?
 
 set('cleanup_use_sudo', false); // Using sudo in cleanup commands?


### PR DESCRIPTION
As stated in https://github.com/deployphp/deployer/issues/869 the copy_dirs task works relative to release_path rather then deploy_path as indicated by the comment in recipe/common.php

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | 869