### PR TITLE
contrib: Add default value for missing {{target}} option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Lots, and lots of long-standing bugs.
+- Missing default value for {{target}} option in most of the contrib recipes. [#2238]
 
 
 ## v6.8.0
@@ -597,6 +598,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2238]: https://github.com/deployphp/deployer/issues/2238
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/contrib/discord.php
+++ b/contrib/discord.php
@@ -53,8 +53,9 @@ after('deploy:failed', 'discord:notify:failure');
  */
 namespace Deployer;
 
-use Deployer\Task\Context;
 use Deployer\Utility\Httpie;
+
+set('target', '{{hostname}}');
 
 set('discord_webhook', function () {
     return 'https://discordapp.com/api/webhooks/{{discord_channel}}/{{discord_token}}/slack';

--- a/contrib/hipchat.php
+++ b/contrib/hipchat.php
@@ -30,6 +30,8 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+set('target', '{{hostname}}');
+
 set('hipchat_color', 'green');
 set('hipchat_from', '{{target}}');
 set('hipchat_message', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');

--- a/contrib/mattermost.php
+++ b/contrib/mattermost.php
@@ -83,6 +83,8 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+set('target', '{{hostname}}');
+
 set('mattermost_webhook', null);
 set('mattermost_channel', null);
 set('mattermost_username', 'deployer');

--- a/contrib/ms-teams.php
+++ b/contrib/ms-teams.php
@@ -74,6 +74,9 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+// Target of deployment
+set('target', '{{hostname}}');
+
 // Title of project
 set('teams_title', function () {
     return get('application', 'Project');

--- a/contrib/rocketchat.php
+++ b/contrib/rocketchat.php
@@ -67,6 +67,8 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+set('target', '{{hostname}}');
+
 set('rockchat_title', function() {
     return get('application', 'Project');
 });

--- a/contrib/rollbar.php
+++ b/contrib/rollbar.php
@@ -30,6 +30,8 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+set('target', '{{hostname}}');
+
 set('rollbar_comment', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');
 
 desc('Notifying Rollbar of deployment');

--- a/contrib/slack.php
+++ b/contrib/slack.php
@@ -65,6 +65,9 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+// Target of deployment
+set('target', '{{hostname}}');
+
 // Title of project
 set('slack_title', function () {
     return get('application', 'Project');

--- a/contrib/telegram.php
+++ b/contrib/telegram.php
@@ -63,6 +63,9 @@ after('deploy:failed', 'telegram:notify:failure');
 namespace Deployer;
 use Deployer\Utility\Httpie;
 
+// Target of deployment
+set('target', '{{hostname}}');
+
 // Title of project
 set('telegram_title', function () {
     return get('application', 'Project');

--- a/contrib/workplace.php
+++ b/contrib/workplace.php
@@ -73,6 +73,9 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+// Target of deployment
+set('target', '{{hostname}}');
+
 // Deploy message
 set('workplace_text', '_{{user}}_ deploying `{{branch}}` to *{{target}}*');
 set('workplace_success_text', 'Deploy to *{{target}}* successful');

--- a/contrib/yammer.php
+++ b/contrib/yammer.php
@@ -60,6 +60,9 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
+// Target of deployment
+set('target', '{{hostname}}');
+
 set('yammer_url', 'https://www.yammer.com/api/v1/messages.json');
 
 // Title of project

--- a/docs/contrib/discord.md
+++ b/docs/contrib/discord.md
@@ -60,6 +60,7 @@ after('deploy:failed', 'discord:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`discord_webhook`](#discord_webhook)
   * [`discord_notify_text`](#discord_notify_text)
   * [`discord_success_text`](#discord_success_text)
@@ -73,55 +74,60 @@ after('deploy:failed', 'discord:notify:failure');
   * [`discord:notify:failure`](#discordnotifyfailure) — Notify Discord about deploy failure
 
 ## Config
+### target
+[Source](/contrib/discord.php#L58)
+
+
+
 ### discord_webhook
-[Source](/contrib/discord.php#L59)
+[Source](/contrib/discord.php#L60)
 
 
 
 ### discord_notify_text
-[Source](/contrib/discord.php#L64)
+[Source](/contrib/discord.php#L65)
 
 Deploy messages
 
 ### discord_success_text
-[Source](/contrib/discord.php#L69)
+[Source](/contrib/discord.php#L70)
 
 
 
 ### discord_failure_text
-[Source](/contrib/discord.php#L74)
+[Source](/contrib/discord.php#L75)
 
 
 
 ### discord_message
-[Source](/contrib/discord.php#L81)
+[Source](/contrib/discord.php#L82)
 
 The message
 
 
 ## Tasks
 ### discord_send_message
-[Source](/contrib/discord.php#L84)
+[Source](/contrib/discord.php#L85)
 
 Helpers
 
 ### discord:test
-[Source](/contrib/discord.php#L92)
+[Source](/contrib/discord.php#L93)
 
 Tasks
 
 ### discord:notify
-[Source](/contrib/discord.php#L104)
+[Source](/contrib/discord.php#L105)
 
 
 
 ### discord:notify:success
-[Source](/contrib/discord.php#L113)
+[Source](/contrib/discord.php#L114)
 
 
 
 ### discord:notify:failure
-[Source](/contrib/discord.php#L122)
+[Source](/contrib/discord.php#L123)
 
 
 

--- a/docs/contrib/hipchat.md
+++ b/docs/contrib/hipchat.md
@@ -35,6 +35,7 @@ after('deploy', 'hipchat:notify');
 
 
 * Config
+  * [`target`](#target)
   * [`hipchat_color`](#hipchat_color)
   * [`hipchat_from`](#hipchat_from)
   * [`hipchat_message`](#hipchat_message)
@@ -43,30 +44,35 @@ after('deploy', 'hipchat:notify');
   * [`hipchat:notify`](#hipchatnotify) — Notifying Hipchat channel of deployment
 
 ## Config
-### hipchat_color
+### target
 [Source](/contrib/hipchat.php#L33)
 
 
 
-### hipchat_from
-[Source](/contrib/hipchat.php#L34)
-
-
-
-### hipchat_message
+### hipchat_color
 [Source](/contrib/hipchat.php#L35)
 
 
 
-### hipchat_url
+### hipchat_from
 [Source](/contrib/hipchat.php#L36)
+
+
+
+### hipchat_message
+[Source](/contrib/hipchat.php#L37)
+
+
+
+### hipchat_url
+[Source](/contrib/hipchat.php#L38)
 
 
 
 
 ## Tasks
 ### hipchat:notify
-[Source](/contrib/hipchat.php#L39)
+[Source](/contrib/hipchat.php#L41)
 
 
 

--- a/docs/contrib/mattermost.md
+++ b/docs/contrib/mattermost.md
@@ -88,6 +88,7 @@ after('deploy:failed', 'mattermost:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`mattermost_webhook`](#mattermost_webhook)
   * [`mattermost_channel`](#mattermost_channel)
   * [`mattermost_username`](#mattermost_username)
@@ -103,65 +104,70 @@ after('deploy:failed', 'mattermost:notify:failure');
   * [`mattermost:notify:failure`](#mattermostnotifyfailure) — Notifying mattermost about deploy failure
 
 ## Config
-### mattermost_webhook
+### target
 [Source](/contrib/mattermost.php#L86)
 
 
 
-### mattermost_channel
-[Source](/contrib/mattermost.php#L87)
-
-
-
-### mattermost_username
+### mattermost_webhook
 [Source](/contrib/mattermost.php#L88)
 
 
 
-### mattermost_icon_url
+### mattermost_channel
 [Source](/contrib/mattermost.php#L89)
 
 
 
-### mattermost_success_emoji
+### mattermost_username
+[Source](/contrib/mattermost.php#L90)
+
+
+
+### mattermost_icon_url
 [Source](/contrib/mattermost.php#L91)
 
 
 
+### mattermost_success_emoji
+[Source](/contrib/mattermost.php#L93)
+
+
+
 ### mattermost_failure_emoji
-[Source](/contrib/mattermost.php#L92)
-
-
-
-### mattermost_text
 [Source](/contrib/mattermost.php#L94)
 
 
 
+### mattermost_text
+[Source](/contrib/mattermost.php#L96)
+
+
+
 ### mattermost_success_text
-[Source](/contrib/mattermost.php#L95)
+[Source](/contrib/mattermost.php#L97)
 
 
 
 ### mattermost_failure_text
-[Source](/contrib/mattermost.php#L96)
+[Source](/contrib/mattermost.php#L98)
 
 
 
 
 ## Tasks
 ### mattermost:notify
-[Source](/contrib/mattermost.php#L99)
+[Source](/contrib/mattermost.php#L101)
 
 
 
 ### mattermost:notify:success
-[Source](/contrib/mattermost.php#L120)
+[Source](/contrib/mattermost.php#L122)
 
 
 
 ### mattermost:notify:failure
-[Source](/contrib/mattermost.php#L141)
+[Source](/contrib/mattermost.php#L143)
 
 
 

--- a/docs/contrib/ms-teams.md
+++ b/docs/contrib/ms-teams.md
@@ -79,6 +79,7 @@ after('deploy:failed', 'teams:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`teams_title`](#teams_title)
   * [`teams_text`](#teams_text)
   * [`teams_success_text`](#teams_success_text)
@@ -92,55 +93,60 @@ after('deploy:failed', 'teams:notify:failure');
   * [`teams:notify:failure`](#teamsnotifyfailure) — Notifying Teams about deploy failure
 
 ## Config
-### teams_title
+### target
 [Source](/contrib/ms-teams.php#L78)
+
+Target of deployment
+
+### teams_title
+[Source](/contrib/ms-teams.php#L81)
 
 Title of project
 
 ### teams_text
-[Source](/contrib/ms-teams.php#L83)
+[Source](/contrib/ms-teams.php#L86)
 
 Deploy message
 
 ### teams_success_text
-[Source](/contrib/ms-teams.php#L84)
+[Source](/contrib/ms-teams.php#L87)
 
 
 
 ### teams_failure_text
-[Source](/contrib/ms-teams.php#L85)
+[Source](/contrib/ms-teams.php#L88)
 
 
 
 ### teams_color
-[Source](/contrib/ms-teams.php#L88)
+[Source](/contrib/ms-teams.php#L91)
 
 Color of attachment
 
 ### teams_success_color
-[Source](/contrib/ms-teams.php#L89)
+[Source](/contrib/ms-teams.php#L92)
 
 
 
 ### teams_failure_color
-[Source](/contrib/ms-teams.php#L90)
+[Source](/contrib/ms-teams.php#L93)
 
 
 
 
 ## Tasks
 ### teams:notify
-[Source](/contrib/ms-teams.php#L93)
+[Source](/contrib/ms-teams.php#L96)
 
 
 
 ### teams:notify:success
-[Source](/contrib/ms-teams.php#L108)
+[Source](/contrib/ms-teams.php#L111)
 
 
 
 ### teams:notify:failure
-[Source](/contrib/ms-teams.php#L123)
+[Source](/contrib/ms-teams.php#L126)
 
 
 

--- a/docs/contrib/rocketchat.md
+++ b/docs/contrib/rocketchat.md
@@ -72,6 +72,7 @@ after('deploy:failed', 'rocketchat:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`rockchat_title`](#rockchat_title)
   * [`rocketchat_icon_emoji`](#rocketchat_icon_emoji)
   * [`rocketchat_icon_url`](#rocketchat_icon_url)
@@ -91,85 +92,90 @@ after('deploy:failed', 'rocketchat:notify:failure');
   * [`rocketchat:notify:failure`](#rocketchatnotifyfailure) — Notifying RocketChat about deploy failure
 
 ## Config
-### rockchat_title
+### target
 [Source](/contrib/rocketchat.php#L70)
 
 
 
+### rockchat_title
+[Source](/contrib/rocketchat.php#L72)
+
+
+
 ### rocketchat_icon_emoji
-[Source](/contrib/rocketchat.php#L74)
+[Source](/contrib/rocketchat.php#L76)
 
 
 
 ### rocketchat_icon_url
-[Source](/contrib/rocketchat.php#L75)
-
-
-
-### rocketchat_channel
 [Source](/contrib/rocketchat.php#L77)
 
 
 
-### rocketchat_room_id
-[Source](/contrib/rocketchat.php#L78)
-
-
-
-### rocketchat_username
+### rocketchat_channel
 [Source](/contrib/rocketchat.php#L79)
 
 
 
-### rocketchat_webhook
+### rocketchat_room_id
 [Source](/contrib/rocketchat.php#L80)
 
 
 
-### rocketchat_color
+### rocketchat_username
+[Source](/contrib/rocketchat.php#L81)
+
+
+
+### rocketchat_webhook
 [Source](/contrib/rocketchat.php#L82)
 
 
 
-### rocketchat_success_color
-[Source](/contrib/rocketchat.php#L83)
-
-
-
-### rocketchat_failure_color
+### rocketchat_color
 [Source](/contrib/rocketchat.php#L84)
 
 
 
-### rocketchat_text
+### rocketchat_success_color
+[Source](/contrib/rocketchat.php#L85)
+
+
+
+### rocketchat_failure_color
 [Source](/contrib/rocketchat.php#L86)
 
 
 
+### rocketchat_text
+[Source](/contrib/rocketchat.php#L88)
+
+
+
 ### rocketchat_success_text
-[Source](/contrib/rocketchat.php#L87)
+[Source](/contrib/rocketchat.php#L89)
 
 
 
 ### rocketchat_failure_text
-[Source](/contrib/rocketchat.php#L88)
+[Source](/contrib/rocketchat.php#L90)
 
 
 
 
 ## Tasks
 ### rocketchat:notify
-[Source](/contrib/rocketchat.php#L91)
+[Source](/contrib/rocketchat.php#L93)
 
 
 
 ### rocketchat:notify:success
-[Source](/contrib/rocketchat.php#L121)
+[Source](/contrib/rocketchat.php#L123)
 
 
 
 ### rocketchat:notify:failure
-[Source](/contrib/rocketchat.php#L151)
+[Source](/contrib/rocketchat.php#L153)
 
 
 

--- a/docs/contrib/rollbar.md
+++ b/docs/contrib/rollbar.md
@@ -35,20 +35,26 @@ after('deploy', 'rollbar:notify');
 
 
 * Config
+  * [`target`](#target)
   * [`rollbar_comment`](#rollbar_comment)
 * Tasks
   * [`rollbar:notify`](#rollbarnotify) — Notifying Rollbar of deployment
 
 ## Config
-### rollbar_comment
+### target
 [Source](/contrib/rollbar.php#L33)
+
+
+
+### rollbar_comment
+[Source](/contrib/rollbar.php#L35)
 
 
 
 
 ## Tasks
 ### rollbar:notify
-[Source](/contrib/rollbar.php#L36)
+[Source](/contrib/rollbar.php#L38)
 
 
 

--- a/docs/contrib/slack.md
+++ b/docs/contrib/slack.md
@@ -70,6 +70,7 @@ after('deploy:failed', 'slack:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`slack_title`](#slack_title)
   * [`slack_text`](#slack_text)
   * [`slack_success_text`](#slack_success_text)
@@ -86,70 +87,75 @@ after('deploy:failed', 'slack:notify:failure');
   * [`slack:notify:rollback`](#slacknotifyrollback) — Notifying Slack about rollback
 
 ## Config
-### slack_title
+### target
 [Source](/contrib/slack.php#L69)
+
+Target of deployment
+
+### slack_title
+[Source](/contrib/slack.php#L72)
 
 Title of project
 
 ### slack_text
-[Source](/contrib/slack.php#L74)
+[Source](/contrib/slack.php#L77)
 
 Deploy message
 
 ### slack_success_text
-[Source](/contrib/slack.php#L75)
+[Source](/contrib/slack.php#L78)
 
 
 
 ### slack_failure_text
-[Source](/contrib/slack.php#L76)
+[Source](/contrib/slack.php#L79)
 
 
 
 ### slack_rollback_text
-[Source](/contrib/slack.php#L77)
+[Source](/contrib/slack.php#L80)
 
 
 
 ### slack_color
-[Source](/contrib/slack.php#L80)
+[Source](/contrib/slack.php#L83)
 
 Color of attachment
 
 ### slack_success_color
-[Source](/contrib/slack.php#L81)
+[Source](/contrib/slack.php#L84)
 
 
 
 ### slack_failure_color
-[Source](/contrib/slack.php#L82)
+[Source](/contrib/slack.php#L85)
 
 
 
 ### slack_rollback_color
-[Source](/contrib/slack.php#L83)
+[Source](/contrib/slack.php#L86)
 
 
 
 
 ## Tasks
 ### slack:notify
-[Source](/contrib/slack.php#L86)
+[Source](/contrib/slack.php#L89)
 
 
 
 ### slack:notify:success
-[Source](/contrib/slack.php#L105)
+[Source](/contrib/slack.php#L108)
 
 
 
 ### slack:notify:failure
-[Source](/contrib/slack.php#L124)
+[Source](/contrib/slack.php#L127)
 
 
 
 ### slack:notify:rollback
-[Source](/contrib/slack.php#L143)
+[Source](/contrib/slack.php#L146)
 
 
 

--- a/docs/contrib/telegram.md
+++ b/docs/contrib/telegram.md
@@ -69,6 +69,7 @@ after('deploy:failed', 'telegram:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`telegram_title`](#telegram_title)
   * [`telegram_token`](#telegram_token)
   * [`telegram_chat_id`](#telegram_chat_id)
@@ -80,45 +81,50 @@ after('deploy:failed', 'telegram:notify:failure');
   * [`telegram:notify`](#telegramnotify)
 
 ## Config
-### telegram_title
+### target
 [Source](/contrib/telegram.php#L67)
+
+Target of deployment
+
+### telegram_title
+[Source](/contrib/telegram.php#L70)
 
 Title of project
 
 ### telegram_token
-[Source](/contrib/telegram.php#L72)
+[Source](/contrib/telegram.php#L75)
 
 Telegram settings
 
 ### telegram_chat_id
-[Source](/contrib/telegram.php#L75)
-
-
-
-### telegram_url
 [Source](/contrib/telegram.php#L78)
 
 
 
+### telegram_url
+[Source](/contrib/telegram.php#L81)
+
+
+
 ### telegram_text
-[Source](/contrib/telegram.php#L83)
+[Source](/contrib/telegram.php#L86)
 
 Deploy message
 
 ### telegram_success_text
-[Source](/contrib/telegram.php#L84)
+[Source](/contrib/telegram.php#L87)
 
 
 
 ### telegram_failure_text
-[Source](/contrib/telegram.php#L85)
+[Source](/contrib/telegram.php#L88)
 
 
 
 
 ## Tasks
 ### telegram:notify
-[Source](/contrib/telegram.php#L90)
+[Source](/contrib/telegram.php#L93)
 
 
 

--- a/docs/contrib/workplace.md
+++ b/docs/contrib/workplace.md
@@ -78,6 +78,7 @@ after('deploy:failed', 'workplace:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`workplace_text`](#workplace_text)
   * [`workplace_success_text`](#workplace_success_text)
   * [`workplace_failure_text`](#workplace_failure_text)
@@ -88,40 +89,45 @@ after('deploy:failed', 'workplace:notify:failure');
   * [`workplace:notify:failure`](#workplacenotifyfailure) — Notifying Workplace about deploy failure
 
 ## Config
-### workplace_text
+### target
 [Source](/contrib/workplace.php#L77)
+
+Target of deployment
+
+### workplace_text
+[Source](/contrib/workplace.php#L80)
 
 Deploy message
 
 ### workplace_success_text
-[Source](/contrib/workplace.php#L78)
+[Source](/contrib/workplace.php#L81)
 
 
 
 ### workplace_failure_text
-[Source](/contrib/workplace.php#L79)
+[Source](/contrib/workplace.php#L82)
 
 
 
 ### workplace_edit_post
-[Source](/contrib/workplace.php#L82)
+[Source](/contrib/workplace.php#L85)
 
 By default, create a new post for every message
 
 
 ## Tasks
 ### workplace:notify
-[Source](/contrib/workplace.php#L85)
+[Source](/contrib/workplace.php#L88)
 
 
 
 ### workplace:notify:success
-[Source](/contrib/workplace.php#L110)
+[Source](/contrib/workplace.php#L113)
 
 
 
 ### workplace:notify:failure
-[Source](/contrib/workplace.php#L122)
+[Source](/contrib/workplace.php#L125)
 
 
 

--- a/docs/contrib/yammer.md
+++ b/docs/contrib/yammer.md
@@ -65,6 +65,7 @@ after('deploy:failed', 'yammer:notify:failure');
 
 
 * Config
+  * [`target`](#target)
   * [`yammer_url`](#yammer_url)
   * [`yammer_title`](#yammer_title)
   * [`yammer_body`](#yammer_body)
@@ -76,45 +77,50 @@ after('deploy:failed', 'yammer:notify:failure');
   * [`yammer:notify:failure`](#yammernotifyfailure) — Notifying Yammer about deploy failure
 
 ## Config
+### target
+[Source](/contrib/yammer.php#L64)
+
+Target of deployment
+
 ### yammer_url
-[Source](/contrib/yammer.php#L63)
+[Source](/contrib/yammer.php#L66)
 
 
 
 ### yammer_title
-[Source](/contrib/yammer.php#L66)
+[Source](/contrib/yammer.php#L69)
 
 Title of project
 
 ### yammer_body
-[Source](/contrib/yammer.php#L71)
+[Source](/contrib/yammer.php#L74)
 
 Deploy message
 
 ### yammer_success_body
-[Source](/contrib/yammer.php#L72)
+[Source](/contrib/yammer.php#L75)
 
 
 
 ### yammer_failure_body
-[Source](/contrib/yammer.php#L73)
+[Source](/contrib/yammer.php#L76)
 
 
 
 
 ## Tasks
 ### yammer:notify
-[Source](/contrib/yammer.php#L76)
+[Source](/contrib/yammer.php#L79)
 
 
 
 ### yammer:notify:success
-[Source](/contrib/yammer.php#L96)
+[Source](/contrib/yammer.php#L99)
 
 
 
 ### yammer:notify:failure
-[Source](/contrib/yammer.php#L116)
+[Source](/contrib/yammer.php#L119)
 
 
 


### PR DESCRIPTION
Most of the contrib recipes use the target option but do not come with a default value.
Therefore using those recipes will lead to an exception.

This PR adds the target option to all recipes and sets the hostname as default.

- [x] Bug fix #2238 
- [x] Changelog updated