### PR TITLE
Use rfc2606 for example domains

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -6,7 +6,7 @@ Each host contains a hostname, a stage, one or more roles and configuration para
 You can define hosts with the `host` function in `deploy.php` file. Here is an example of a host definition:
 
 ~~~php
-host('domain.com')
+host('production.example.com')
     ->stage('production')
     ->roles('app')
     ->set('deploy_path', '~/app');
@@ -17,7 +17,7 @@ Host *domain.com* has stage `production`, one role `app` and a configuration par
 Hosts can also be described by using yaml syntax. Write this in a `hosts.yml` file:
 
 ~~~yaml
-domain.com:
+production.example.com:
   stage: production
   roles: app
   deploy_path: ~/app
@@ -33,7 +33,7 @@ Make sure that your `~/.ssh/config` file contains information about your domains
 Or you can specify that information in the `deploy.php` file itself.
 
 ~~~php
-host('domain.com')
+host('production.example.com')
     ->user('name')
     ->port(22)
     ->configFile('~/.ssh/config')
@@ -69,7 +69,7 @@ Inside any task, you can get host config with the `get` function, and the host o
 task('...', function () {
     $deployPath = get('deploy_path');
     
-    $host = host('domain.com');
+    $host = host('example.com');
     $port = $host->getPort();
 });
 ~~~


### PR DESCRIPTION
Using actual domains in examples could be considered dangerous. For example, currently, domain.com is owned, and it's ssh port even answers.

This PR changes to use subdomains of reserved example.com: 
- https://tools.ietf.org/html/rfc2606

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md. A command-line tool has been included to make this easy, see [CONTRIBUTING.md](CONTRIBUTING.md#update-the-changelog) for details.
