### PR TITLE
[issue-2170] Modified runLocally function to accept closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - ISPManager recipe and docs.
 - Symfony 5 recipe.
 - Command for checking if a deploy is unlocked. [#2150] [#2150]
+- `runLocally` function now accepts string or a Closure as first parameter. [#2170]
 
 ### Fixed
 - Normalize CRLF to LF new line endings. [#2111]
@@ -17,6 +18,7 @@
 - When symfony_env is set to dev, require-dev are not installed. [#2035]
 - Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
 - When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
+- Fixed `recipe/check_remote.php` calling `get('bin/php)` in remote host context twice. [#2170]
 
 
 ## v6.8.0
@@ -583,6 +585,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2170]: https://github.com/deployphp/deployer/issues/2170
 [#2165]: https://github.com/deployphp/deployer/issues/2165
 [#2150]: https://github.com/deployphp/deployer/issues/2150
 [#2111]: https://github.com/deployphp/deployer/pull/2111

--- a/recipe/deploy/check_remote.php
+++ b/recipe/deploy/check_remote.php
@@ -39,7 +39,10 @@ task('deploy:check_remote', function () {
             $opt = '--heads';
         }
 
-        $remoteLs = runLocally(sprintf("%s ls-remote $opt $repository $ref", get('bin/git')));
+        $remoteLs = runLocally(function () use ($opt, $repository, $ref) {
+            $cmd = sprintf("%s ls-remote $opt $repository $ref", get('bin/git'));
+            return run($cmd);
+        });
         if (strstr($remoteLs, "\n")) {
             throw new Exception("Could not determine target revision. '$ref' matched multiple commits.");
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes
| BC breaks?    |  No
| Deprecations? |  No
| Fixed tickets | #2170 

As noted in the issue #2170, the logic in the `recipe/check_remote.php` would try to get the binary path of local and remote git executable.

However, due to specific implementation, the `get('bin/git')` would have been called twice in the context of remote host, instead of invoking it once on remote and once on local machine.

The `runLocally` function has thus been reworked, to accept Closure, which will be invoked in the context of the localhost machine.
Once a Closure has been passed, the function will push the Localhost to the Context, invoke the closure, store the stdout (if available), pop the Localhost from the Context and finally return the stdout.

For compatibility reasons, the function also accepts the string argument, however it is wrapped in a closure and once again passed to the `runLocally` function.

The `recipe/check_remote.php` file has been reworked, to utilize the Closure, to make sure that the `get('bin/git')` is being called in the Localhost context.

