### PR TITLE
[#2207] Symfony change dir to execute DoctrineMigrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - When the second parameter $options passed to run() and runLocally(), use it to overwrite default env config. [#2165]
 - Replaced `runLocally` with `on(localhost(), ...)` in `deploy:check_remote` to make sure all code is ran on localhost. [#2170]
 - Fixed unit tests on non-master branches. [#2181]
+- Fixes Symfony / DoctrineMigrations >= 3.0 relative paths. [#2207]
 
 
 ## v6.8.0
@@ -596,6 +597,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2207]: https://github.com/deployphp/deployer/issues/2207
 [#2192]: https://github.com/deployphp/deployer/issues/2192
 [#2187]: https://github.com/deployphp/deployer/issues/2187
 [#2181]: https://github.com/deployphp/deployer/issues/2181

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -23,7 +23,7 @@ task('database:migrate', function () {
         $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
     }
 
-    run(sprintf('{{bin/php}} {{bin/console}} doctrine:migrations:migrate %s {{console_options}}', $options));
+    run(sprintf('cd {{release_path}} && {{bin/php}} {{bin/console}} doctrine:migrations:migrate %s {{console_options}}', $options));
 });
 
 desc('Clear cache');

--- a/recipe/symfony5.php
+++ b/recipe/symfony5.php
@@ -23,7 +23,7 @@ task('database:migrate', function () {
         $options = sprintf('%s --configuration={{release_path}}/{{migrations_config}}', $options);
     }
 
-    run(sprintf('{{bin/php}} {{bin/console}} doctrine:migrations:migrate %s {{console_options}}', $options));
+    run(sprintf('cd {{release_path}} && {{bin/php}} {{bin/console}} doctrine:migrations:migrate %s {{console_options}}', $options));
 });
 
 desc('Clear cache');


### PR DESCRIPTION
- [X] Bug fix #2207
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?

Just needed to change dir before executing the command.