### PR TITLE
Fix shared configuration file

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -24,7 +24,7 @@ set('content_version', function () {
 });
 
 set('shared_files', [
-    'app/etc/env.php',
+    'app/etc/config.php',
     'var/.maintenance.ip',
 ]);
 set('shared_dirs', [


### PR DESCRIPTION
According to the [magento2 devdocs](https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-sens.html):
*  The [`magento app:config:dump` command](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-export.html) writes system-specific settings to the system-specific configuration file, `app/etc/env.php`, which should _not_ be in source control. It also writes shared configuration for all Magento instances to `app/etc/config.php`, this file _should_ be in source control.

Therefore the only change is the shared file 'app/etc/env.php' is removed and replaced by the shared file 'app/etc/config.php'.
- [x] Bug fix #2413
- [x] New feature: no
- [x] BC breaks: no
- [x] Deprecations: no
- [x] Tests added: no 
- [ ] Changelog updated: no

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
