### PR TITLE
Added nginx/php/php-fpm version checking to provision e2e test

### DIFF
--- a/test/e2e/ProvisionE2ETest.php
+++ b/test/e2e/ProvisionE2ETest.php
@@ -25,5 +25,10 @@ class ProvisionE2ETest extends AbstractE2ETest
 
         $display = trim($this->tester->getDisplay());
         self::assertEquals(0, $this->tester->getStatusCode(), $display);
+
+        self::assertStringContainsString('nginx version:', $display);
+        self::assertStringContainsString('PHP 7', $display);
+        self::assertStringContainsString('(cli)', $display);
+        self::assertStringContainsString('(fpm-fcgi)', $display);
     }
 }

--- a/test/e2e/recipe/provision.php
+++ b/test/e2e/recipe/provision.php
@@ -7,9 +7,30 @@ host('provisioned.test')
     ->set('timeout', 300)
     ->setTag('e2e')
     ->setRemoteUser('root')
-    ->setSshOptions(
-        [
-            'UserKnownHostsFile' => '/dev/null',
-            'StrictHostKeyChecking' => 'no',
-        ]
-    );
+    ->setSshArguments([
+        '-o UserKnownHostsFile=/dev/null',
+        '-o StrictHostKeyChecking=no',
+    ]);
+
+task('version:get', [
+    'version:get:nginx',
+    'version:get:php',
+    'version:get:php-fpm',
+]);
+
+task('version:get:nginx', function () {
+    $versionCmdOutput = run('nginx -v 2>&1'); // nginx prints version info to stderr, so we redirect it to stdout
+    output()->writeln($versionCmdOutput);
+});
+
+task('version:get:php', function () {
+    $versionCmdOutput = run('php -v');
+    output()->writeln($versionCmdOutput);
+});
+
+task('version:get:php-fpm', function () {
+    $versionCmdOutput = run('php-fpm{{php_version}} -v');
+    output()->writeln($versionCmdOutput);
+});
+
+after('provision', 'version:get');


### PR DESCRIPTION
To make sure that provisioning has been properly finished, I've added simple version checks that verify that:
- nginx is present
- php is present
- php-fpm is present