### PR TITLE
Fixed: Bug

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -504,7 +504,7 @@ function writeln($message, $options = 0)
  */
 function write($message, $options = 0)
 {
-    output()->write(parse($message), $options);
+    output()->write(parse($message), false, $options);
 }
 
 /**


### PR DESCRIPTION
`OutputInterface` have next definition, and `$options` is the third parameter of `write`, not second:
```
    /**
     * Writes a message to the output.
     *
     * @param string|iterable $messages The message as an iterable of strings or a single string
     * @param bool            $newline  Whether to add a newline
     * @param int             $options  A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
     */
    public function write($messages, bool $newline = false, int $options = 0);
```

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md] for details.

[CONTRIBUTING.md]: https://github.com/deployphp/deployer/blob/master/.github/CONTRIBUTING.md#update-the-changelog
