### PR TITLE
[issue-2170] Use on(localhost(), ...) instead of runLocally in check_remote.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - When symfony_env is set to dev, require-dev are not installed. [#2035]
 - Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
 - When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
+- Replaced `runLocally` with `on(localhost(), ...)` in `deploy:check_remote` to make sure all code is ran on localhost. [#2170]
 
 
 ## v6.8.0
@@ -583,6 +584,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2170]: https://github.com/deployphp/deployer/issues/2170
 [#2165]: https://github.com/deployphp/deployer/issues/2165
 [#2150]: https://github.com/deployphp/deployer/issues/2150
 [#2111]: https://github.com/deployphp/deployer/pull/2111

--- a/recipe/deploy/check_remote.php
+++ b/recipe/deploy/check_remote.php
@@ -39,7 +39,12 @@ task('deploy:check_remote', function () {
             $opt = '--heads';
         }
 
-        $remoteLs = runLocally(sprintf("%s ls-remote $opt $repository $ref", get('bin/git')));
+        $remoteLs = null;
+        on(localhost(), function () use (& $remoteLs, $opt, $repository, $ref) {
+            $getRemoteRevisionCmd = sprintf("%s ls-remote $opt $repository $ref", get('bin/git'));
+            $remoteLs = run($getRemoteRevisionCmd);
+        });
+
         if (strstr($remoteLs, "\n")) {
             throw new Exception("Could not determine target revision. '$ref' matched multiple commits.");
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | #2170 


Reworked the `deploy:check_remote` step, to use the `on(localhost(), ...)`, instead of relying on `runLocally`.

This has been changed, to make sure that the all functions that are being executed and are related to "local" part of the logic, are ran on the local host.

Previously in `runLocally(sprintf("%s ls-remote $opt $repository $ref", get('bin/git')));` the `get('bin/git')` would've been executed on the remote host, which could have resulted in an unexpected behaviour.

By closing all of the instructions, in the closure that is executed by the `on()` function, we are sure that the context is set to the right host.

