### PR TITLE
[#2192] Support for placeholders in run and runLocally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added ability to customize rsync flags.
 - Symfony 5 recipe.
 - Command for checking if a deploy is unlocked. [#2150] [#2150]
+- Added support for placeholders in run and runLocally methods. [#2192]
 
 ### Changed
 - `within` passess through `$callback` return value. [#2178]
@@ -592,6 +593,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2192]: https://github.com/deployphp/deployer/issues/2192
 [#2187]: https://github.com/deployphp/deployer/issues/2187
 [#2181]: https://github.com/deployphp/deployer/issues/2181
 [#2178]: https://github.com/deployphp/deployer/issues/2178

--- a/src/Component/ProcessRunner/ProcessRunner.php
+++ b/src/Component/ProcessRunner/ProcessRunner.php
@@ -43,6 +43,7 @@ class ProcessRunner
             'idle_timeout' => null,
             'cwd' => defined('DEPLOYER_ROOT') ? DEPLOYER_ROOT : null,
             'tty' => false,
+            'vars' => [],
         ];
         $config = array_merge($defaults, $config);
 
@@ -53,6 +54,8 @@ class ProcessRunner
             $this->logger->printBuffer($host, $type, $buffer);
             $terminalOutput($type, $buffer);
         };
+
+        $command = $this->replacePlaceholders($command, $config['vars']);
 
         $command = str_replace('%secret%', $config['secret'] ?? '', $command);
         $command = str_replace('%sudo_pass%', $config['sudo_pass'] ?? '', $command);
@@ -78,5 +81,14 @@ class ProcessRunner
                 $process->getErrorOutput()
             );
         }
+    }
+
+    private function replacePlaceholders(string $command, array $variables): string
+    {
+        foreach ($variables as $placeholder => $replacement) {
+            $command = str_replace("%$placeholder%", $replacement, $command);
+        }
+
+        return $command;
     }
 }

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -35,6 +35,7 @@ class Client
         $defaults = [
             'timeout' => $host->get('default_timeout', 300),
             'idle_timeout' => null,
+            'vars' => [],
         ];
 
         $config = array_merge($defaults, $config);
@@ -69,6 +70,8 @@ class Client
             $this->logger->printBuffer($host, $type, $buffer);
             $terminalOutput($type, $buffer);
         };
+
+        $command = $this->replacePlaceholders($command, $config['vars']);
 
         $command = str_replace('%secret%', $config['secret'] ?? '', $command);
         $command = str_replace('%sudo_pass%', $config['sudo_pass'] ?? '', $command);
@@ -167,5 +170,14 @@ class Client
             $this->pop->printBuffer(Process::OUT, $host, $output);
         }
         return (bool)preg_match('/Master running/', $output);
+    }
+
+    private function replacePlaceholders(string $command, array $variables): string
+    {
+        foreach ($variables as $placeholder => $replacement) {
+            $command = str_replace("%$placeholder%", $replacement, $command);
+        }
+
+        return $command;
     }
 }

--- a/test/src/FunctionsTest.php
+++ b/test/src/FunctionsTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
+use function Deployer\localhost;
 
 class FunctionsTest extends TestCase
 {
@@ -133,6 +134,25 @@ class FunctionsTest extends TestCase
         self::assertEquals('default', $output);
         $output = runLocally('echo $DEPLOYER_ENV_TMP', ['env' => ['DEPLOYER_ENV_TMP' => 'overwritten']]);
         self::assertEquals('overwritten', $output);
+    }
+
+    public function testRunLocallyWithTwoPlaceholders(): void
+    {
+        $cmd = "echo 'placeholder %foo% %baz%'";
+        $vars = [ 'foo' => '{{bar}}', 'baz' => 'xyz%' ];
+
+        $output = runLocally($cmd, [ 'vars' => $vars ]);
+        self::assertEquals('placeholder {{bar}} xyz%', $output);
+    }
+
+    public function testRunLocallyWithPlaceholdersAndParsedValues(): void
+    {
+        $cmd = "echo 'placeholder %foo%; parsed {{baz}}'";
+        $vars = [ 'foo' => '{{bar}}' ];
+        Context::get()->getConfig()->set('baz', 'xyz');
+
+        $output = runLocally($cmd, [ 'vars' => $vars ]);
+        self::assertEquals("placeholder {{bar}}; parsed xyz", $output);
     }
 
     public function testWithinSetsWorkingPaths()


### PR DESCRIPTION
- [x] New feature?
- [ ] BC breaks
- [ ] Deprecations
- [x] Tests added
- [x] Changelog updated

Added support for placeholder in the `run` and `runLocally` functions.
By passing the `vars` key with an associative array to the second
argument of `run` and `runLocally`, it is possible to use placeholders
in the command, that will be used directly in the executed command.

The placeholders should be wrapped in the command with `%NAME%`, for
instance `%foo%`. The `vars` array could be `[ 'foo' => '{{bar}}']`.

Sample:

```php
runLocally("echo '%foo%'", ['vars' => ['foo' => '{{bar}}']]);
```

will output:

```plain
{{bar}}
```

Fixes #2192 