### PR TITLE
Fix Property "seriesExecutor" does not exist.

### DIFF
--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -231,9 +231,14 @@ class Task
         return $this;
     }
 
+    /**
+     * @param string $selector
+     * @return Task
+     */
     public function select(string $selector)
     {
         $this->selector = Selector::parse($selector);
+        return $this;
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -430,7 +430,7 @@ function invoke($task)
     $hosts = [Context::get()->getHost()];
     $tasks = Deployer::get()->scriptManager->getTasks($task, $hosts);
 
-    $executor = Deployer::get()->seriesExecutor;
+    $executor = Deployer::get()->executor;
     $executor->run($tasks, $hosts);
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

I've started to create a POC for our deploying needs and noticed that the follow snippet threw an error in the master branch:

```php
task('build', function() {
    run('echo "hello world" > build.txt');
})->local();

task('deploy', function() {
    invoke('build');
});
```