### PR TITLE
Laravel Task artisan:migrate should only run once

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -88,7 +88,7 @@ desc('Enable maintenance mode');
 task('artisan:down', artisan('down', ['runInCurrent', 'showOutput']));
 
 desc('Execute artisan migrate');
-task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']));
+task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']))->once();
 
 desc('Execute artisan migrate:fresh');
 task('artisan:migrate:fresh', artisan('migrate:fresh --force'));


### PR DESCRIPTION
Add once() again command from c1309f255fc6756c70c42465f76e3d08cbeebc7a that got dropped from the v7 updated commit.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to CHANGELOG.md. A command line tool has been included to make this easy, see [CONTRIBUTING.md] for details.

[CONTRIBUTING.md]: https://github.com/deployphp/deployer/blob/master/.github/CONTRIBUTING.md#update-the-changelog
