### PR TITLE
fixed issue #1982

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
 - Replaced `runLocally` with `on(localhost(), ...)` in `deploy:check_remote` to make sure all code is ran on localhost. [#2170]
 - Fixed unit tests on non-master branches. [#2181]
+- Shared folder creation. [#1982]
 
 
 ## v6.8.0
@@ -607,6 +608,7 @@
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990
 [#1989]: https://github.com/deployphp/deployer/issues/1989
+[#1982]: https://github.com/deployphp/deployer/issues/1982
 [#1971]: https://github.com/deployphp/deployer/pull/1971
 [#1969]: https://github.com/deployphp/deployer/issues/1969
 [#1909]: https://github.com/deployphp/deployer/issues/1909

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -32,7 +32,7 @@ task('deploy:shared', function () {
 
         // Create path to shared dir in release dir if it does not exist.
         // Symlink will not create the path and will fail otherwise.
-        run("mkdir -p `dirname {{release_path}}/$dir`");
+        run("mkdir -p {{release_path}}/$dir");
 
         // Symlink shared dir to release dir
         run("{{bin/symlink}} $sharedPath/$dir {{release_path}}/$dir");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #1982

Fixes issue where we use dirname before recursive directory creation to symlink shared folders. For example dirname a/b/c will return a/b and try to create it then next step will try to symlink a/b/c but c was never created