### PR TITLE
added `@throws` for run/runLocally and friends

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -212,6 +212,7 @@ run("echo $path");
 ```
 
 
+
 ## runLocally()
 
 ```php
@@ -219,6 +220,7 @@ runLocally(string $command, array $options = []): string
 ```
 
 Execute commands on local machine
+
 
 
 
@@ -237,6 +239,7 @@ if (test('[ -d {{release_path}} ]')) {
 }
 ```
 
+
 ## testLocally()
 
 ```php
@@ -247,6 +250,7 @@ Run test command locally.
 Example:
 
     testLocally('[ -d {{local_release_path}} ]')
+
 
 ## on()
 
@@ -300,6 +304,7 @@ Upload file or directory to host.
 > The alternative, without the trailing slash, would place build, including the directory, within public. This would create a hierarchy that looks like: {{release_path}}/public/build
 
 
+
 ## download()
 
 ```php
@@ -307,6 +312,7 @@ download(string $source, string $destination, array $config = []): void
 ```
 
 Download file or directory from host
+
 
 
 ## info()
@@ -427,6 +433,7 @@ commandExist(string $command): bool
 ```
 
 Check if command exists
+
 
 ## commandSupportsOption()
 

--- a/src/Component/ProcessRunner/ProcessRunner.php
+++ b/src/Component/ProcessRunner/ProcessRunner.php
@@ -28,6 +28,8 @@ class ProcessRunner
 
     /**
      * Runs a command, consider deployer global configs (timeout,...)
+     *
+     * @throws RunException
      */
     public function run(Host $host, string $command, array $config = []): string
     {

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -31,6 +31,9 @@ class Client
         $this->logger = $logger;
     }
 
+    /**
+     * @throws RunException
+     */
     public function run(Host $host, string $command, array $config = []): string
     {
         $connectionString = $host->getConnectionString();

--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -35,6 +35,8 @@ class Rsync
      * - `flags` for overriding the default `-azP` passed to the `rsync` command
      * - `options` with additional flags passed directly to the `rsync` command
      * - `timeout` for `Process::fromShellCommandline()` (`null` by default)
+     * 
+     * @throws RunException
      */
     public function call(Host $host, string $source, string $destination, array $config = []): void
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -312,6 +312,8 @@ function within(string $path, callable $callback)
  * ```
  *
  * @param array $options
+ * 
+ * @throws RunException
  */
 function run(string $command, array $options = []): string
 {
@@ -376,6 +378,8 @@ function run(string $command, array $options = []): string
  * @param array $options
  *
  * @return string Output of command.
+ * 
+ * @throws RunException
  */
 function runLocally(string $command, array $options = []): string
 {
@@ -402,6 +406,8 @@ function runLocally(string $command, array $options = []): string
  * ...
  * }
  * ```
+ * 
+ * @throws RunException
  */
 function test(string $command): bool
 {
@@ -413,6 +419,8 @@ function test(string $command): bool
  * Example:
  *
  *     testLocally('[ -d {{local_release_path}} ]')
+ * 
+ * @throws RunException
  */
 function testLocally(string $command): bool
 {
@@ -490,6 +498,7 @@ function invoke(string $taskName): void
  * > The alternative, without the trailing slash, would place build, including the directory, within public. This would create a hierarchy that looks like: {{release_path}}/public/build
  *
  * @param array $config
+ * 
  * @throws RunException
  */
 function upload(string $source, string $destination, array $config = []): void
@@ -510,6 +519,7 @@ function upload(string $source, string $destination, array $config = []): void
  * Download file or directory from host
  *
  * @param array $config
+ * 
  * @throws RunException
  */
 function download(string $source, string $destination, array $config = []): void
@@ -747,12 +757,17 @@ function output(): OutputInterface
 
 /**
  * Check if command exists
+ * 
+ * @throws RunException
  */
 function commandExist(string $command): bool
 {
     return test("hash $command 2>/dev/null");
 }
 
+/**
+ * @throws RunException
+ */
 function commandSupportsOption(string $command, string $option): bool
 {
     $man = run("(man $command 2>&1 || $command -h 2>&1 || $command --help 2>&1) | grep -- $option || true");
@@ -762,6 +777,9 @@ function commandSupportsOption(string $command, string $option): bool
     return str_contains($man, $option);
 }
 
+/**
+ * @throws RunException
+ */
 function locateBinaryPath(string $name): string
 {
     $nameEscaped = escapeshellarg($name);


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog

declare `@throws` phpdoc so users know which exceptions to catch, in case they want to handle errors.
this information will help people upgrading from v6, because phpstan and friends can tell them, that they need to adjust their `catch` clauses in the recipies.

as with other phpdoc only changes, I did not add a changelog item.

great to see that we have a unique exception `RunException` for all cases. in v6 we had to catch different exceptions whether you invoke `run` or `runLocally`