### PR TITLE
[issue-2178] within() passes through $callback return value

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -262,13 +262,14 @@ function cd($path)
  *
  * @param string $path
  * @param callable $callback
+ * @return mixed|void Return value of the $callback function or void if callback doesn't return anything
  */
 function within($path, $callback)
 {
     $lastWorkingPath = get('working_path', '');
     try {
         set('working_path', parse($path));
-        $callback();
+        return $callback();
     } finally {
         set('working_path', $lastWorkingPath);
     }

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -135,6 +135,53 @@ class FunctionsTest extends TestCase
         self::assertEquals('overwritten', $output);
     }
 
+    public function testWithinSetsWorkingPaths()
+    {
+        Context::get()->getConfig()->set('working_path', '/foo');
+
+        within('/bar', function () {
+            $withinWorkingPath = Context::get()->getConfig()->get('working_path');
+            self::assertEquals('/bar', $withinWorkingPath);
+        });
+
+        $originalWorkingPath = Context::get()->getConfig()->get('working_path');
+        self::assertEquals('/foo', $originalWorkingPath);
+    }
+
+    public function testWithinRestoresWorkingPathInCaseOfException()
+    {
+        Context::get()->getConfig()->set('working_path', '/foo');
+
+        try {
+            within('/bar', function () {
+                throw new \Exception('Dummy exception');
+            });
+        } catch (\Exception $exception) {
+            // noop
+        }
+
+        $originalWorkingPath = Context::get()->getConfig()->get('working_path');
+        self::assertEquals('/foo', $originalWorkingPath);
+    }
+
+    public function testWithinReturningValue()
+    {
+        $output = within('/foo', function () {
+           return 'bar';
+        });
+
+        self::assertEquals('bar', $output);
+    }
+
+    public function testWithinWithVoidFunction()
+    {
+        $output = within('/foo', function () {
+            // noop
+        });
+
+        self::assertNull($output);
+    }
+
     private function taskToNames($tasks)
     {
         return array_map(function (Task $task) {


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature #2178 
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests added
- [x] Changelog updated

The `within()` function has been modified to pass-through the return value of the `$callback` function.

It is now possible to write code like:

```php
$out = within('/foo', function () {
  return 'bar';
});
```

The `$out` variable will now contain the value `'bar'`.

If the callback function returns nothing, then the return of `within()` call will be `null`.

Fixes #2178