### PR TITLE
Add composer_version to choose which composer version to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added docker-based E2E testing environment. [#2197]
 - Typehinting for functions.php. [#2187]
 - Phpstan static analysis via GitHub Actions.
+- Added `composer_version` to choose composer version to install.
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -6,6 +6,15 @@ set('composer_action', 'install');
 
 set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
 
+/**
+ * Can be used to choose what composer version to install.
+ * Valid values are any that are listed here: https://getcomposer.org/download/
+ *
+ * For example:
+ * set('composer_version', '10.10.15')
+ */
+set('composer_version', null);
+
 set('bin/composer', function () {
     if (commandExist('composer')) {
         return '{{bin/php}} ' . locateBinaryPath('composer');
@@ -15,7 +24,14 @@ set('bin/composer', function () {
         return '{{bin/php}} {{deploy_path}}/.dep/composer.phar';
     }
 
-    run("cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}");
+    $composerVersionToInstall = get('composer_version', null);
+    $installCommand = "cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}";
+
+    if ($composerVersionToInstall) {
+        $installCommand .= " -- --version=" . $composerVersionToInstall;
+    }
+
+    run($installCommand);
     run('mv {{release_path}}/composer.phar {{deploy_path}}/.dep/composer.phar');
     return '{{bin/php}} {{deploy_path}}/.dep/composer.phar';
 });


### PR DESCRIPTION
This solves https://github.com/deployphp/deployer/issues/2012 & https://github.com/deployphp/deployer/discussions/2220

- [ ] Bug fix #…?
- [X] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [X] Changelog updated?

I wasn't sure how to add tests for this, I could do that though.