### PR TITLE
Magento 2 Zero downtime deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -597,6 +597,7 @@
 - Fixed typo3 recipe.
 - Fixed remove of shared dir on first deploy.
 
+
 [#2261]: https://github.com/deployphp/deployer/pull/2261
 [#2260]: https://github.com/deployphp/deployer/pull/2260
 [#2253]: https://github.com/deployphp/deployer/issues/2253

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Docs rewritten to be more clean, easy to use and understandable.
 - Better parallel execution support, configurable per task.
 - Refactored `dep init` command.
+- Magento 2 database migrations check in order to get zero downtime deployments. [#2202]
 
 ### Fixed
 - Lots, and lots of long-standing bugs.
@@ -603,6 +604,7 @@
 [#2261]: https://github.com/deployphp/deployer/pull/2261
 [#2260]: https://github.com/deployphp/deployer/pull/2260
 [#2253]: https://github.com/deployphp/deployer/issues/2253
+[#2202]: https://github.com/deployphp/deployer/issues/2202
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -28,35 +28,35 @@
 
 ## Config
 ### static_content_locales
-[Source](/recipe/magento2.php#L13)
+[Source](/recipe/magento2.php#L19)
 
 By default setup:static-content:deploy uses `en_US`.
 To change that, simply put set('static_content_locales', 'en_US de_DE');`
 in you deployer script.
 
 ### shared_files
-[Source](/recipe/magento2.php#L15)
+[Source](/recipe/magento2.php#L21)
 
 * Overrides [`shared_files`](/docs/recipe/common.md#shared_files) from `recipe/common.php`
 
 
 
 ### shared_dirs
-[Source](/recipe/magento2.php#L19)
+[Source](/recipe/magento2.php#L25)
 
 * Overrides [`shared_dirs`](/docs/recipe/common.md#shared_dirs) from `recipe/common.php`
 
 
 
 ### writable_dirs
-[Source](/recipe/magento2.php#L33)
+[Source](/recipe/magento2.php#L39)
 
 * Overrides [`writable_dirs`](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`
 
 
 
 ### clear_paths
-[Source](/recipe/magento2.php#L39)
+[Source](/recipe/magento2.php#L45)
 
 * Overrides [`clear_paths`](/docs/recipe/common.md#clear_paths) from `recipe/common.php`
 
@@ -65,50 +65,48 @@ in you deployer script.
 
 ## Tasks
 ### magento:compile
-[Source](/recipe/magento2.php#L50)
+[Source](/recipe/magento2.php#L56)
 
 Tasks
 
 ### magento:deploy:assets
-[Source](/recipe/magento2.php#L56)
+[Source](/recipe/magento2.php#L63)
 
 
 
 ### magento:maintenance:enable
-[Source](/recipe/magento2.php#L61)
+[Source](/recipe/magento2.php#L68)
 
 
 
 ### magento:maintenance:disable
-[Source](/recipe/magento2.php#L66)
+[Source](/recipe/magento2.php#L73)
 
 
 
 ### magento:upgrade:db
-[Source](/recipe/magento2.php#L71)
+[Source](/recipe/magento2.php#L78)
 
 
 
 ### magento:cache:flush
-[Source](/recipe/magento2.php#L76)
+[Source](/recipe/magento2.php#L115)
 
 
 
 ### deploy:magento
-[Source](/recipe/magento2.php#L81)
+[Source](/recipe/magento2.php#L120)
 
 
 
 This task is group task which contains next tasks:
 * [`magento:compile`](/docs/recipe/magento2.md#magentocompile)
 * [`magento:deploy:assets`](/docs/recipe/magento2.md#magentodeployassets)
-* [`magento:maintenance:enable`](/docs/recipe/magento2.md#magentomaintenanceenable)
 * [`magento:upgrade:db`](/docs/recipe/magento2.md#magentoupgradedb)
-* [`magento:cache:flush`](/docs/recipe/magento2.md#magentocacheflush)
 
 
 ### deploy
-[Source](/recipe/magento2.php#L91)
+[Source](/recipe/magento2.php#L128)
 
 
 

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -16,6 +16,8 @@
   * [`shared_dirs`](#shared_dirs)
   * [`writable_dirs`](#writable_dirs)
   * [`clear_paths`](#clear_paths)
+  * [`magento_version`](#magento_version)
+  * [`maintenance_mode_status_active`](#maintenance_mode_status_active)
 * Tasks
   * [`magento:compile`](#magentocompile) — Compile magento di
   * [`magento:deploy:assets`](#magentodeployassets) — Deploy assets
@@ -29,69 +31,79 @@
 
 ## Config
 ### static_content_locales
-[Source](/recipe/magento2.php#L20)
+[Source](/recipe/magento2.php#L19)
 
 By default setup:static-content:deploy uses `en_US`.
 To change that, simply put set('static_content_locales', 'en_US de_DE');`
 in you deployer script.
 
 ### shared_files
-[Source](/recipe/magento2.php#L22)
+[Source](/recipe/magento2.php#L21)
 
 * Overrides [`shared_files`](/docs/recipe/common.md#shared_files) from `recipe/common.php`
 
 
 
 ### shared_dirs
-[Source](/recipe/magento2.php#L26)
+[Source](/recipe/magento2.php#L25)
 
 * Overrides [`shared_dirs`](/docs/recipe/common.md#shared_dirs) from `recipe/common.php`
 
 
 
 ### writable_dirs
-[Source](/recipe/magento2.php#L40)
+[Source](/recipe/magento2.php#L39)
 
 * Overrides [`writable_dirs`](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`
 
 
 
 ### clear_paths
-[Source](/recipe/magento2.php#L46)
+[Source](/recipe/magento2.php#L45)
 
 * Overrides [`clear_paths`](/docs/recipe/common.md#clear_paths) from `recipe/common.php`
+
+
+
+### magento_version
+[Source](/recipe/magento2.php#L54)
+
+
+
+### maintenance_mode_status_active
+[Source](/recipe/magento2.php#L61)
 
 
 
 
 ## Tasks
 ### magento:compile
-[Source](/recipe/magento2.php#L57)
+[Source](/recipe/magento2.php#L69)
 
 Tasks
 
 ### magento:deploy:assets
-[Source](/recipe/magento2.php#L64)
+[Source](/recipe/magento2.php#L76)
 
 
 
 ### magento:maintenance:enable
-[Source](/recipe/magento2.php#L69)
+[Source](/recipe/magento2.php#L81)
 
 
 
 ### magento:maintenance:disable
-[Source](/recipe/magento2.php#L74)
+[Source](/recipe/magento2.php#L86)
 
 
 
 ### magento:config:import
-[Source](/recipe/magento2.php#L79)
+[Source](/recipe/magento2.php#L91)
 
 
 
 ### magento:upgrade:db
-[Source](/recipe/magento2.php#L116)
+[Source](/recipe/magento2.php#L126)
 
 
 

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -21,6 +21,7 @@
   * [`magento:deploy:assets`](#magentodeployassets) — Deploy assets
   * [`magento:maintenance:enable`](#magentomaintenanceenable) — Enable maintenance mode
   * [`magento:maintenance:disable`](#magentomaintenancedisable) — Disable maintenance mode
+  * [`magento:config:import`](#magentoconfigimport) — Config Import
   * [`magento:upgrade:db`](#magentoupgradedb) — Upgrade magento database
   * [`magento:cache:flush`](#magentocacheflush) — Flush Magento Cache
   * [`deploy:magento`](#deploymagento) — Magento2 deployment operations
@@ -28,35 +29,35 @@
 
 ## Config
 ### static_content_locales
-[Source](/recipe/magento2.php#L19)
+[Source](/recipe/magento2.php#L20)
 
 By default setup:static-content:deploy uses `en_US`.
 To change that, simply put set('static_content_locales', 'en_US de_DE');`
 in you deployer script.
 
 ### shared_files
-[Source](/recipe/magento2.php#L21)
+[Source](/recipe/magento2.php#L22)
 
 * Overrides [`shared_files`](/docs/recipe/common.md#shared_files) from `recipe/common.php`
 
 
 
 ### shared_dirs
-[Source](/recipe/magento2.php#L25)
+[Source](/recipe/magento2.php#L26)
 
 * Overrides [`shared_dirs`](/docs/recipe/common.md#shared_dirs) from `recipe/common.php`
 
 
 
 ### writable_dirs
-[Source](/recipe/magento2.php#L39)
+[Source](/recipe/magento2.php#L40)
 
 * Overrides [`writable_dirs`](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`
 
 
 
 ### clear_paths
-[Source](/recipe/magento2.php#L45)
+[Source](/recipe/magento2.php#L46)
 
 * Overrides [`clear_paths`](/docs/recipe/common.md#clear_paths) from `recipe/common.php`
 
@@ -65,48 +66,54 @@ in you deployer script.
 
 ## Tasks
 ### magento:compile
-[Source](/recipe/magento2.php#L56)
+[Source](/recipe/magento2.php#L57)
 
 Tasks
 
 ### magento:deploy:assets
-[Source](/recipe/magento2.php#L63)
+[Source](/recipe/magento2.php#L64)
 
 
 
 ### magento:maintenance:enable
-[Source](/recipe/magento2.php#L68)
+[Source](/recipe/magento2.php#L69)
 
 
 
 ### magento:maintenance:disable
-[Source](/recipe/magento2.php#L73)
+[Source](/recipe/magento2.php#L74)
+
+
+
+### magento:config:import
+[Source](/recipe/magento2.php#L79)
 
 
 
 ### magento:upgrade:db
-[Source](/recipe/magento2.php#L78)
+[Source](/recipe/magento2.php#L116)
 
 
 
 ### magento:cache:flush
-[Source](/recipe/magento2.php#L115)
+[Source](/recipe/magento2.php#L153)
 
 
 
 ### deploy:magento
-[Source](/recipe/magento2.php#L120)
+[Source](/recipe/magento2.php#L158)
 
 
 
 This task is group task which contains next tasks:
 * [`magento:compile`](/docs/recipe/magento2.md#magentocompile)
 * [`magento:deploy:assets`](/docs/recipe/magento2.md#magentodeployassets)
+* [`magento:config:import`](/docs/recipe/magento2.md#magentoconfigimport)
 * [`magento:upgrade:db`](/docs/recipe/magento2.md#magentoupgradedb)
 
 
 ### deploy
-[Source](/recipe/magento2.php#L128)
+[Source](/recipe/magento2.php#L167)
 
 
 

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -61,7 +61,7 @@ task('magento:compile', function () {
 
 desc('Deploy assets');
 task('magento:deploy:assets', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static_content_locales}}");
+    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static_content_locales}} --force");
 });
 
 desc('Enable maintenance mode');

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -25,15 +25,15 @@ set('shared_files', [
 set('shared_dirs', [
     'var/composer_home',
     'var/log',
-    'var/cache',
     'var/export',
     'var/report',
+    'var/import',
     'var/import_history',
     'var/session',
     'var/importexport',
     'var/backups',
     'var/tmp',
-    'pub/sitemaps',
+    'pub/sitemap',
     'pub/media'
 ]);
 set('writable_dirs', [

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -54,6 +54,7 @@ set('clear_paths', [
 // Tasks
 desc('Compile magento di');
 task('magento:compile', function () {
+    run('cd {{release_path}} && {{bin/composer}} dump-autoload -o');
     run("{{bin/php}} {{release_path}}/bin/magento setup:di:compile");
     run('cd {{release_path}} && {{bin/composer}} dump-autoload -o');
 });

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -61,7 +61,7 @@ task('magento:compile', function () {
 
 desc('Deploy assets');
 task('magento:deploy:assets', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static_content_locales}} --force");
+    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy {{static_content_locales}}");
 });
 
 desc('Enable maintenance mode');


### PR DESCRIPTION
- [ ] Bug fix
- [X] New feature  #2202
- [ ] BC breaks
- [ ] Deprecations
- [ ] Tests added
- [ ] Changelog updated

Implements check for Magento 2 database migration needs, in order to get zero downtime deployments otherwise.

Also fixes magento 2.4 deployments due to composer autoload issue https://github.com/magento/magento2/issues/23251

Tested with Deployer 7-beta.3 and Magento 2.2 | 2.3 | 2.4 (to date only 2.3 and 2.4 are officially supported by magento).

I've checked it does not introduce so far BC breaks for these versions.

