### PR TITLE
Boolean options should not go through the `self::escape` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Lots, and lots of long-standing bugs.
 - Fixed incorrect plugin:list parsing (remove duplicate version column). Invoke nested sw:plugin:refresh task instead of redefining it, so that it actually runs.
 - Shopware activates/runs migration in order (respects dependencies in composer.json). [#2423] [#2425]
+- Boolean options should not go through the `self::escape` function. [#2392]
 
 
 ## v6.8.0
@@ -601,6 +602,7 @@
 
 [#2425]: https://github.com/deployphp/deployer/pull/2425
 [#2423]: https://github.com/deployphp/deployer/issues/2423
+[#2392]: https://github.com/deployphp/deployer/issues/2392
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/src/Support/Stringify.php
+++ b/src/Support/Stringify.php
@@ -32,6 +32,11 @@ class Stringify
                 $option = [$option];
             }
             foreach ($option as $value) {
+                if(is_bool($value)){
+                    $options[] = "--$name ";
+                    continue;
+                }
+
                 $options[] = "--$name " . self::escape($value);
             }
         }

--- a/test/src/Support/StringifyTest.php
+++ b/test/src/Support/StringifyTest.php
@@ -26,10 +26,11 @@ class StringifyTest extends TestCase
             new Option('start-from', null, Option::VALUE_REQUIRED, 'Start execution from this task'),
             new Option('log', null, Option::VALUE_REQUIRED, 'Write log to a file'),
             new Option('profile', null, Option::VALUE_REQUIRED, 'Write profile to a file',),
+            new Option('ansi', null, Option::VALUE_OPTIONAL, 'Force ANSI output',),
         ]);
 
-        self::assertEquals("--option 'env=prod' --limit 1 -vvv", Stringify::options(
-            new ArgvInput(['deploy', '-o', 'env=prod', '-l1'], $definition),
+        self::assertEquals("--option 'env=prod' --option ansi --limit 1 -vvv", Stringify::options(
+            new ArgvInput(['deploy', '-o', 'env=prod', '-o', 'ansi', '-l1'], $definition),
             new ConsoleOutput(Output::VERBOSITY_DEBUG, false)
         ));
     }

--- a/test/src/Support/StringifyTest.php
+++ b/test/src/Support/StringifyTest.php
@@ -29,7 +29,7 @@ class StringifyTest extends TestCase
             new Option('ansi', null, Option::VALUE_OPTIONAL, 'Force ANSI output',),
         ]);
 
-        self::assertEquals("--option 'env=prod' --ansi --limit 1 -vvv", Stringify::options(
+        self::assertEquals("--option 'env=prod' --limit 1 -vvv", Stringify::options(
             new ArgvInput(['deploy', '-o', 'env=prod', '--ansi', '-l1'], $definition),
             new ConsoleOutput(Output::VERBOSITY_DEBUG, false)
         ));

--- a/test/src/Support/StringifyTest.php
+++ b/test/src/Support/StringifyTest.php
@@ -29,8 +29,8 @@ class StringifyTest extends TestCase
             new Option('ansi', null, Option::VALUE_OPTIONAL, 'Force ANSI output',),
         ]);
 
-        self::assertEquals("--option 'env=prod' --option ansi --limit 1 -vvv", Stringify::options(
-            new ArgvInput(['deploy', '-o', 'env=prod', '-o', 'ansi', '-l1'], $definition),
+        self::assertEquals("--option 'env=prod' --ansi --limit 1 -vvv", Stringify::options(
+            new ArgvInput(['deploy', '-o', 'env=prod', '--ansi', '-l1'], $definition),
             new ConsoleOutput(Output::VERBOSITY_DEBUG, false)
         ));
     }


### PR DESCRIPTION
Dump of [$input->getOptions()](https://github.com/deployphp/deployer/commit/18bdfc8bd94a8aa408f59dac1fb9daa6a8800c8c#diff-b872a77de62f6d05e055c5c2c19e0175ad4b9f4075531eee37dcba67a6d3cea8R20):

```php
array:18 [
  "tag" => null
  "revision" => null
  "branch" => null
  "option" => []
  "limit" => null
  "no-hooks" => false
  "plan" => false
  "start-from" => null
  "log" => null
  "profile" => null
  "help" => false
  "quiet" => false
  "verbose" => false
  "version" => false
  "ansi" => true
  "no-ansi" => false
  "no-interaction" => true
  "file" => null
]
```

```diff
            foreach ($option as $value) {
+                if(is_bool($value)){
+                    $options[] = "--$name";
+                    continue;
+                }
+
                $options[] = "--$name " . self::escape((string)$value);
            }
```

Output of `Stringify::options()` before/after:
```diff
-"--ansi 1 --decorated"
+"--ansi --decorated"
```

> Deployer\Support\Stringify::escape(): Argument #1 ($token) must be of type string, bool given

**Check list**

- [x] Bug fix #2392?
- [ ] ~~New feature?~~
- [ ] ~~BC breaks?~~
- [ ] ~~Deprecations?~~
- [x] Tests added?
- [x] Changelog updated?