### PR TITLE
Add support for Symfony 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.4.5...master](https://github.com/deployphp/deployer/compare/v6.4.5...master)
+
+### Fixed
+- Add Symfony 5+ support
+
+
 ## v6.4.5
 [v6.4.4...v6.4.5](https://github.com/deployphp/deployer/compare/v6.4.4...v6.4.5)
 

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "php": ">=7.2.5",
         "deployer/phar-update": "~2.1",
         "pimple/pimple": "~3.0",
-        "symfony/console": "~2.7|~3.0|~4.0",
-        "symfony/process": "~2.7|~3.0|~4.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0"
+        "symfony/console": "~2.7|~3.0|~4.0|~5.0",
+        "symfony/process": "~2.7|~3.0|~4.0|~5.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0|~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4.3"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "112321f3a7b05ab4cba5042c398ac1c4",
+    "content-hash": "cde387b0950d8a56b6f93df8799b1229",
     "packages": [
         {
             "name": "deployer/phar-update",
@@ -60,6 +60,7 @@
                 "phar",
                 "update"
             ],
+            "abandoned": true,
             "time": "2018-02-27T17:29:10+00:00"
         },
         {


### PR DESCRIPTION
This PR fixes the following error when deployer is installed as a dependency (not standalone) on an SF5 project.

> deployer/deployer v6.8.1 requires symfony/console ~2.7|~3.0|~4.0 -> found symfony/console[v2.7.0, ..., v2.8.52, v3.0.0, ..., v3.4.47, v4.0.0, ..., v4.4.17] but it conflicts with your root composer.json require (5.2.*).

