### PR TITLE
Updated Shopware 6 recipe

### DIFF
--- a/recipe/shopware6.php
+++ b/recipe/shopware6.php
@@ -15,9 +15,9 @@ set('shared_dirs', [
     'public/sitemap'
 ]);
 set('writable_dirs', [
-//    'var',
-//    'public/media',
-//    'public/thumbnail'
+    'var',
+    'public/media',
+    'public/thumbnail'
 ]);
 set('static_folders', []);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | Yes
| Deprecations? | No
| Fixed tickets | N/A or xx

There were a bunch of things missing in the Shopware 6 recipe. These were probably hidden in the previously referenced `build.sh`, which doesn't exist in a normal Shopware 6 installation (or Deployer itself).

I've also added `.psh.yaml.override` in the shared_files so database credentials don't have to be committed to the Git repo. I also added missing `composer install` and database migration task.