### PR TITLE
fixes composer not using specified {{bin/php}}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
 - When symfony_env is set to dev, require-dev are not installed. [#2035]
 - Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
-
+- composer install now respects {{bin/php}} config
 
 ## v6.8.0
 [v6.7.3...v6.8.0](https://github.com/deployphp/deployer/compare/v6.7.3...v6.8.0)

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -12,5 +12,5 @@ task('deploy:vendors', function () {
     if (!commandExist('unzip')) {
         warning('To speed up composer installation setup "unzip" command with PHP zip extension.');
     }
-    run('cd {{release_path}} && {{bin/composer}} {{composer_options}} 2>&1');
+    run('cd {{release_path}} && {{bin/php}} {{bin/composer}} {{composer_options}} 2>&1');
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

fixes missing {{bin/php}} in vendor task for composer calls.

forces composer calls to use the specified php binary