### PR TITLE
[composer 3] [6.x] Removed deprecated option "--no-suggest"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.4.5...master](https://github.com/deployphp/deployer/compare/v6.4.5...master)
+
+### Changed
+- [composer 3] Removed deprecated option "--no-suggest"
+
+
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)
 

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -87,7 +87,7 @@ set('use_atomic_symlink', function () {
 });
 
 set('composer_action', 'install');
-set('composer_options', '{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader --no-suggest');
+set('composer_options', '{{composer_action}} --verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
 
 set('env', []); // Run command environment (for example, SYMFONY_ENV=prod)
 


### PR DESCRIPTION
- [x] Deprecations?
- [x] Changelog updated?

> You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.

![image](https://user-images.githubusercontent.com/10347617/96557800-72dde700-12c3-11eb-9dfc-5361967e3d8a.png)
