### PR TITLE
Allow changing Composer channel

### DIFF
--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -17,6 +17,11 @@ set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction 
  */
 set('composer_version', null);
 
+/**
+ * Set this variable to stable, snapshot, preview, 1 or 2 to select which Composer channel to use
+ */
+set('composer_channel', null);
+
 set('bin/composer', function () {
     if (commandExist('composer')) {
         return '{{bin/php}} ' . locateBinaryPath('composer');
@@ -27,10 +32,18 @@ set('bin/composer', function () {
     }
 
     $composerVersionToInstall = get('composer_version', null);
+    $composerChannel = get('composer_channel', null);
     $installCommand = "cd {{release_path}} && curl -sS https://getcomposer.org/installer | {{bin/php}}";
 
     if ($composerVersionToInstall) {
         $installCommand .= " -- --version=" . $composerVersionToInstall;
+    }
+    elseif ($composerChannel) {
+        $composerValidChannels = ['stable', 'snapshot', 'preview', '1', '2', ];
+        if(!in_array($composerChannel, $composerValidChannels)) {
+            throw new \Exception('Selected Composer channel '.$composerChannel.' is not valid. Valid channels are: '.implode(', ', $composerValidChannels));
+        }
+        $installCommand .= " -- --".$composerChannel;
     }
 
     run($installCommand);


### PR DESCRIPTION
Composer installer can now take an argument to select which version channel to use: https://github.com/composer/getcomposer.org/pull/156/files
This allows for exemple to stay on major version 1 without specifying a specific Composer version

- [ ] Bug fix #…?
- [X] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
