### PR TITLE
Let `rollback` fail if there are no more releases to revert to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
 - When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process. [#2035]
+- Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
 
 
 ## v6.8.0
@@ -577,6 +578,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2052]: https://github.com/deployphp/deployer/issues/2052
 [#2043]: https://github.com/deployphp/deployer/pull/2043
 [#2040]: https://github.com/deployphp/deployer/issues/2040
 [#2035]: https://github.com/deployphp/deployer/issues/2035

--- a/recipe/deploy/rollback.php
+++ b/recipe/deploy/rollback.php
@@ -7,6 +7,8 @@
 
 namespace Deployer;
 
+use Deployer\Exception\Exception;
+
 desc('Rollback to previous release');
 task('rollback', function () {
     $releases = get('releases_list');
@@ -23,6 +25,6 @@ task('rollback', function () {
 
         writeln("<info>rollback</info> to {$releases[1]} release was <success>successful</success>");
     } else {
-        writeln("<error>no more releases you can revert to</error>");
+        throw new Exception("No more releases you can revert to.");
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2052 

> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md] for details.

[CONTRIBUTING.md]: https://github.com/deployphp/deployer/blob/master/.github/CONTRIBUTING.md#update-the-changelog
