### PR TITLE
fixed issue #2209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Lots, and lots of long-standing bugs.
+- Copy shared files and folder should be verbose only when deployer is run with Very verbose output. [#2209]
 
 
 ## v6.8.0
@@ -597,6 +598,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2209]: https://github.com/deployphp/deployer/issues/2209
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -30,7 +30,7 @@ task('deploy:shared', function () {
                 run(
                     sprintf(
                         'cp -r%s {{release_path}}/%s %s/%s',
-                        output()->getVerbosity() === OutputInterface::VERBOSITY_VERY_VERBOSE ? 'v' : '',
+                        output()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG ? 'v' : '',
                         $dir,
                         $sharedPath,
                         dirname(parse($dir))
@@ -65,7 +65,7 @@ task('deploy:shared', function () {
             run(
                 sprintf(
                     'cp -r%s {{release_path}}/%s %s/%s',
-                    output()->getVerbosity() === OutputInterface::VERBOSITY_VERY_VERBOSE ? 'v' : '',
+                    output()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG ? 'v' : '',
                     $file,
                     $sharedPath,
                     $file

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -2,6 +2,7 @@
 namespace Deployer;
 
 use Deployer\Exception\Exception;
+use Symfony\Component\Console\Output\OutputInterface;
 
 desc('Creating symlinks for shared files and dirs');
 task('deploy:shared', function () {
@@ -26,7 +27,15 @@ task('deploy:shared', function () {
             run("mkdir -p $sharedPath/$dir");
             // If release contains shared dir, copy that dir from release to shared.
             if (test("[ -d $(echo {{release_path}}/$dir) ]")) {
-                run("cp -rv {{release_path}}/$dir $sharedPath/" . dirname(parse($dir)));
+                run(
+                    sprintf(
+                        'cp -r%s {{release_path}}/%s %s/%s',
+                        output()->getVerbosity() === OutputInterface::VERBOSITY_VERY_VERBOSE ? 'v' : '',
+                        $dir,
+                        $sharedPath,
+                        dirname(parse($dir))
+                    )
+                );
             }
         }
 
@@ -53,7 +62,15 @@ task('deploy:shared', function () {
         // and file exist in release
         if (!test("[ -f $sharedPath/$file ]") && test("[ -f {{release_path}}/$file ]")) {
             // Copy file in shared dir if not present
-            run("cp -rv {{release_path}}/$file $sharedPath/$file");
+            run(
+                sprintf(
+                    'cp -r%s {{release_path}}/%s %s/%s',
+                    output()->getVerbosity() === OutputInterface::VERBOSITY_VERY_VERBOSE ? 'v' : '',
+                    $file,
+                    $sharedPath,
+                    $file
+                )
+            );
         }
 
         // Remove from source.

--- a/recipe/deploy/shared.php
+++ b/recipe/deploy/shared.php
@@ -17,6 +17,8 @@ task('deploy:shared', function () {
         }
     }
 
+    $copyVerbosity = output()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG ? 'v' : '';
+
     foreach (get('shared_dirs') as $dir) {
         // Make sure all path without tailing slash.
         $dir = trim($dir, '/');
@@ -27,15 +29,7 @@ task('deploy:shared', function () {
             run("mkdir -p $sharedPath/$dir");
             // If release contains shared dir, copy that dir from release to shared.
             if (test("[ -d $(echo {{release_path}}/$dir) ]")) {
-                run(
-                    sprintf(
-                        'cp -r%s {{release_path}}/%s %s/%s',
-                        output()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG ? 'v' : '',
-                        $dir,
-                        $sharedPath,
-                        dirname(parse($dir))
-                    )
-                );
+                run("cp -r{$copyVerbosity} {{release_path}}/{$dir} {$sharedPath}/" . dirname(parse($dir)));
             }
         }
 
@@ -63,13 +57,7 @@ task('deploy:shared', function () {
         if (!test("[ -f $sharedPath/$file ]") && test("[ -f {{release_path}}/$file ]")) {
             // Copy file in shared dir if not present
             run(
-                sprintf(
-                    'cp -r%s {{release_path}}/%s %s/%s',
-                    output()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG ? 'v' : '',
-                    $file,
-                    $sharedPath,
-                    $file
-                )
+                "cp -r{$copyVerbosity} {{release_path}}/{$file} {$sharedPath}/{$file}"
             );
         }
 


### PR DESCRIPTION
Copy shared files and folder should be verbose only when deployer is run with Very verbose output `-vvv`

- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?
