### PR TITLE
#2427 deployer:push Can't open user config file ~/.ssh/config: No suc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Fixed
 - Lots, and lots of long-standing bugs.
 - Fixed incorrect plugin:list parsing (remove duplicate version column). Invoke nested sw:plugin:refresh task instead of redefining it, so that it actually runs.
+- Rsync finds ssh_config if path contains ~. [#2427] [#2428]
 
 
 ## v6.8.0
@@ -596,6 +597,8 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2428]: https://github.com/deployphp/deployer/pull/2428
+[#2427]: https://github.com/deployphp/deployer/issues/2427
 [#2197]: https://github.com/deployphp/deployer/issues/2197
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -196,7 +196,11 @@ class Client
         }
 
         if ($host->has('config_file')) {
-            $options .= " -F " . $host->getConfigFile();
+            if (\Deployer\Support\str_contains($host->getConfigFile(), '~')) {
+                $options .= " -F `realpath " . $host->getConfigFile() . '`';
+            } else {
+                $options .= " -F " . $host->getConfigFile();
+            }
         }
 
         if ($host->has('identity_file')) {

--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -53,7 +53,7 @@ class Rsync
 
         $connectionOptions = Client::connectionOptions($host);
         if ($connectionOptions !== '') {
-            $options[] = "-e 'ssh $connectionOptions'";
+            $options[] = "-e \"ssh $connectionOptions\"";
         }
 
         if ($host->has("become")) {

--- a/test/src/Component/Ssh/ClientTest.php
+++ b/test/src/Component/Ssh/ClientTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Component\Ssh;
+
+use Deployer\Host\Host;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    private function createHostMock($sshConfig)
+    {
+        /** @var MockObject|Host $host */
+        $host = $this->createMock(Host::class);
+        $host->method('getConfigFile')->willReturn($sshConfig);
+
+        $host->method('has')->withAnyParameters()->willReturnCallback(static function ($parameter) {
+            if ($parameter === 'config_file') {
+                return true;
+            }
+            return false;
+        });
+
+        return $host;
+    }
+
+    public function testSshConfigDoesNotUseTilde(): void
+    {
+        $sshOptions = Client::connectionOptions($this->createHostMock('/some/path'));
+        $this->assertStringContainsString('-F /some/path', $sshOptions);
+        $this->assertStringNotContainsString('`realpath', $sshOptions);
+    }
+
+    public function testSshConfigWithTildeUsesRealpath(): void
+    {
+        $sshOptions = Client::connectionOptions($this->createHostMock('~/.ssh/config'));
+        $this->assertStringContainsString('-F `realpath ~/.ssh/config`', $sshOptions);
+    }
+}


### PR DESCRIPTION
- [X] Bug fix #2427?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [X] Tests added?
- [X] Changelog updated?

realpath can't use `~` in the ssh_config, therefore deployer push breaks. (more on the issue)

This fixes the problem

# BUT

I don't know wether we open any security problem by adding ` `` ` to the ssh command. Can someone with more knowledge about security and consoles have a look at that?

What I do is change
```
$ rsync [...] -F ~/.ssh/config [...]
```
to
```
$ rsync [...] -F `realpath ~/.ssh/config` [...]
```

but only if a ~ is contained in the ssh-file