### PR TITLE
Fix for option without value

### DIFF
--- a/test/src/Support/StringifyTest.php
+++ b/test/src/Support/StringifyTest.php
@@ -32,5 +32,10 @@ class StringifyTest extends TestCase
             new ArgvInput(['deploy', '-o', 'env=prod', '-l1'], $definition),
             new ConsoleOutput(Output::VERBOSITY_DEBUG, false)
         ));
+
+        self::assertEquals("--plan", Stringify::options(
+            new ArgvInput(['deploy', '--plan'], $definition),
+            new ConsoleOutput(Output::VERBOSITY_DEBUG, false)
+        ));
     }
 }


### PR DESCRIPTION
- [x] Bug fix #2364?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [x] Tests added?
- [ ] Changelog updated?

I first created a failing test and tried to solve it the problem in `Stringify.php`. Something like this:

```php
foreach ($option as $value) {
     $value = is_string($value) ? self::escape($value) : '';
     $options[] = "--$name " . self::escape($value);
}
```

But I think `Stringify::options` can be replaced by Symfony `ArrayInput` class ([docs](https://symfony.com/doc/current/console/calling_commands.html)), because that's exactly doing what you want. But maybe I'm completely wrong.