### PR TITLE
support for locales in static-content deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [v6.8.0...master](https://github.com/deployphp/deployer/compare/v6.8.0...master)
 
 ### Fixed
-- Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. By default it's using `en_US`. To change that, simply put i. e. `set('static-content-locales', 'en_US de_DE');` in you deployer script.
+- Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. By default it's using `en_US`. To change that, simply put i. e. `set('static-content-locales', 'en_US de_DE');` in you deployer script. [#2040]
 - When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process. [#2035]
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [v6.8.0...master](https://github.com/deployphp/deployer/compare/v6.8.0...master)
 
 ### Fixed
-- Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. By default it's using `en_US`. To change that, simply put i. e. `set('static-content-locales', 'en_US de_DE');` in you deployer script. [#2040]
+- Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
 - When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process. [#2035]
 
 
@@ -573,6 +573,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2040]: https://github.com/deployphp/deployer/issues/2040
 [#2035]: https://github.com/deployphp/deployer/issues/2035
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 [v6.8.0...master](https://github.com/deployphp/deployer/compare/v6.8.0...master)
 
 ### Fixed
+- Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. By default it's using `en_US`. To change that, simply put i. e. `set('static-content-locales', 'en_US de_DE');` in you deployer script.
 - When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process. [#2035]
 
 

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -4,6 +4,8 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 // Configuration
+set('static-content-locales', 'en_US');
+
 set('shared_files', [
     'app/etc/env.php',
     'var/.maintenance.ip',
@@ -46,7 +48,7 @@ task('magento:compile', function () {
 
 desc('Deploy assets');
 task('magento:deploy:assets', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy");
+    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static-content-locales}}");
 });
 
 desc('Enable maintenance mode');

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -4,7 +4,11 @@ namespace Deployer;
 require_once __DIR__ . '/common.php';
 
 // Configuration
-set('static-content-locales', 'en_US');
+
+// By default setup:static-content:deploy uses `en_US`. 
+// To change that, simply put set('static_content_locales', 'en_US de_DE');` 
+// in you deployer script.
+set('static_content_locales', 'en_US');
 
 set('shared_files', [
     'app/etc/env.php',
@@ -48,7 +52,7 @@ task('magento:compile', function () {
 
 desc('Deploy assets');
 task('magento:deploy:assets', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static-content-locales}}");
+    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static_content_locales}}");
 });
 
 desc('Enable maintenance mode');


### PR DESCRIPTION
you can now `set('static-content-locales', 'en_US de_DE');` in you deploy.php to deploy multiple locales instead of just en_US

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2040

> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md](CONTRIBUTING.md#update-the-changelog) for details.
