### PR TITLE
Refresh composer binary version according to 'composer_version' or 'composer_channel'

### DIFF
--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -26,7 +26,7 @@ set('bin/composer', function () {
     $composerVersionToInstall = get('composer_version', null);
     $composerChannelToInstall = get('composer_channel', null);
     $composerValidChannels = ['stable', 'snapshot', 'preview', '1', '2',];
-    if (!in_array((string)$composerChannelToInstall, $composerValidChannels, true)) {
+    if ($composerChannelToInstall && !in_array((string)$composerChannelToInstall, $composerValidChannels, true)) {
         throw new \Exception('Selected Composer channel ' . $composerChannelToInstall . ' is not valid. Valid channels are: ' . implode(', ', $composerValidChannels));
     }
 
@@ -40,7 +40,7 @@ set('bin/composer', function () {
     }
 
     if ($composerBin) {
-        $currentComposerVersionRaw = run('{{bin/php}} ' . $composerBin . ' --version');
+        $currentComposerVersionRaw = run($composerBin . ' --version');
         if (preg_match('/(\\d+\\.\\d+)(\\.\\d+)?-?(RC|alpha|beta|dev)?\d*/', $currentComposerVersionRaw, $composerVersionMatches)) {
             $currentComposerVersion = $composerVersionMatches[0] ?? null;
             if ($currentComposerVersion) {

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -24,11 +24,7 @@ set('composer_channel', null);
 
 set('bin/composer', function () {
     $composerVersionToInstall = get('composer_version', null);
-    $composerChannelToInstall = get('composer_channel', null);
-    $composerValidChannels = ['stable', 'snapshot', 'preview', '1', '2',];
-    if ($composerChannelToInstall && !in_array((string)$composerChannelToInstall, $composerValidChannels, true)) {
-        throw new \Exception('Selected Composer channel ' . $composerChannelToInstall . ' is not valid. Valid channels are: ' . implode(', ', $composerValidChannels));
-    }
+    $composerChannelToInstall = get('composer_channel', 'stable');
 
     $composerBin = null;
     if (commandExist('composer')) {

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -32,11 +32,11 @@ set('bin/composer', function () {
 
     $composerBin = null;
     if (commandExist('composer')) {
-        $composerBin = '{{bin/php} ' . locateBinaryPath('composer');
+        $composerBin = '{{bin/php}} ' . locateBinaryPath('composer');
     }
 
     if (test('[ -f {{deploy_path}}/.dep/composer.phar ]')) {
-        $composerBin = '{{bin/php} {{deploy_path}}/.dep/composer.phar';
+        $composerBin = '{{bin/php}} {{deploy_path}}/.dep/composer.phar';
     }
 
     if ($composerBin) {

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -32,11 +32,11 @@ set('bin/composer', function () {
 
     $composerBin = null;
     if (commandExist('composer')) {
-        $composerBin = locateBinaryPath('composer');
+        $composerBin = '{{bin/php} ' . locateBinaryPath('composer');
     }
 
     if (test('[ -f {{deploy_path}}/.dep/composer.phar ]')) {
-        $composerBin = '{{deploy_path}}/.dep/composer.phar';
+        $composerBin = '{{bin/php} {{deploy_path}}/.dep/composer.phar';
     }
 
     if ($composerBin) {
@@ -45,7 +45,7 @@ set('bin/composer', function () {
             $currentComposerVersion = $composerVersionMatches[0] ?? null;
             if ($currentComposerVersion) {
                 if ($composerVersionToInstall && $currentComposerVersion === (string)$composerVersionToInstall) {
-                    return '{{bin/php} ' . $composerBin;
+                    return $composerBin;
                 }
                 if ($composerChannelToInstall && !$composerVersionToInstall) {
                     if (preg_match('/\\+(.*)\\)/', $currentComposerVersionRaw, $snapshotVersion)) {
@@ -54,7 +54,7 @@ set('bin/composer', function () {
                     $composerChannelData = json_decode(file_get_contents('https://getcomposer.org/versions'), true);
                     $latestComposerVersionFromChannel = $composerChannelData[$composerChannelToInstall][0]['version'] ?? null;
                     if ($latestComposerVersionFromChannel && $latestComposerVersionFromChannel === $currentComposerVersion) {
-                        return '{{bin/php} ' . $composerBin;
+                        return $composerBin;
                     }
                 }
             }

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -36,17 +36,24 @@ set('bin/composer', function () {
     }
 
     if ($composerBin) {
+        // "composer --version" can return:
+        // - "Composer version 1.10.17 2020-10-30 22:31:58" - for stable channel
+        // - "Composer version 2.0.0-alpha3 2020-10-30 22:31:58" - alpha/beta/RC for preview channel
+        // - "Composer version 2.0-dev (2.0-dev+378a5b72b9f81e8e919e41ecd3add6893d14b90e) 2020-12-04 09:50:19" - for snapshot channel
         $currentComposerVersionRaw = run($composerBin . ' --version');
         if (preg_match('/(\\d+\\.\\d+)(\\.\\d+)?-?(RC|alpha|beta|dev)?\d*/', $currentComposerVersionRaw, $composerVersionMatches)) {
             $currentComposerVersion = $composerVersionMatches[0] ?? null;
             if ($currentComposerVersion) {
+                // if we have exact version of composer to install (composer_version) and currently installed version match it then return
                 if ($composerVersionToInstall && $currentComposerVersion === (string)$composerVersionToInstall) {
                     return $composerBin;
                 }
                 if ($composerChannelToInstall && !$composerVersionToInstall) {
+                    // for snapshot channel the version is the git hash in "Composer version 2.0-dev (2.0-dev+378a5b72b9f81e8e919e41ecd3add6893d14b90e) 2020-12-04 09:50:19"
                     if (preg_match('/\\+(.*)\\)/', $currentComposerVersionRaw, $snapshotVersion)) {
                         $currentComposerVersion = $snapshotVersion[1] ?? null;
                     }
+                    // Compare latest version of composer channel with and currently installed version. If match then return.
                     $composerChannelData = json_decode(file_get_contents('https://getcomposer.org/versions'), true);
                     $latestComposerVersionFromChannel = $composerChannelData[$composerChannelToInstall][0]['version'] ?? null;
                     if ($latestComposerVersionFromChannel && $latestComposerVersionFromChannel === $currentComposerVersion) {

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -20,11 +20,11 @@ set('composer_version', null);
 /**
  * Set this variable to stable, snapshot, preview, 1 or 2 to select which Composer channel to use
  */
-set('composer_channel', null);
+set('composer_channel', 'stable');
 
 set('bin/composer', function () {
-    $composerVersionToInstall = get('composer_version', null);
-    $composerChannelToInstall = get('composer_channel', 'stable');
+    $composerVersionToInstall = get('composer_version');
+    $composerChannelToInstall = get('composer_channel');
 
     $composerBin = null;
     if (commandExist('composer')) {


### PR DESCRIPTION
https://github.com/deployphp/deployer/pull/2265#issuecomment-736771912

- [ ] Bug fix #…?
- [x ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

I think we need to set at least 'composer_channel' to '2' or 'stable'. Otherwise we can not know to what channel compare the currently installed composer version. This is why if both 'composer_version' is null and 'composer_channel' is null the script will download composer each time. 
When you set 'composer_version' or 'composer_channel' everything is working as expected.
