### PR TITLE
Fix for issue #2407 - Laravel migrations are only run on the first host

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -84,7 +84,7 @@ desc('Enable maintenance mode');
 task('artisan:down', artisan('down', ['runInCurrent', 'showOutput']));
 
 desc('Execute artisan migrate');
-task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']))->once();
+task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']));
 
 desc('Execute artisan migrate:fresh');
 task('artisan:migrate:fresh', artisan('migrate:fresh --force'));


### PR DESCRIPTION
Fix for issue #2407 - Laravel migrations are only run on the first host due there being a `->once` on the task

- [x] Bug fix #2407?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
