### PR TITLE
Feature/2423 shopware order modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Fixed
 - Lots, and lots of long-standing bugs.
 - Fixed incorrect plugin:list parsing (remove duplicate version column). Invoke nested sw:plugin:refresh task instead of redefining it, so that it actually runs.
+- Shopware activates/runs migration in order (respects dependencies in composer.json). [#2423] [#2425]
 
 
 ## v6.8.0
@@ -596,6 +597,8 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2425]: https://github.com/deployphp/deployer/pull/2425
+[#2423]: https://github.com/deployphp/deployer/issues/2423
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,11 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "marcj/topsort": "^2.0",
         "psr/http-message": "^1",
         "react/http": "^1",
         "symfony/console": "^5",
+        "symfony/polyfill-php80": "^1.22",
         "symfony/process": "^5",
         "symfony/yaml": "^5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d1c90e7ccb9d9d4d17949f7b79f62ef",
+    "content-hash": "0b55c4ca42847dae4cff0dc22a70162a",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -48,6 +48,68 @@
                 "event-emitter"
             ],
             "time": "2017-07-23T21:35:13+00:00"
+        },
+        {
+            "name": "marcj/topsort",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marcj/topsort.php.git",
+                "reference": "972f58e42b5f110a0a1d8433247f65248abcfd5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marcj/topsort.php/zipball/972f58e42b5f110a0a1d8433247f65248abcfd5c",
+                "reference": "972f58e42b5f110a0a1d8433247f65248abcfd5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "phpunit/phpunit": "^9",
+                "symfony/console": "~2.5 || ~3.0 || ~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MJS\\TopSort\\": "src/",
+                    "MJS\\TopSort\\Tests\\": "tests/Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marc J. Schmidt",
+                    "email": "marc@marcjschmidt.de"
+                }
+            ],
+            "description": "High-Performance TopSort/Dependency resolving algorithm",
+            "keywords": [
+                "dependency resolving",
+                "topological sort",
+                "topsort"
+            ],
+            "support": {
+                "issues": "https://github.com/marcj/topsort.php/issues",
+                "source": "https://github.com/marcj/topsort.php/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/marcj",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-24T12:39:55+00:00"
         },
         {
             "name": "psr/container",
@@ -1309,16 +1371,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
                 "shasum": ""
             },
             "require": {
@@ -1327,7 +1389,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1371,6 +1433,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1385,7 +1450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/process",
@@ -4386,5 +4451,5 @@
         "php": ">=7.2.5"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -2,8 +2,6 @@
 
 namespace Deployer;
 
-require_once __DIR__ . '/vendor/autoload.php';
-
 use MJS\TopSort\Implementations\FixedArraySort;
 
 add('recipes', ['shopware']);

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -1,5 +1,10 @@
 <?php
+
 namespace Deployer;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use MJS\TopSort\Implementations\FixedArraySort;
 
 add('recipes', ['shopware']);
 
@@ -57,25 +62,79 @@ task('sw:cache:warmup', static function () {
 task('sw:database:migrate', static function () {
     run('cd {{release_path}} && bin/console database:migrate --all');
 });
-task('sw:plugin:refresh', function (){
+task('sw:plugin:refresh', function () {
     run('cd {{release_path}} && bin/console plugin:refresh');
 });
-task('sw:plugin:activate:all', static function () {
-    invoke('sw:plugin:refresh');
-    $plugins = explode("\n", run('cd {{release_path}} && bin/console plugin:list'));
+/**
+ * @return array
+ * @throws \MJS\TopSort\CircularDependencyException
+ * @throws \MJS\TopSort\ElementNotFoundException
+ */
+function getSortedPlugins(): array
+{
+    cd('{{release_path}}');
+    $plugins = explode("\n", run('bin/console plugin:list'));
 
     // take line over headlines and count "-" to get the size of the cells
     $lengths = array_filter(array_map('strlen', explode(' ', $plugins[4])));
 
     // ignore first seven lines (headline, title, table, ...)
     $plugins = array_slice($plugins, 7, -3);
+    $parsedPlugins = [];
     foreach ($plugins as $plugin) {
         $pluginParts = [];
         foreach ($lengths as $length) {
             $pluginParts[] = trim(substr($plugin, 0, $length));
             $plugin = substr($plugin, $length + 1);
         }
+        $parsedPlugins[$pluginParts[0]] = $pluginParts;
+    }
 
+    $composer = json_decode(run('cat composer.lock'), true);
+
+    $pluginMapping = $dependencies = [];
+    foreach ($parsedPlugins as $plugin) {
+        $pluginName = $plugin[0];
+        // collect cpmposer plugin names
+        foreach ($composer['packages'] as $config) {
+            if (!isset($config['extra']['shopware-plugin-class'])) {
+                // we only collect a mapping for shopware modules name <-> composer name
+                continue;
+            }
+            if (str_ends_with($config['extra']['shopware-plugin-class'], $pluginName)) {
+                $pluginMapping[$config['name']] = $pluginName;
+            }
+        }
+
+        // collect dependencies
+        foreach ($composer['packages'] as $config) {
+            if (!isset($pluginMapping[$config['name']])) {
+                // if the composer.json doesn't belong to a shopware module
+                // or doesn't have dependencies, ignore it
+                continue;
+            }
+            $dependencies[$config['name']] = array_filter(array_keys($config['require'] ?? []),
+                static function ($composerName) use ($pluginMapping) {
+                    // only add dependencies between shopware modules
+                    return isset($pluginMapping[$composerName]);
+                });
+        }
+    }
+
+    $sorter = new FixedArraySort();
+    foreach ($dependencies as $name => $dep) {
+        $sorter->add($name, $dep);
+    }
+
+    return array_map(static function ($name) use ($parsedPlugins, $pluginMapping) {
+        return $parsedPlugins[$pluginMapping[$name]];
+    }, $sorter->sort());
+}
+
+task('sw:plugin:activate:all', static function () {
+    invoke('sw:plugin:refresh');
+
+    foreach (getSortedPlugins() as $pluginInfo) {
         [
             $plugin,
             $label,
@@ -85,28 +144,17 @@ task('sw:plugin:activate:all', static function () {
             $installed,
             $active,
             $upgradeable,
-        ] = $pluginParts;
+        ] = $pluginInfo;
 
         if ($installed === 'No' || $active === 'No') {
             run("cd {{release_path}} && bin/console plugin:install --activate $plugin");
         }
     }
 });
-task('sw:plugin:migrate:all', static function(){
-    $plugins = explode("\n", run('cd {{release_path}} && bin/console plugin:list'));
 
-    // take line over headlines and count "-" to get the size of the cells
-    $lengths = array_filter(array_map('strlen', explode(' ', $plugins[4])));
-
-    // ignore first seven lines (headline, title, table, ...)
-    $plugins = array_slice($plugins, 7, -3);
-    foreach ($plugins as $plugin) {
-        $pluginParts = [];
-        foreach ($lengths as $length) {
-            $pluginParts[] = trim(substr($plugin, 0, $length));
-            $plugin = substr($plugin, $length + 1);
-        }
-
+task('sw:plugin:migrate:all', static function () {
+    invoke('sw:plugin:refresh');
+    foreach (getSortedPlugins() as $pluginInfo) {
         [
             $plugin,
             $label,
@@ -116,7 +164,7 @@ task('sw:plugin:migrate:all', static function(){
             $installed,
             $active,
             $upgradeable,
-        ] = $pluginParts;
+        ] = $pluginInfo;
 
         if ($installed === 'Yes' || $active === 'Yes') {
             run("cd {{release_path}} && bin/console database:migrate --all $plugin || true");


### PR DESCRIPTION
- [X] Bug fix #2423 ?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [X] Changelog updated?

This PR reads the dependency infos of shopware modules from composer.lock and sorts the modules according to the `require` dependencies before activating/migration them.

@peterjaap please have a look for the content
@antonmedv I See no way around marcj/topsort, but for PHP8 I only need `str_ends_with`, so in theory we could implement this method on our own and remove the dependency on polyfill80.