### PR TITLE
Let PHPStan analyze recipe and contrib folder

### DIFF
--- a/contrib/cpanel.php
+++ b/contrib/cpanel.php
@@ -204,7 +204,7 @@ task('cpanel:createdb', function () {
 
     $cpanel = getCPanel();
     $config = get('cpanel', []);
-    if (!askConfirmation(sprintf('This will try to create the database %s on the host though CPanel API, ok?', get('cpanel_createdb'), get('deploy_path')), true)) {
+    if (!askConfirmation(sprintf('This will try to create the database %s on the host though CPanel API, ok?', get('cpanel_createdb')), true)) {
         return;
     }
 
@@ -242,7 +242,7 @@ task('cpanel:createaddondomain', function () {
     $addAddonDomainResult = $cpanel->cpanel('AddonDomain', 'addaddondomain', $config['user'], ['dir' => get('addondir'), 'newdomain'=> $domain, 'subdomain' => $subDomain]);
     $addAddonDomainData = json_decode($addAddonDomainResult, true);
 
-    if (isset($delAddonDomainResult['cpanelresult']['error'])) {
+    if (isset($addAddonDomainResult['cpanelresult']['error'])) {
         writeln($addAddonDomainData['cpanelresult']['error']);
     } else {
         writeln('Successfully created addon domain!');

--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -49,7 +49,7 @@ task('crontab:sync', function () {
     $cronJobs = get('crontab:all');
 
     foreach ($syncJobs as $syncJob) {
-        $syncJob = parse($job);
+        $syncJob = parse($syncJob);
         $syncJobData = parseJob($syncJob);
 
         if (is_null ($syncJobData)) {

--- a/contrib/ispmanager.php
+++ b/contrib/ispmanager.php
@@ -304,7 +304,7 @@ task('ispmanager:domain-create', function () {
             throw new Exception('Domain already exists!');
         }
         else {
-            warning1 ('Domain already exists - skipping');
+            warning ('Domain already exists - skipping');
             return true;
         }
     }
@@ -440,7 +440,6 @@ task('ispmanager:domain-php-select', function () {
 
     if (!isset ($config['phpSelect']['mode']) || !isset ($config['phpSelect']['version'])) {
         throw new Exception('Incorrect settings for select php version');
-        return;
     }
 
     $phpVersions = get ('ispmanager_phplist');
@@ -450,7 +449,6 @@ task('ispmanager:domain-php-select', function () {
 
     if (!isset ($phpVersions[$newVersion])) {
         throw new Exception('Incorrect php version');
-        return;
     }
 
     $versionData = $phpVersions[$newVersion];

--- a/contrib/rsync.php
+++ b/contrib/rsync.php
@@ -246,9 +246,9 @@ task('rsync', function() {
         return;
     }
 
-    $host = $host->getHostname();
     $sshArguments = Client::connectionOptions($host);
     $user = !$host->getRemoteUser() ? '' : $host->getRemoteUser() . '@';
+    $host = $host->getHostname();
 
     runLocally("rsync -{$config['flags']} -e 'ssh  $sshArguments' {{rsync_options}}{{rsync_includes}}{{rsync_excludes}}{{rsync_filter}} '$src/' '$user$host:$dst/'", $config);
 });

--- a/docs/contrib/ispmanager.md
+++ b/docs/contrib/ispmanager.md
@@ -78,7 +78,7 @@ Storage
 
 
 ### ispmanager:process
-[Source](/contrib/ispmanager.php#L690)
+[Source](/contrib/ispmanager.php#L688)
 
 
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,11 @@ parameters:
     level: 4
     paths:
         - src
+        - recipe
+        - contrib
 
     ignoreErrors:
         - "#^Constant DEPLOYER_VERSION not found\\.$#"
         - "#^Constant DEPLOYER_BIN not found\\.$#"
+        - "#CpanelPhp#"
+        - "#AMQPMessage#"


### PR DESCRIPTION
- [x] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

I discovered a stupid bug in my PR (#2257). It uses a undefined variable. PHPStan can prevent those stupid mistakes. This PR adds `contrib` and `recipe` to the analysed paths. And on the fly fixes some bugs.