### PR TITLE
Added support for composer v2 installed.json format + composer.phar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Keep consistency with executable naming in lock recipe
 - Unexpected exception in config:* tasks when no stage is defined for host [#1909] [#1909] [#1909]
 - Fixed parsing of installed.json by Composer version 2
+- Fixed only call bin/php on the composer.phar file
 
 
 ## v6.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed backward compatibility of bin/console for symfony4 recipe
 - Keep consistency with executable naming in lock recipe
 - Unexpected exception in config:* tasks when no stage is defined for host [#1909] [#1909] [#1909]
+- Fixed parsing of installed.json by Composer version 2
 
 
 ## v6.7.3

--- a/bin/dep
+++ b/bin/dep
@@ -107,7 +107,7 @@ $version = 'master';
 $installedFile = $vendorDir . '/composer/installed.json';
 if (is_readable($installedFile)) {
     $installed = json_decode(file_get_contents($installedFile), true);
-    $packages = isset($installed['packages']) ? $installed['packages'] : $installed;
+    $packages = $installed['packages'] ?? $installed;
 
     foreach ($packages as $package) {
         if ($package['name'] === 'deployer/deployer') {

--- a/bin/dep
+++ b/bin/dep
@@ -106,7 +106,9 @@ $version = 'master';
 
 $installedFile = $vendorDir . '/composer/installed.json';
 if (is_readable($installedFile)) {
-    $packages = json_decode(file_get_contents($installedFile), true);
+    $installed = json_decode(file_get_contents($installedFile), true);
+    $packages = isset($installed['packages']) ? $installed['packages'] : $installed;
+
     foreach ($packages as $package) {
         if ($package['name'] === 'deployer/deployer') {
             $version = $package['version'];

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -118,10 +118,10 @@ set('bin/composer', function () {
 
     if (empty($composer)) {
         run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}");
-        $composer = '{{release_path}}/composer.phar';
+        $composer = '{{bin/php}} {{release_path}}/composer.phar';
     }
 
-    return '{{bin/php}} ' . $composer;
+    return $composer;
 });
 
 set('bin/symlink', function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A or xx

- Added support for composer v2 installed.json format 
- Only use bin/php on composer.phar
