### PR TITLE
feat!: adapt chat notify favicon to handle custom links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Added
 - Added a Slack notification task on rollback.
 
+### Changed
+- Google hangout chat notification favicon handling.
+
 ### Fixed
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
 - When symfony_env is set to dev, require-dev are not installed and missing packages are breaking installation process. [#2035]

--- a/contrib/chat.php
+++ b/contrib/chat.php
@@ -33,7 +33,7 @@ task('chat:notify', function () {
         'header' => [
             'title'      => get('chat_title'),
             'subtitle'   => get('chat_subtitle'),
-            'imageUrl'   => (get('favicon') ? 'http://' . get('hostname') . '/favicon.png' : ''),
+            'imageUrl'   => get('favicon'),
             'imageStyle' => 'IMAGE'
         ],
         'sections' => [
@@ -76,7 +76,7 @@ task('chat:notify:success', function () {
         'header' => [
             'title'      => get('chat_title'),
             'subtitle'   => get('chat_subtitle'),
-            'imageUrl'   => (get('favicon') ? 'http://' . get('hostname') . '/favicon.png' : ''),
+            'imageUrl'   => get('favicon'),
             'imageStyle' => 'IMAGE'
         ],
         'sections' => [


### PR DESCRIPTION
BREAKING CHANGE: This will affect all deployments that used the default hangout chat notification behavior

With this change it is possible to use custom links instead
of the preset favicon.png for google hangout chat notificactions
This functionality is already set for failure, but not success and base notify

| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A