### PR TITLE
Allow option merge on host add()

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -56,15 +56,11 @@ class Configuration implements \ArrayAccess
 
     public function add(string $name, array $array): void
     {
-        if ($this->has($name)) {
-            $config = $this->get($name);
-            if (!is_array($config)) {
-                throw new ConfigurationException("Config option \"$name\" isn't array.");
-            }
-            $this->set($name, array_merge_alternate($config, $array));
-        } else {
-            $this->set($name, $array);
+        $config = $this->get($name);
+        if (!is_array($config)) {
+            throw new ConfigurationException("Config option \"$name\" isn't array.");
         }
+        $this->set($name, array_merge_alternate($config, $array));
     }
 
     /**


### PR DESCRIPTION
This ensures that global defaults are used as base on host()->add() in case no host-specific base has been set yet.

- [x] Bug fix #2248?
- [x] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
