### PR TITLE
Use absolute url for CONTRIBUTING

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,6 @@
 | Deprecations? | Yes or No
 | Fixed tickets | N/A or xx
 
-> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md](CONTRIBUTING.md#update-the-changelog) for details.
+> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md] for details.
+
+[CONTRIBUTING.md]: https://github.com/deployphp/deployer/blob/master/.github/CONTRIBUTING.md#update-the-changelog


### PR DESCRIPTION
The relative path does not work in pull request itself.

| Q             | A
| ------------- | ---
| Bugfix?      | Yes

> Do not forget to add notes about your changes to CHANGELOG.md. A command-line tool has been included to make this easy, see [CONTRIBUTING.md](CONTRIBUTING.md#update-the-changelog) for details.

Bein on Pull Request view:
- https://github.com/deployphp/deployer/pull/2038

The relative link in PR view will point to:
- https://github.com/deployphp/deployer/pull/CONTRIBUTING.md#update-the-changelog

which will be redirected to:
- https://github.com/deployphp/deployer/compare/CONTRIBUTING.md?expand=1#update-the-changelog