### PR TITLE
Enhancement: Add deploy:is-unlocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Recipe for crontab tasks.
 - ISPManager recipe and docs.
 - Symfony 5 recipe.
+- Command for checking if a deploy is unlocked. [#2150] [#2150]
 
 ### Fixed
 - Normalize CRLF to LF new line endings. [#2111]
@@ -581,6 +582,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2150]: https://github.com/deployphp/deployer/issues/2150
 [#2111]: https://github.com/deployphp/deployer/pull/2111
 [#2052]: https://github.com/deployphp/deployer/issues/2052
 [#2043]: https://github.com/deployphp/deployer/pull/2043

--- a/recipe/deploy/lock.php
+++ b/recipe/deploy/lock.php
@@ -8,6 +8,7 @@
 namespace Deployer;
 
 use Deployer\Exception\GracefulShutdownException;
+use Deployer\Exception\RunException;
 
 desc('Lock deploy');
 task('deploy:lock', function () {
@@ -26,4 +27,17 @@ task('deploy:lock', function () {
 desc('Unlock deploy');
 task('deploy:unlock', function () {
     run("rm -f {{deploy_path}}/.dep/deploy.lock");//always success
+});
+
+desc('Check if deploy is unlocked');
+task('deploy:is-unlocked', function () {
+    $locked = test("[ -f {{deploy_path}}/.dep/deploy.lock ]");
+
+    if ($locked) {
+        writeln( 'Deploy is currently locked.');
+
+        throw new GracefulShutdownException();
+    }
+
+    writeln( 'Deploy is currently unlocked.');
 });

--- a/test/recipe/DeployTest.php
+++ b/test/recipe/DeployTest.php
@@ -186,4 +186,48 @@ class DeployTest extends AbstractTest
         self::assertStringContainsString('[prod] /new/deploy/path', $display);
         self::assertStringContainsString('[beta] /new/deploy/path', $display);
     }
+
+    public function testIsUnlockedExitsWithOneWhenDeployIsLocked()
+    {
+        $recipe = __DIR__ . '/deploy.php';
+
+        $this->init($recipe);
+
+        $this->tester->run(['deploy:lock', '-s' => 'all', '-f' => $recipe, '-l' => 1], [
+            'verbosity' => Output::VERBOSITY_VERBOSE,
+            'interactive' => false,
+        ]);
+
+        $this->tester->run(['deploy:is-unlocked', '-s' => 'all', '-f' => $recipe, '-l' => 1], [
+            'verbosity' => Output::VERBOSITY_VERBOSE,
+            'interactive' => false,
+        ]);
+
+        $display = $this->tester->getDisplay();
+
+        self::assertStringContainsString('Deploy is currently locked.', $display);
+        self::assertSame(1, $this->tester->getStatusCode());
+    }
+
+    public function testIsUnlockedExitsWithZeroWhenDeployIsNotLocked()
+    {
+        $recipe = __DIR__ . '/deploy.php';
+
+        $this->init($recipe);
+
+        $this->tester->run(['deploy:unlock', '-s' => 'all', '-f' => $recipe, '-l' => 1], [
+            'verbosity' => Output::VERBOSITY_VERBOSE,
+            'interactive' => false,
+        ]);
+
+        $this->tester->run(['deploy:is-unlocked', '-s' => 'all', '-f' => $recipe, '-l' => 1], [
+            'verbosity' => Output::VERBOSITY_VERBOSE,
+            'interactive' => false,
+        ]);
+
+        $display = $this->tester->getDisplay();
+
+        self::assertStringContainsString('Deploy is currently unlocked.', $display);
+        self::assertSame(0, $this->tester->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2150 

This PR

* [x] adds a command that allows to check if a deploy is locked