### PR TITLE
added phpdocs Task->addBefore() and Task->addAfter()

### DIFF
--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -124,12 +124,18 @@ class Task
         return $this->hidden;
     }
 
+    /**
+     * Make $task being run before this task
+     */
     public function addBefore(string $task)
     {
         array_unshift($this->before, $task);
         return $this;
     }
 
+    /**
+     * Make $task being run after this task
+     */
     public function addAfter(string $task)
     {
         array_push($this->after, $task);


### PR DESCRIPTION
this PR adds phpdoc to Task->addBefore()/addAfter(). The docs are added because I think its not obvious what the methods are doing.

e.g. a line like `task(...)->addAfter("deploy:unlock");` reads like `task` is added after `deploy:unlock` - but in fact its the opposite. `deploy:unlock` will be added after `task`.

(same argumentation for `addBefore`)

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

>      Please, update CHANGELOG.md by running next command:
>      $ php bin/changelog

not sure whether doc only changes should be noted in the CHANGELOG?
