### PR TITLE
Introduce sendfile command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.phar
 .phpunit.result.cache
 docker-compose.override.yml
+.php_cs.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added support for secret passing in `run()` func without outputting to logs.
 - Added docker-based E2E testing environment. [#2197]
 - Added support for PHP8.
+- Added sendfile command.
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.

--- a/src/Command/SendFileCommand.php
+++ b/src/Command/SendFileCommand.php
@@ -118,15 +118,35 @@ class SendFileCommand extends Command
 
         $scpOptions = $input->getOption('scpOptions');
 
+        $verbosity = $this->determineVerbosity($output);
+
         foreach ($hosts as $host) {
             $port = '';
 
             if ($host->has('port')) {
-                $port = "-P {$host->getPort()}";
+                $port = " -P {$host->getPort()}";
             }
+
             $connectionString = $host->getConnectionString();
-            passthru("scp $scpOptions $port $source $connectionString:$deployPath");
+
+            $command = "scp$verbosity$port $source $connectionString:$deployPath";
+
+            if ($output->getVerbosity() != OutputInterface::VERBOSITY_QUIET) {
+                $output->writeln("Executing: $command");
+            }
+
+            passthru($command);
         }
+
         return 0;
+    }
+
+    protected function determineVerbosity(OutputInterface $output): string
+    {
+        if ($output->getVerbosity() == OutputInterface::VERBOSITY_DEBUG) {
+            return ' -v ';
+        }
+
+        return '';
     }
 }

