### PR TITLE
Local composer should take precedence over global composer

### DIFF
--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -10,12 +10,12 @@ set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction 
 // composer version to `.dep/composer.phar`. To use specific composer version
 // download desired phar and place it at `.dep/composer.phar`.
 set('bin/composer', function () {
-    if (commandExist('composer')) {
-        return '{{bin/php}} ' . locateBinaryPath('composer');
-    }
-
     if (test('[ -f {{deploy_path}}/.dep/composer.phar ]')) {
         return '{{bin/php}} {{deploy_path}}/.dep/composer.phar';
+    }
+
+    if (commandExist('composer')) {
+        return '{{bin/php}} ' . locateBinaryPath('composer');
     }
 
     warning("Composer binary wasn't found. Installing latest composer to \"{{deploy_path}}/.dep/composer.phar\".");


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ X] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog

I cannot run `php bin/changelog` because I have PHP 7.2 installed (and PHP 7.3 is required).