### PR TITLE
laravel recipe -> fix shared_folders issue on inital (first) deployment

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -5,7 +5,14 @@ require_once __DIR__ . '/common.php';
 
 add('recipes', ['laravel']);
 
-set('shared_dirs', ['storage']);
+set('shared_dirs', [
+    'storage/app/public',
+    'storage/framework/cache',
+    'storage/framework/sessions',
+    'storage/framework/views',
+    'storage/logs',
+]);
+
 set('shared_files', ['.env']);
 set('writable_dirs', [
     'bootstrap/cache',


### PR DESCRIPTION
see -> https://github.com/deployphp/deployer/issues/2454


- Deployer version: latest
- Deployment OS: OSX -> ubuntu 16.04

This line is not enough anymore:

https://github.com/deployphp/deployer/blob/387b4c1d511006932a7a495b714e8b7072dd43f9/recipe/laravel.php#L8

because of your check in `shared.php`

```php
desc('Creating symlinks for shared files and dirs');
task('deploy:shared', function () {
    $sharedPath = "{{deploy_path}}/shared";

    // Validate shared_dir, find duplicates
    foreach (get('shared_dirs') as $a) {
        foreach (get('shared_dirs') as $b) {
            if ($a !== $b && strpos(rtrim($a, '/') . '/', rtrim($b, '/') . '/') === 0) {
                throw new Exception("Can not share same dirs `$a` and `$b`.");
            }
        }
    }
```

So https://github.com/deployphp/deployer/blob/387b4c1d511006932a7a495b714e8b7072dd43f9/recipe/laravel.php#L8

must be

```
set('shared_dirs', [
    'storage/app/public',
    'storage/framework/cache',
    'storage/framework/sessions',
    'storage/framework/views',
    'storage/logs',
]);
```

Otherwise on initial deployment the deployment will fail as long you do not create the directory manually via ssh.

This issue came just up to me when i made a upgrade from PHP 7.2 deployer version to PHP 7.4 latest-deployer built.

Cheers,

Stefan