### PR TITLE
Crontab root

### DIFF
--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -15,7 +15,7 @@ task('crontab:load', function () {
     set('crontab:all', []);
 
     // Crontab is empty
-    if (!test ("[ -f '/var/spool/cron/{{user}}' ]")) {
+    if (!test ("{{bin/crontab}} -l >> /dev/null 2>&1")) {
         return;
     }
 


### PR DESCRIPTION
- [x] Bug fix #…? (not reported)
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

`[ -f '/var/spool/cron/{{user}}' ]` requires root access and doesn't work on Debian/Ubuntu servers. Replaced it by a `crontab -l` call.

