### PR TITLE
[issue-2176] Added `escape`/`unescape` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - ISPManager recipe and docs.
 - Symfony 5 recipe.
 - Command for checking if a deploy is unlocked. [#2150] [#2150]
+- Added `escape` and `unescape` method to ignore certain values from being parsing. [#2176]
 
 ### Changed
 - `within` passess through `$callback` return value. [#2178]
@@ -590,6 +591,7 @@
 
 [#2181]: https://github.com/deployphp/deployer/issues/2181
 [#2178]: https://github.com/deployphp/deployer/issues/2178
+[#2176]: https://github.com/deployphp/deployer/issues/2176
 [#2170]: https://github.com/deployphp/deployer/issues/2170
 [#2165]: https://github.com/deployphp/deployer/issues/2165
 [#2150]: https://github.com/deployphp/deployer/issues/2150

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -13,6 +13,7 @@ use function Deployer\get;
 use function Deployer\Support\array_merge_alternate;
 use function Deployer\Support\is_closure;
 use function Deployer\Support\normalize_line_endings;
+use function Deployer\unescape;
 
 class Configuration implements \ArrayAccess
 {
@@ -107,7 +108,8 @@ class Configuration implements \ArrayAccess
     {
         if (is_string($value)) {
             $normalizedValue = normalize_line_endings($value);
-            return preg_replace_callback('/\{\{\s*([\w\.\/-]+)\s*\}\}/', [$this, 'parseCallback'], $normalizedValue);
+            $parsed = preg_replace_callback('/\{\{\s*([\w\.\/-]+)\s*\}\}/', [$this, 'parseCallback'], $normalizedValue);
+            return unescape($parsed);
         }
 
         return $value;

--- a/src/functions.php
+++ b/src/functions.php
@@ -551,6 +551,30 @@ function parse($value)
 }
 
 /**
+ * Escapes value so it won't be parsed by @see parse()
+ *
+ * @param string $value value to be escaped
+ * @return string escaped value
+ */
+function escape($value)
+{
+    $output = str_replace(['{{', '}}'], ['\\{\\{', '\\}\\}'], $value);
+    return $output;
+}
+
+/**
+ * Removes escape characters from the string that was processed with @see escape()
+ *
+ * @param string $value that has been previous escaped
+ * @return string value with escape characters removed
+ */
+function unescape($value)
+{
+    $output = str_replace(['\\{\\{', '\\}\\}'], ['{{', '}}'], $value);
+    return $output;
+}
+
+/**
  * Setup configuration option.
  *
  * @param string $name

--- a/test/src/Configuration/ConfigurationTest.php
+++ b/test/src/Configuration/ConfigurationTest.php
@@ -16,6 +16,32 @@ class ConfigurationTest extends TestCase
         self::assertEquals('a b', $config->parse('{{foo}} {{bar}}'));
     }
 
+    public function parseWithRawDataProvider()
+    {
+        return [
+            'string with only raw value' => [ '\\{\\{foo\\}\\}', '{{foo}}', [] ],
+            'string with raw and parsed value' => ['\\{\\{foo\\}\\} {{foo}}', '{{foo}} bar', [ 'foo' => 'bar' ] ],
+            'string with multiple raw values' => ['\\{\\{foo\\}\\} {{foo}} \\{\\{baz\\}\\}', '{{foo}} bar {{baz}}', [ 'foo' => 'bar' ] ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseWithRawDataProvider
+     * @param string $input
+     * @param string $expected
+     * @param array $configValues
+     */
+    public function testParseWithRaw($input, $expected, $configValues)
+    {
+        $config = new Configuration();
+        foreach ($configValues as $key => $value) {
+            $config->set($key, $value);
+        }
+
+        $output = $config->parse($input);
+        self::assertEquals($expected, $output);
+    }
+
     public function testUnset()
     {
         $config = new Configuration();

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -182,6 +182,50 @@ class FunctionsTest extends TestCase
         self::assertNull($output);
     }
 
+    public function escapeValueDataProvider()
+    {
+        return [
+            'escape whole string' => [ '{{foo}}', '\\{\\{foo\\}\\}' ],
+            'escape part of string' => [ 'foo {{bar}}', 'foo \\{\\{bar\\}\\}' ],
+            'escape multiple times' => [ '{{foo}} {{bar}}', '\\{\\{foo\\}\\} \\{\\{bar\\}\\}' ],
+            'do nothing' => [ 'foo', 'foo' ],
+        ];
+    }
+
+    public function unescapeValueDataProvider()
+    {
+        return [
+            'unescape whole string' => [ '\\{\\{foo\\}\\}', '{{foo}}' ],
+            'unescape part of string' => [ 'foo \\{\\{bar\\}\\}', 'foo {{bar}}' ],
+            'unescape multiple times' => [ '\\{\\{foo\\}\\} \\{\\{bar\\}\\}', '{{foo}} {{bar}}' ],
+            'do nothing' => [ 'foo', 'foo' ],
+        ];
+    }
+
+    /**
+     * @dataProvider escapeValueDataProvider
+     *
+     * @param string $input
+     * @param string $expected
+     */
+    public function testEscapeValue($input, $expected)
+    {
+        $output = escape($input);
+        self::assertEquals($expected, $output);
+    }
+
+    /**
+     * @dataProvider unescapeValueDataProvider
+     *
+     * @param string $input
+     * @param string $expected
+     */
+    public function testUnescapeValue($input, $expected)
+    {
+        $output = unescape($input);
+        self::assertEquals($expected, $output);
+    }
+
     private function taskToNames($tasks)
     {
         return array_map(function (Task $task) {


### PR DESCRIPTION
- [x] New feature: functions for escaping/unescaping values wrapped in `{{}}`
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests added
- [x] Changelog updated


This commit adds two new functions:
* `escape(string): string`
* `unescape(string): string`

Once the value has been processed by the `escape` function, then the values wrapped in `{{}}` like `{{foo}}` will not be parsed by the `parse` function.

The `escape` function works by replacing the `{{` with `\\{\\{` and `}}` with `\\}\\}`.
The `unescape` function reverses the process.

The `parse` function has been updated to run the `unescape` afterparsing has been completed, to ensure that the commands are being executed normally.

Fixes #2176 