### PR TITLE
Fix: merge $options env to context env config, with overwriting (#2165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Recipe for Magento now supports locale configuration for `setup:static-content:deploy`. [#2040]
 - When symfony_env is set to dev, require-dev are not installed. [#2035]
 - Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
+- When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
 
 
 ## v6.8.0
@@ -582,6 +583,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2165]: https://github.com/deployphp/deployer/issues/2165
 [#2150]: https://github.com/deployphp/deployer/issues/2150
 [#2111]: https://github.com/deployphp/deployer/pull/2111
 [#2052]: https://github.com/deployphp/deployer/issues/2052

--- a/src/functions.php
+++ b/src/functions.php
@@ -26,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use function Deployer\Support\array_merge_alternate;
 use function Deployer\Support\array_to_string;
 use function Deployer\Support\str_contains;
 
@@ -297,7 +298,7 @@ function run($command, $options = [])
             $command = "cd $workingPath && ($command)";
         }
 
-        $env = get('env', []) + ($options['env'] ?? []);
+        $env = array_merge_alternate(get('env', []), $options['env'] ?? []);
         if (!empty($env)) {
             $env = array_to_string($env);
             $command = "export $env; $command";
@@ -347,7 +348,7 @@ function runLocally($command, $options = [])
     $process = Deployer::get()->processRunner;
     $command = parse($command);
 
-    $env = get('env', []) + ($options['env'] ?? []);
+    $env = array_merge_alternate(get('env', []), $options['env'] ?? []);
     if (!empty($env)) {
         $env = array_to_string($env);
         $command = "export $env; $command";

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -120,6 +120,21 @@ class FunctionsTest extends TestCase
         self::assertEquals('hello', $output);
     }
 
+    public function testRunLocallyWithOptions()
+    {
+        Context::get()->getConfig()->set('env', ['DEPLOYER_ENV' => 'default', 'DEPLOYER_ENV_TMP' => 'default']);
+
+        $output = runLocally('echo $DEPLOYER_ENV');
+        self::assertEquals('default', $output);
+        $output = runLocally('echo $DEPLOYER_ENV_TMP');
+        self::assertEquals('default', $output);
+
+        $output = runLocally('echo $DEPLOYER_ENV', ['env' => ['DEPLOYER_ENV_TMP' => 'overwritten']]);
+        self::assertEquals('default', $output);
+        $output = runLocally('echo $DEPLOYER_ENV_TMP', ['env' => ['DEPLOYER_ENV_TMP' => 'overwritten']]);
+        self::assertEquals('overwritten', $output);
+    }
+
     private function taskToNames($tasks)
     {
         return array_map(function (Task $task) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2165 

Fixed: when the second parameter `$options` passed to `run()` and `runLocally()`, use it to overwrite default env config.