### PR TITLE
Fix: Do not bother updating composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
       - acl
 
 install:
-  - composer self-update
   - composer update --no-interaction --prefer-dist $COMPOSER_FLAGS
 
 script:


### PR DESCRIPTION
This PR

* [x] stops updating `composer` twice

💁‍♂️ It's already updated on Travis. For reference, see

- https://travis-ci.org/github/deployphp/deployer/jobs/722653436#L192
- https://travis-ci.org/github/deployphp/deployer/jobs/722653436#L215