### PR TITLE
Implemented E2E tests for provision recipe

### DIFF
--- a/docs/recipe/provision.md
+++ b/docs/recipe/provision.md
@@ -27,19 +27,19 @@
 
 ## Config
 ### php_version
-[Source](/recipe/provision.php#L10)
+[Source](/recipe/provision.php#L11)
 
 
 
 ### sudo_password
-[Source](/recipe/provision.php#L11)
+[Source](/recipe/provision.php#L12)
 
 
 
 
 ## Tasks
 ### provision
-[Source](/recipe/provision.php#L16)
+[Source](/recipe/provision.php#L17)
 
 
 
@@ -56,57 +56,57 @@ This task is group task which contains next tasks:
 
 
 ### provision:check
-[Source](/recipe/provision.php#L35)
+[Source](/recipe/provision.php#L36)
 
 
 
 ### provision:upgrade
-[Source](/recipe/provision.php#L56)
+[Source](/recipe/provision.php#L57)
 
 
 
 ### provision:install
-[Source](/recipe/provision.php#L62)
+[Source](/recipe/provision.php#L63)
 
 
 
 ### provision:ssh
-[Source](/recipe/provision.php#L85)
+[Source](/recipe/provision.php#L86)
 
 
 
 ### provision:user:deployer
-[Source](/recipe/provision.php#L99)
+[Source](/recipe/provision.php#L100)
 
 
 
 ### provision:firewall
-[Source](/recipe/provision.php#L134)
+[Source](/recipe/provision.php#L135)
 
 
 
 ### provision:install:php
-[Source](/recipe/provision.php#L142)
+[Source](/recipe/provision.php#L151)
 
 
 
 ### provision:install:composer
-[Source](/recipe/provision.php#L167)
+[Source](/recipe/provision.php#L176)
 
 
 
 ### provision:config:php:sessions
-[Source](/recipe/provision.php#L200)
+[Source](/recipe/provision.php#L209)
 
 
 
 ### provision:nginx:dhparam
-[Source](/recipe/provision.php#L206)
+[Source](/recipe/provision.php#L215)
 
 
 
 ### provision:nginx
-[Source](/recipe/provision.php#L217)
+[Source](/recipe/provision.php#L226)
 
 
 

--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -3,6 +3,7 @@
 namespace Deployer;
 
 use Deployer\Exception\GracefulShutdownException;
+use Symfony\Component\Console\Input\InputOption;
 use function Deployer\Support\starts_with;
 
 add('recipes', ['provision']);
@@ -132,10 +133,18 @@ task('provision:user:deployer', function () {
 
 desc('Setup firewall');
 task('provision:firewall', function () {
-    run('ufw allow 22');
-    run('ufw allow 80');
-    run('ufw allow 443');
-    run('ufw --force enable');
+    $firewallEnabled = get('firewall', true);
+
+    if ($firewallEnabled) {
+        run('ufw allow 22');
+        run('ufw allow 80');
+        run('ufw allow 443');
+        run('ufw --force enable');
+    } else {
+        if (output()->isDebug()) {
+            writeln("Skipping firewall setup");
+        }
+    }
 });
 
 desc('Install PHP packages');

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -96,3 +96,31 @@ RUN chmod a+x /usr/local/bin/start-servers \
 
 EXPOSE 22 80 81
 CMD [ "start-servers" ]
+
+
+
+
+
+FROM ubuntu:20.04 AS provisioned
+RUN apt-get update && apt-get install -y \
+            openssh-server \
+            sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN mkdir /run/sshd \
+    && sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
+
+COPY --from=deployer /root/.ssh/id_rsa.pub /tmp/root_rsa.pub
+
+RUN mkdir ~root/.ssh \
+    && cat /tmp/root_rsa.pub >> ~root/.ssh/authorized_keys \
+    && chmod 700 ~root/.ssh \
+    && chmod 600 ~root/.ssh \
+    && rm -rf /tmp/root_rsa.pub
+
+COPY scripts/provisioned-start.sh /usr/local/bin/provisioned-start
+RUN chmod a+x /usr/local/bin/provisioned-start
+
+EXPOSE 22 80 443
+CMD [ "provisioned-start" ]

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     depends_on:
       server:
         condition: service_healthy
+      provisioned:
+        condition: service_started
     volumes:
       - ./../../:/project
     command: "php vendor/bin/pest --config test/e2e/phpunit-e2e.xml"
@@ -41,6 +43,15 @@ services:
       e2e:
         aliases:
           - server.test
+
+  provisioned:
+    build:
+      context: ""
+      target: provisioned
+    networks:
+      e2e:
+        aliases:
+          - provisioned.test
 
 networks:
   e2e:

--- a/test/docker/scripts/provisioned-start.sh
+++ b/test/docker/scripts/provisioned-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Starting provisioned environment..."
+service ssh start
+
+while :
+do
+	echo "Provisioned environment is running"
+	sleep 10
+done

--- a/test/e2e/ProvisionE2ETest.php
+++ b/test/e2e/ProvisionE2ETest.php
@@ -1,0 +1,29 @@
+<?php
+namespace e2e;
+
+use Deployer\Exception\Exception;
+
+class ProvisionE2ETest extends AbstractE2ETest
+{
+    private const RECIPE = __DIR__ . '/recipe/provision.php';
+
+    /**
+     * @throws Exception
+     */
+    public function testProvisionRecipe(): void
+    {
+        $this->init(self::RECIPE);
+
+        $this->tester->setInputs(['deployer']); // set input for deployer user pass
+
+        $this->tester->run([
+            'provision',
+            '-f' => self::RECIPE,
+            '-o' => [ 'firewall=false' ], // disable firewall provisioning in docker e2e environment
+            'selector' => 'all'
+        ]);
+
+        $display = trim($this->tester->getDisplay());
+        self::assertEquals(0, $this->tester->getStatusCode(), $display);
+    }
+}

--- a/test/e2e/recipe/provision.php
+++ b/test/e2e/recipe/provision.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace Deployer;
+
+require_once __DIR__ . '/../../../recipe/provision.php';
+
+host('provisioned.test')
+    ->set('timeout', 300)
+    ->setTag('e2e')
+    ->setRemoteUser('root')
+    ->setSshOptions(
+        [
+            'UserKnownHostsFile' => '/dev/null',
+            'StrictHostKeyChecking' => 'no',
+        ]
+    );


### PR DESCRIPTION
Created new container using Ubuntu 20.04 as a base, for a E2E test
environment for the provision recipe.

Due to container sharing a kernel with host os, the firewall provisioning
had to be turn off during the testing procedure.

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [x] Tests added
- [ ] Changelog updated?
