### PR TITLE
Shared upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Added a Slack notification task on rollback.
+- Ability to upload shared files from deploy server at first time deploy of project.
 
 ### Fixed
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -64,6 +64,7 @@ set('repository', ''); // Repository to deploy.
 
 set('shared_dirs', []);
 set('shared_files', []);
+set('shared_use_bootstrap', false);
 
 set('copy_dirs', []);
 

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -59,6 +59,12 @@ task('deploy:shared', function () {
             // Copy file in shared dir if not present
             run("cp -rv {{release_path}}/$file $sharedPath/$file");
         }
+        else {
+            $sharedBootstrapDir = get('shared_use_bootstrap') ? 'shared' : '';
+            if ($sharedBootstrapDir != '') {
+                upload($sharedBootstrapDir . '/' . $file, $sharedPath . '/' . $file);
+            }
+        }
 
         // Remove from source.
         run("if [ -f $(echo {{release_path}}/$file) ]; then rm -rf {{release_path}}/$file; fi");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

This small feature resolve situations with first time deploy to new server, when shared files (.env for laravel for example) is empty.

Example:
1. Put production copy of .env file to folder shared
2. set('shared_use_bootstrap', true);