### PR TITLE
Add sulu images cache folder to shared_dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.x
+
+### Added
+- Add sulu images cache folder to shared_dirs
+
 
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)

--- a/recipe/sulu2.php
+++ b/recipe/sulu2.php
@@ -4,7 +4,7 @@ namespace Deployer;
 
 require_once __DIR__ . '/symfony4.php';
 
-add('shared_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'public/uploads']);
+add('shared_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'public/uploads', 'var/images-cache']);
 
 add('writable_dirs', ['public/uploads']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No 
| Deprecations? | No
| Fixed tickets | -
| Related PR | https://github.com/sulu/sulu/pull/5424

A new directory was added in sulu 2 which needed to be shared.

This is still WIP but don't want to forget it to update this recipe when merged here: https://github.com/sulu/sulu/pull/5424
