### PR TITLE
Fixed resolving of cachetool binary and disabled support of cachetool below version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - Lots, and lots of long-standing bugs.
+- Fixed resolving of cachetool binary for php above 7.2. [#2275]
 
 
 ## v6.8.0
@@ -597,6 +598,7 @@
 - Fixed remove of shared dir on first deploy.
 
 
+[#2275]: https://github.com/deployphp/deployer/issues/2275
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -49,19 +49,11 @@ namespace Deployer;
 
 set('cachetool', '');
 set('cachetool_args', '');
-set('cachetool_binary', function () {
-    return run("{{bin/php}} -r \"echo (PHP_VERSION_ID <= 50640) ? 'cachetool-3.2.1.phar' : ((PHP_VERSION_ID <= 70133) ? 'cachetool-4.1.1.phar' : 'cachetool.phar');\"");
-});
 set('bin/cachetool', function () {
-    $cachetool_binary = get('cachetool_binary');
-    $cachetool_binary = locateBinaryPath($cachetool_binary);
-
-    if (empty($cachetool_binary)) {
-        run("cd {{release_path}} && curl -sSO https://gordalina.github.io/cachetool/downloads/{{cachetool_binary}}");
-        $cachetool_binary = '{{release_path}}/{{cachetool_binary}}';
+    if (!test('[ -f {{release_path}}/cachetool.phar ]')) {
+        run("cd {{release_path}} && curl -sLO https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar");
     }
-
-    return $cachetool_binary;
+    return '{{release_path}}/cachetool.phar';
 });
 set('cachetool_options', function () {
     $options = get('cachetool');

--- a/docs/contrib/cachetool.md
+++ b/docs/contrib/cachetool.md
@@ -55,7 +55,6 @@ http://gordalina.github.io/cachetool/
 * Config
   * [`cachetool`](#cachetool)
   * [`cachetool_args`](#cachetool_args)
-  * [`cachetool_binary`](#cachetool_binary)
   * [`cachetool_options`](#cachetool_options)
 * Tasks
   * [`cachetool:clear:apc`](#cachetoolclearapc) — Clearing APC system cache
@@ -74,35 +73,30 @@ http://gordalina.github.io/cachetool/
 
 
 
-### cachetool_binary
-[Source](/contrib/cachetool.php#L52)
-
-
-
 ### cachetool_options
-[Source](/contrib/cachetool.php#L66)
+[Source](/contrib/cachetool.php#L58)
 
 
 
 
 ## Tasks
 ### cachetool:clear:apc
-[Source](/contrib/cachetool.php#L80)
+[Source](/contrib/cachetool.php#L72)
 
 
 
 ### cachetool:clear:opcache
-[Source](/contrib/cachetool.php#L88)
+[Source](/contrib/cachetool.php#L80)
 
 Clear opcache cache
 
 ### cachetool:clear:apcu
-[Source](/contrib/cachetool.php#L96)
+[Source](/contrib/cachetool.php#L88)
 
 Clear APCU cache
 
 ### cachetool:clear:stat
-[Source](/contrib/cachetool.php#L104)
+[Source](/contrib/cachetool.php#L96)
 
 Clear file status cache, including the realpath cache
 


### PR DESCRIPTION
Fixed resolving of cachetool binary.

- [x] Bug fix #2275 and https://github.com/deployphp/recipes/issues/238
- [ ] New feature
- [ ] BC breaks
- [ ] Deprecations
- [ ] Tests added
- [x] Changelog updated