### PR TITLE
Safety to avoid modifying files outside deploy_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Added support for placeholders in `run()` func.
 - Added support for secret passing in `run()` func without outputting to logs.
 - Added docker-based E2E testing environment. [#2197]
-- Added safety to avoid modifying files outside deploy_path
+- Added safety to avoid modifying files outside deploy_path.
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added support for placeholders in `run()` func.
 - Added support for secret passing in `run()` func without outputting to logs.
 - Added docker-based E2E testing environment. [#2197]
+- Added safety to avoid modifying files outside deploy_path
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.

--- a/docs/recipe/deploy/writable.md
+++ b/docs/recipe/deploy/writable.md
@@ -17,6 +17,7 @@
   * [`writable_recursive`](#writable_recursive)
   * [`writable_chmod_mode`](#writable_chmod_mode)
   * [`writable_chmod_recursive`](#writable_chmod_recursive)
+  * [`writable_allow_absolute_path`](#writable_allow_absolute_path)
 * Tasks
   * [`deploy:writable`](#deploywritable) — Make writable dirs
 
@@ -61,10 +62,15 @@ For chmod mode
 
 For chmod mode only (if is boolean, it has priority over `writable_recursive`)
 
+### writable_allow_absolute_path
+[Source](/recipe/deploy/writable.php#L43)
+
+Allow absolute path in writable_dirs
+
 
 ## Tasks
 ### deploy:writable
-[Source](/recipe/deploy/writable.php#L44)
+[Source](/recipe/deploy/writable.php#L46)
 
 
 

--- a/docs/recipe/deploy/writable.md
+++ b/docs/recipe/deploy/writable.md
@@ -17,7 +17,6 @@
   * [`writable_recursive`](#writable_recursive)
   * [`writable_chmod_mode`](#writable_chmod_mode)
   * [`writable_chmod_recursive`](#writable_chmod_recursive)
-  * [`writable_allow_absolute_path`](#writable_allow_absolute_path)
 * Tasks
   * [`deploy:writable`](#deploywritable) — Make writable dirs
 
@@ -61,11 +60,6 @@ For chmod mode
 [Source](https://github.com/deployphp/deployer/search?q=%22writable_chmod_recursive%22+in%3Afile+language%3Aphp+path%3Arecipe%2Fdeploy+filename%3Awritable.php)
 
 For chmod mode only (if is boolean, it has priority over `writable_recursive`)
-
-### writable_allow_absolute_path
-[Source](/recipe/deploy/writable.php#L43)
-
-Allow absolute path in writable_dirs
 
 
 ## Tasks

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -39,12 +39,16 @@ set('writable_chmod_mode', '0755');
 // For chmod mode only (if is boolean, it has priority over `writable_recursive`)
 set('writable_chmod_recursive', true);
 
+// Allow absolute path in writable_dirs
+set('writable_allow_absolute_path', false);
 
 desc('Make writable dirs');
 task('deploy:writable', function () {
-    // Safety to avoid modifying files outside the deploy_path
-    $safeDirs = array_map(function($v) { return ltrim($v, '/'); }, get('writable_dirs'));
-    $dirs = join(' ', $safeDirs);
+    // Without writable_allow_absolute_path we prefix each writable_dir whith deploy_path
+    // to avoid changing files outside the deploy_path
+    $path = get('writable_allow_absolute_path') ? ' ' : ' ' . get('deploy_path');
+    $dirs = $path . join($path, get('writable_dirs'));
+
     $mode = get('writable_mode');
     $sudo = get('writable_use_sudo') ? 'sudo' : '';
     $httpUser = get('http_user');

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -45,8 +45,6 @@ task('deploy:writable', function () {
     // Safety to avoid modifying files outside the deploy_path
     $safeDirs = array_map(function($v) { return ltrim($v, '/'); }, get('writable_dirs'));
     $dirs = join(' ', $safeDirs);
-
-    $dirs = join(' ', get('writable_dirs'));
     $mode = get('writable_mode');
     $sudo = get('writable_use_sudo') ? 'sudo' : '';
     $httpUser = get('http_user');

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -42,6 +42,10 @@ set('writable_chmod_recursive', true);
 
 desc('Make writable dirs');
 task('deploy:writable', function () {
+    // Safety to avoid modifying files outside the deploy_path
+    $safeDirs = array_map(function($v) { return ltrim($v, '/'); }, get('writable_dirs'));
+    $dirs = join(' ', $safeDirs);
+
     $dirs = join(' ', get('writable_dirs'));
     $mode = get('writable_mode');
     $sudo = get('writable_use_sudo') ? 'sudo' : '';

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -46,7 +46,7 @@ desc('Make writable dirs');
 task('deploy:writable', function () {
     // Without writable_allow_absolute_path we prefix each writable_dir whith deploy_path
     // to avoid changing files outside the deploy_path
-    $path = get('writable_allow_absolute_path') ? ' ' : ' ' . get('deploy_path');
+    $path = get('writable_allow_absolute_path') ? ' ' : ' ' . get('deploy_path') . '/';
     $dirs = $path . join($path, get('writable_dirs'));
 
     $mode = get('writable_mode');

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -37,22 +37,19 @@ set('writable_chmod_mode', '0755');
 // For chmod mode only (if is boolean, it has priority over `writable_recursive`)
 set('writable_chmod_recursive', true);
 
-// Allow absolute path in writable_dirs
-set('writable_allow_absolute_path', false);
-
 desc('Make writable dirs');
 task('deploy:writable', function () {
-    // Without writable_allow_absolute_path we prefix each writable_dir whith deploy_path
-    // to avoid changing files outside the deploy_path
-    $path = get('writable_allow_absolute_path') ? ' ' : ' ' . get('deploy_path') . '/';
-    $dirs = $path . join($path, get('writable_dirs'));
-
+    $dirs = join(' ', get('writable_dirs'));
     $mode = get('writable_mode');
     $sudo = get('writable_use_sudo') ? 'sudo' : '';
     $httpUser = get('http_user');
 
     if (empty($dirs)) {
         return;
+    }
+    // Check that we don't have absolute path
+    if (strpos($dirs, ' /') !== false) {
+        throw new \RuntimeException('Absolute path not allowed in config parameter `writable_dirs`.');
     }
 
     cd('{{release_path}}');


### PR DESCRIPTION
Using writable_dirs with writable_use_sudo can lead to a disaster on a server (example using /var/log instead of var/log as writable dir).

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
