### PR TITLE
Remove config/jwt from writable dirs list

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -26,7 +26,6 @@ set('shared_dirs', [
 ]);
 set('writable_dirs', [
     'custom/plugins',
-    'config/jwt',
     'files',
     'var',
     'public/media',


### PR DESCRIPTION
config/jwt should have chmod 600, not 755

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
