### PR TITLE
Fix dep init outside of git

### DIFF
--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -61,7 +61,7 @@ class InitCommand extends Command
         $template = $io->choice('Select project template', $this->recipes(), 'common');
 
         // Repo
-        $default = false;
+        $default = '';
         try {
             $process = Process::fromShellCommandline('git remote get-url origin');
             $default = $process->mustRun()->getOutput();
@@ -86,7 +86,7 @@ class InitCommand extends Command
         }
 
         // Project
-        $default = false;
+        $default = '';
         try {
             $process = Process::fromShellCommandline('basename "$PWD"');
             $default = $process->mustRun()->getOutput();


### PR DESCRIPTION
If it is set to null, an error will occur in other processing,
 so it was initialized with an empty string.

SymfonyStyle#ask is v5 with type-hint added.
`$default` is ?string so bool is not acceptable.

https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Console/Style/SymfonyStyle.php#L267

### error message

```sh
$ dep init
 Select recipe language [php]:
  [0] php
  [1] yaml
 > 1

 Select project template [common]:
  [0 ] cakephp
  [1 ] codeigniter
  [2 ] common
...
 > 2

 TypeError  in SymfonyStyle.php on line 257:

  Symfony\Component\Console\Style\SymfonyStyle::ask(): Argument #2 ($default) must be of type ?string, bool given, called in phar:///src/deployer.phar/src/Command/InitCommand.php on line 71
```

- [x] Bug fix no issues
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?
  - I haven't written a CHANGELOG because it's a very minor fix, but I'll write it if necessary.

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
