### PR TITLE
Add sw:plugin:activate:all and sw:plugin:migrate:all to Shopware 6 recipe

### DIFF
--- a/recipe/shopware6.php
+++ b/recipe/shopware6.php
@@ -56,17 +56,19 @@ task('sw:cache:warmup', static function () {
 task('sw:database:migrate', static function () {
     run('cd {{release_path}} && bin/console database:migrate --all');
 });
-task('sw:plugins:installActivateUpgrade', static function () {
+task('sw:plugin:refresh', function (){
+    run('cd {{release_path}} && bin/console plugin:refresh');
+});
+task('sw:plugin:activate:all', static function () {
+    task('sw:plugin:refresh');
     $plugins = explode("\n", run('cd {{release_path}} && bin/console plugin:list'));
 
-// take line over headlines and count "-" to get the size of the cells
+    // take line over headlines and count "-" to get the size of the cells
     $lengths = array_filter(array_map('strlen', explode(' ', $plugins[4])));
 
-// ignore first seven lines (headline, title, table, ...)
+    // ignore first seven lines (headline, title, table, ...)
     $plugins = array_slice($plugins, 7, -3);
     foreach ($plugins as $plugin) {
-// PayonePayment   PAYONE Payment   2.0.0                       PAYONE GmbH, Kellerkinder Pluginwerk GmbH   No          No       No
-
         $pluginParts = [];
         foreach ($lengths as $length) {
             $pluginParts[] = trim(substr($plugin, 0, $length));
@@ -88,9 +90,37 @@ task('sw:plugins:installActivateUpgrade', static function () {
         if ($installed === 'No' || $active === 'No') {
             run("cd {{release_path}} && bin/console plugin:install --activate $plugin");
         }
+    }
+});
+task('sw:plugin:migrate:all', static function(){
+    $plugins = explode("\n", run('cd {{release_path}} && bin/console plugin:list'));
 
-        if ($upgradeable === 'Yes') {
-            run("cd {{release_path}} && bin/console plugin:update -c $plugin");
+    // take line over headlines and count "-" to get the size of the cells
+    $lengths = array_filter(array_map('strlen', explode(' ', $plugins[4])));
+
+    // ignore first seven lines (headline, title, table, ...)
+    $plugins = array_slice($plugins, 7, -3);
+    foreach ($plugins as $plugin) {
+        $pluginParts = [];
+        foreach ($lengths as $length) {
+            $pluginParts[] = trim(substr($plugin, 0, $length));
+            $plugin = substr($plugin, $length + 1);
+        }
+
+        [
+            $plugin,
+            $label,
+            $version,
+            $upgrade,
+            $version,
+            $author,
+            $installed,
+            $active,
+            $upgradeable,
+        ] = $pluginParts;
+
+        if ($installed === 'Yes' || $active === 'Yes') {
+            run("cd {{release_path}} && bin/console database:migrate --all $plugin");
         }
     }
 });
@@ -99,9 +129,10 @@ task('sw:plugins:installActivateUpgrade', static function () {
  * Grouped SW deploy tasks
  */
 task('sw:deploy', [
-//    'sw:plugins:installActivateUpgrade',
     'sw:build',
+    'sw:plugin:activate:all',
     'sw:database:migrate',
+    'sw:plugin:migrate:all',
     'sw:theme:compile',
     'sw:cache:clear',
 ]);

--- a/recipe/shopware6.php
+++ b/recipe/shopware6.php
@@ -120,7 +120,7 @@ task('sw:plugin:migrate:all', static function(){
         ] = $pluginParts;
 
         if ($installed === 'Yes' || $active === 'Yes') {
-            run("cd {{release_path}} && bin/console database:migrate --all $plugin");
+            run("cd {{release_path}} && bin/console database:migrate --all $plugin || true");
         }
     }
 });


### PR DESCRIPTION
Do not update upgradeable plugins, it updates code too. What we actually want is to run the migration. But the database:migrate --all command only runs the migrations for the core. Added a task that runs migrations for all plugins too.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No
| BC breaks?    | Yes or No
| Deprecations? | Yes or No
| Fixed tickets | N/A or xx

> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md] for details.

[CONTRIBUTING.md]: https://github.com/deployphp/deployer/blob/master/.github/CONTRIBUTING.md#update-the-changelog
