### PR TITLE
[issue-2181] Fix unit tests on non-master branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed exit status of rollback command when there are no releases to rollback to. [#2052]
 - When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
 - Replaced `runLocally` with `on(localhost(), ...)` in `deploy:check_remote` to make sure all code is ran on localhost. [#2170]
+- Fixed unit tests on non-master branches. [#2181]
 
 
 ## v6.8.0
@@ -584,6 +585,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2181]: https://github.com/deployphp/deployer/issues/2181
 [#2170]: https://github.com/deployphp/deployer/issues/2170
 [#2165]: https://github.com/deployphp/deployer/issues/2165
 [#2150]: https://github.com/deployphp/deployer/issues/2150

--- a/test/recipe/AbstractTest.php
+++ b/test/recipe/AbstractTest.php
@@ -29,6 +29,11 @@ abstract class AbstractTest extends TestCase
         $repository = __DIR__ . '/repository';
 
         exec("cd $repository && git init");
+
+        // Switch the mock repo to Deployer's current branch
+        $currentRepoBranch = trim(shell_exec('git rev-parse --abbrev-ref HEAD'));
+        exec("cd $repository && git checkout -B $currentRepoBranch 2>&1");
+
         exec("cd $repository && git add .");
         exec("cd $repository && git config user.name 'Anton Medvedev'");
         exec("cd $repository && git config user.email 'anton.medv@example.com'");


### PR DESCRIPTION
- [x] Bug fix #2181 
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [ ] Tests added
- [x] Changelog updated

The unit tests would fail, when started on a non-master branch.
This was happening because the test repository has been initialized
with git default branch, whereas deploy configuration expects to
work with current git branch.

This has been fixed by adding `git checkout -B BRANCH_NAME`, right after
test repo initialization to the DeployTest setup procedure, to make sure
that the test repositoryis always in sync repo-wise with the Deployer
repository.

Fixes #2181