### PR TITLE
Make deploy:check_remote command less vague in its output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Symfony 5 recipe.
 - Command for checking if a deploy is unlocked. [#2150] [#2150]
 
+### Changed
+- Make deploy:check_remote command less vague in its output. [#2160]
+
 ### Fixed
 - Normalize CRLF to LF new line endings. [#2111]
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
@@ -586,6 +589,7 @@
 
 [#2170]: https://github.com/deployphp/deployer/issues/2170
 [#2165]: https://github.com/deployphp/deployer/issues/2165
+[#2160]: https://github.com/deployphp/deployer/issues/2160
 [#2150]: https://github.com/deployphp/deployer/issues/2150
 [#2111]: https://github.com/deployphp/deployer/pull/2111
 [#2052]: https://github.com/deployphp/deployer/issues/2052

--- a/recipe/deploy/check_remote.php
+++ b/recipe/deploy/check_remote.php
@@ -3,6 +3,7 @@ namespace Deployer;
 
 use Deployer\Exception\Exception;
 use Deployer\Exception\GracefulShutdownException;
+use Deployer\Task\Context;
 
 // Cancel deployment if there would be no change to the codebase.
 // This avoids unnecessary releases if the latest commit has already been deployed.
@@ -53,6 +54,11 @@ task('deploy:check_remote', function () {
     $targetRevision = trim($targetRevision);
     $lastDeployedRevision = trim(run(sprintf('cd {{deploy_path}}/current && %s rev-parse HEAD', get('bin/git'))));
     if ($targetRevision && strpos($lastDeployedRevision, $targetRevision) === 0) {
-        throw new GracefulShutdownException("Already up-to-date.");
+        $targetHost = Context::get()->getHost();
+
+        $hostname = $targetHost->getHostname();
+        $realHostname = $targetHost->getRealHostname();
+
+        throw new GracefulShutdownException("$hostname ($realHostname) is already up-to-date.");
     }
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2160 

The `deploy:check_remote` command would return very vague information about the target machine being up-to-date:

```
➤ Executing task deploy:check_remote

In check_remote.php line 57:

  Already up-to-date.
```

When deploying to multiple hosts in a single stage, this message can be too vague, because it doesn't specify which host is preventing the deploy.

This commit changes that behavior, to pull the host from the Context and present that information in the message:

```
➤ Executing task deploy:check_remote

In deploy_steps.php line 63:

  HOSTNAME (real.hostname.domain) is already up-to-date.
```

Fixes #2160 