--- a/src/Command/SendFileCommand.php
+++ b/src/Command/SendFileCommand.php
@@ -43,6 +43,11 @@ class SendFileCommand extends SelectCommand
             'Source'
         );
         $this->addArgument(
+            'selector',
+            InputArgument::REQUIRED,
+            'One or more target hosts where the file should be sent to'
+        );
+        $this->addArgument(
             'hostname',
             InputArgument::OPTIONAL,
             'Hostname'

--- a/src/Command/SendFileCommand.php
+++ b/src/Command/SendFileCommand.php
@@ -21,15 +21,14 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 /**
  * @codeCoverageIgnore
  */
-class SendFileCommand extends Command
+class SendFileCommand extends SelectCommand
 {
     use CommandCommon;
-
-    private $deployer;
+    use CustomOption;
 
     public function __construct(Deployer $deployer)
     {
-        parent::__construct('sendfile');
+        parent::__construct('sendfile', $deployer);
 
         $this->setDescription('Send a file to given host(s)');
 

--- a/src/Command/SendFileCommand.php
+++ b/src/Command/SendFileCommand.php
@@ -11,7 +11,6 @@ use Deployer\Component\Ssh\Client;
 use Deployer\Deployer;
 use Deployer\Host\Host;
 use Deployer\Host\Localhost;
-use Deployer\Task\Context;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -103,25 +102,18 @@ class SendFileCommand extends Command
             }
         }
 
-        $shell_path = 'exec $SHELL -l';
-
-        if ($host->has('shell_path')) {
-            $shell_path = 'exec ' . $host->get('shell_path') . ' -l';
-        }
-
-        Context::push(new Context($host, $input, $output));
-        if ($input->getOption('targetPath')) {
-            $deployPath = $input->getOption('targetPath');
-        } else {
-            $deployPath = $host->get('deploy_path', '~');
-        }
-
         $scpOptions = $input->getOption('scpOptions');
 
         $verbosity = $this->determineVerbosity($output);
 
         foreach ($hosts as $host) {
             $port = '';
+
+            if ($input->getOption('targetPath')) {
+                $deployPath = $input->getOption('targetPath');
+            } else {
+                $deployPath = $host->get('deploy_path', '~');
+            }
 
             if ($host->has('port')) {
                 $port = " -P {$host->getPort()}";

--- a/src/Command/SendFileCommand.php
+++ b/src/Command/SendFileCommand.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+/* (c) Herbert Maschke <thyseus@pm.me>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Command;
+
+use Deployer\Component\Ssh\Client;
+use Deployer\Deployer;
+use Deployer\Host\Host;
+use Deployer\Host\Localhost;
+use Deployer\Task\Context;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption as Option;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+/**
+ * @codeCoverageIgnore
+ */
+class SendFileCommand extends Command
+{
+    use CommandCommon;
+
+    private $deployer;
+
+    public function __construct(Deployer $deployer)
+    {
+        parent::__construct('sendfile');
+
+        $this->setDescription('Send a file to given host(s)');
+
+        $this->deployer = $deployer;
+    }
+
+    protected function configure()
+    {
+        $this->addArgument(
+            'source',
+            InputArgument::REQUIRED,
+            'Source'
+        );
+        $this->addArgument(
+            'hostname',
+            InputArgument::OPTIONAL,
+            'Hostname'
+        );
+        $this->addOption(
+            'targetPath',
+            '-t',
+            InputArgument::OPTIONAL,
+            'Path on the host. Defaults to deploy_path of host'
+        );
+        $this->addOption(
+            'scpOptions',
+            null,
+            InputArgument::OPTIONAL,
+            'Options to be passed to the scp command'
+        );
+    }
+
+    protected function ensureFile(string $source): void
+    {
+        if (!file_exists($source)) {
+            $this->deployer->output->writeln("<error>Error:</error> Source file <info>$source</info> does not exist.");
+            exit(1);
+        }
+
+        if (!is_readable($source)) {
+            $this->deployer->output->writeln("<error>Error:</error> Source file <info>$source</info> is not readable.");
+            exit(1);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->deployer->input = $input;
+        $this->deployer->output = $output;
+
+        $hostname = $input->getArgument('hostname');
+        $source = $input->getArgument('source');
+
+        $this->ensureFile($source);
+
+        if (!empty($hostname)) {
+            $host = $this->deployer->hosts->get($hostname);
+        } else {
+            $hostsAliases = [];
+            foreach ($this->deployer->hosts as $host) {
+                if ($host instanceof Localhost) {
+                    continue;
+                }
+                $hostsAliases[] = $host->getAlias();
+            }
+
+            if (count($hostsAliases) === 0) {
+                $output->writeln('No remote hosts.');
+                return 2; // Because there are no hosts.
+            }
+
+            if (count($hostsAliases) === 1) {
+                $host = current($this->deployer->hosts->all());
+            } else {
+                $helper = $this->getHelper('question');
+                $question = new ChoiceQuestion(
+                    '<question>Select host:</question>',
+                    $hostsAliases
+                );
+                $question->setErrorMessage('There is no "%s" host.');
+
+                $hostname = $helper->ask($input, $output, $question);
+                $host = $this->deployer->hosts->get($hostname);
+            }
+        }
+
+        $shell_path = 'exec $SHELL -l';
+
+        if ($host->has('shell_path')) {
+            $shell_path = 'exec ' . $host->get('shell_path') . ' -l';
+        }
+
+        Context::push(new Context($host, $input, $output));
+        if ($input->getOption('targetPath')) {
+            $deployPath = $input->getOption('targetPath');
+        } else {
+            $deployPath = $host->get('deploy_path', '~');
+        }
+
+        $port = "-P {$host->getPort()}";
+        $scpOptions = $input->getOption('scpOptions');
+
+        passthru("scp $scpOptions $port $source {$host->getConnectionString()}:$deployPath");
+        return 0;
+    }
+}

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -15,6 +15,7 @@ use Deployer\Command\DiceCommand;
 use Deployer\Command\InitCommand;
 use Deployer\Command\MainCommand;
 use Deployer\Command\RunCommand;
+use Deployer\Command\SendFileCommand;
 use Deployer\Command\SshCommand;
 use Deployer\Command\TreeCommand;
 use Deployer\Command\WorkerCommand;
@@ -211,6 +212,7 @@ class Deployer extends Container
         $this->getConsole()->add(new DiceCommand());
         $this->getConsole()->add(new InitCommand());
         $this->getConsole()->add(new TreeCommand($this));
+        $this->getConsole()->add(new SendFileCommand($this));
         $this->getConsole()->add(new SshCommand($this));
         $this->getConsole()->add(new RunCommand($this));
         if (self::isPharArchive()) {
@@ -287,7 +289,6 @@ class Deployer extends Container
             // Run Deployer
             $deployer->init();
             $console->run($input, $output);
-
         } catch (Throwable $exception) {
             if (str_contains("$input", "-vvv")) {
                 $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);


### PR DESCRIPTION
This PR adds a "sendfile" command which allows to quickly "deploy" a single file to a single or multiple configured hosts.
This can be handy for hotfixes which needs to be deployed immediately or for using deployer as managing tool for multiple servers.
It is simply a wrapper for scp.

- [X] New feature?
- [X] Changelog updated?