### PR TITLE
Add config var parsing support to crontab jobs

### DIFF
--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -49,6 +49,7 @@ task('crontab:sync', function () {
     $cronJobs = get('crontab:all');
 
     foreach ($syncJobs as $syncJob) {
+        $syncJob = parse($job);
         $syncJobData = parseJob($syncJob);
 
         if (is_null ($syncJobData)) {


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated? (crontab is new, but not mentioned in the CHANGELOG.

Makes it possible to do:

```
add('crontab:jobs', [
    '* * * * * cd {{current_path}} && {{bin/php}} artisan schedule:run >> /dev/null 2>&1',
]);
```
