### PR TITLE
Refactor shell arguments escaping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,13 @@
         ]
     },
     "scripts": {
+        "dep": "bin/dep -f deploy.yaml",
+        "release": "@dep release",
         "test": "pest",
         "test:e2e": "pest --config tests/e2e/phpunit-e2e.xml",
         "phpcs": "phpcs",
         "phpstan": "phpstan analyse -c phpstan.neon",
-        "phpstan:baseline": "phpstan analyse -c phpstan.neon --generate-baseline tests/phpstan-baseline.neon"
+        "phpstan:baseline": "@phpstan --generate-baseline tests/phpstan-baseline.neon"
     },
     "bin": [
         "bin/dep"
@@ -60,6 +62,7 @@
         "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "process-timeout": 0
     }
 }

--- a/contrib/rsync.php
+++ b/contrib/rsync.php
@@ -246,7 +246,7 @@ task('rsync', function() {
         return;
     }
 
-    $sshArguments = Client::connectionOptions($host);
+    $sshArguments = Client::connectionOptionsString($host);
     $user = !$host->getRemoteUser() ? '' : $host->getRemoteUser() . '@';
     $host = $host->getHostname();
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,5 +1,6 @@
 import:
   - src/Support/Config/version.php
+  - src/Support/Config/verification.php
 
 config:
   depl: ~/dev/deployer
@@ -10,6 +11,11 @@ hosts:
   deployer.org: ~
 
 tasks:
+  check_master:
+    local: true
+    script:
+      - "[[ $(git branch --show-current) == 'master' ]] || { echo 'Checkout master branch to release Deployer.'; exit 1; }"
+
   pull:
     script:
       - cd {{depl}}
@@ -50,5 +56,7 @@ tasks:
 
 before:
   release:
+    - check_master
     - pull
     - test
+    - verification

--- a/docs/api.md
+++ b/docs/api.md
@@ -291,7 +291,7 @@ run("echo $path");
 - ### timeout
   **type**: `int|null `
 
-   Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec; see {{default_timeout}}, `null` to disable).
+  Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec; see {{default_timeout}}, `null` to disable).
 - ### idle_timeout
   **type**: `int|null `
 
@@ -338,7 +338,7 @@ runLocally("echo $user");
 - ### timeout
   **type**: `int|null `
 
-   Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec, `null` to disable).
+  Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec, `null` to disable).
 - ### idle_timeout
   **type**: `int|null `
 

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -14,8 +14,11 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface as Input;
 use Symfony\Component\Console\Input\InputOption as Option;
 use Symfony\Component\Console\Output\OutputInterface as Output;
+use function Deployer\cd;
+use function Deployer\get;
 use function Deployer\has;
 use function Deployer\run;
+use function Deployer\writeln;
 
 class RunCommand extends SelectCommand
 {
@@ -49,19 +52,16 @@ class RunCommand extends SelectCommand
         $this->deployer->input = $input;
         $this->deployer->output = $output;
 
-        if ($output->getVerbosity() === Output::VERBOSITY_NORMAL) {
-            $output->setVerbosity(Output::VERBOSITY_VERBOSE);
-        }
-
         $command = implode('; ', $input->getOption('command') ?? '');
         $hosts = $this->selectHosts($input, $output);
         $this->applyOverrides($hosts, $input->getOption('option'));
 
         $task = new Task($command, function () use ($command) {
             if (has('current_path')) {
-                $command = "cd {{current_path}}; $command";
+                cd(get('current_path'));
             }
-            run($command);
+            $output = run($command);
+            writeln($output);
         });
 
         foreach ($hosts as $host) {

--- a/src/Command/SshCommand.php
+++ b/src/Command/SshCommand.php
@@ -85,7 +85,7 @@ class SshCommand extends Command
         }
 
         Context::push(new Context($host, $input, $output));
-        $options = Client::connectionOptions($host);
+        $options = Client::connectionOptionsString($host);
         $deployPath = $host->get('deploy_path', '~');
 
         passthru("ssh -t $options {$host->getConnectionString()} 'cd '''$deployPath/current'''; $shell_path'");

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -42,28 +42,30 @@ class Client
             'idle_timeout' => null,
             'vars' => [],
         ];
-
         $config = array_merge($defaults, $config);
-        $options = self::connectionOptions($host);
 
         // TODO: Init multiplexing again only after passing ControlPersist seconds.
         if ($host->getSshMultiplexing()) {
             $this->initMultiplexing($host);
         }
 
+        $shellId = bin2hex(random_bytes(10));
         $become = '';
         if ($host->has('become')) {
-            $become = sprintf('sudo -H -u %s', $host->get('become'));
+            $become = "sudo -H -u {$host->get('become')} ";
         }
-
-        $shellId = bin2hex(random_bytes(10));
         $shellCommand = $host->getShell();
 
-        $ssh = "ssh $options $connectionString $become " . escapeshellarg(": $shellId; $shellCommand; printf [exit_code:%s] $?;");
+        $bash = ": $shellId; $become $shellCommand";
+        $ssh = array_merge(['ssh'], self::connectionOptionsArray($host), [$connectionString, $bash]);
 
         // -vvv for ssh command
         if ($this->output->isDebug()) {
-            $this->pop->writeln(Process::OUT, $host, "$ssh");
+            $sshString = $ssh[0];
+            for ($i = 1; $i < count($ssh); $i++) {
+                $sshString .= ' ' . escapeshellarg($ssh[$i]);
+            }
+            $this->output->writeln("[$host] $sshString");
         }
 
         $this->pop->command($host, $command);
@@ -73,9 +75,9 @@ class Client
         $command = str_replace('%secret%', $config['secret'] ?? '', $command);
         $command = str_replace('%sudo_pass%', $config['sudo_pass'] ?? '', $command);
 
-        $process = Process::fromShellCommandline($ssh);
+        $process = new Process($ssh);
         $process
-            ->setInput($command)
+            ->setInput($command . "; printf '[exit_code:%s]' $?;")
             ->setTimeout($config['timeout'])
             ->setIdleTimeout($config['idle_timeout']);
 
@@ -127,7 +129,7 @@ class Client
 
     private function initMultiplexing(Host $host): void
     {
-        $options = self::connectionOptions($host);
+        $options = self::connectionOptionsString($host);
 
         if (!$this->isMasterRunning($host, $options)) {
             $connectionString = $host->getConnectionString();
@@ -183,36 +185,45 @@ class Client
         return $command;
     }
 
-    public static function connectionOptions(Host $host): string
+    public static function connectionOptionsString(Host $host): string
     {
-        $options = "";
+        return implode(' ', array_map('escapeshellarg', self::connectionOptionsArray($host)));
+    }
+
+    /**
+     * @return string[]
+     * @throws Exception
+     */
+    public static function connectionOptionsArray(Host $host): array
+    {
+        $options = [];
 
         if ($host->has('ssh_arguments')) {
-            $options .= " " . implode(' ', $host->getSshArguments());
+            $options = array_merge($options, $host->getSshArguments());
         }
 
         if ($host->has('port')) {
-            $options .= " -p " . $host->getPort();
+            $options = array_merge($options, ['-p', $host->getPort()]);
         }
 
         if ($host->has('config_file')) {
-            $options .= " -F " . $host->getConfigFile();
+            $options = array_merge($options, ['-F', $host->getConfigFile()]);
         }
 
         if ($host->has('identity_file')) {
-            $options .= " -i " . $host->getIdentityFile();
+            $options = array_merge($options, ['-i', $host->getIdentityFile()]);
         }
 
         if ($host->has('forward_agent') && $host->getForwardAgent()) {
-            $options .= " -A";
+            $options = array_merge($options, ['-A']);
         }
 
         if ($host->has('ssh_multiplexing') && $host->getSshMultiplexing()) {
-            $options .= " " . implode(' ', [
-                    '-o ControlMaster=auto',
-                    '-o ControlPersist=60',
-                    '-o ControlPath=' . self::generateControlPath($host),
-                ]);
+            $options = array_merge($options, [
+                '-o', 'ControlMaster=auto',
+                '-o', 'ControlPersist=60',
+                '-o', 'ControlPath=' . self::generateControlPath($host),
+            ]);
         }
 
         return $options;

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -77,7 +77,7 @@ class Client
 
         $process = new Process($ssh);
         $process
-            ->setInput($command . "; printf '[exit_code:%s]' $?;")
+            ->setInput("( $command ); printf '[exit_code:%s]' $?;")
             ->setTimeout($config['timeout'])
             ->setIdleTimeout($config['idle_timeout']);
 

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,7 +13,7 @@ class Exception extends \Exception
 {
     private static $taskSourceLocation = '';
     private $taskFilename = '';
-    private $taskLineNumber = '';
+    private $taskLineNumber = 0;
 
     public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
     {

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -72,7 +72,7 @@ class Host
         return $this->config->get($name, $default);
     }
 
-    public function getAlias():? string
+    public function getAlias(): ?string
     {
         return $this->config->get('alias');
     }
@@ -83,7 +83,7 @@ class Host
         return $this;
     }
 
-    public function getTag():? string
+    public function getTag(): ?string
     {
         return $this->config->get('tag', $this->generateTag());
     }
@@ -94,7 +94,7 @@ class Host
         return $this;
     }
 
-    public function getHostname():? string
+    public function getHostname(): ?string
     {
         return $this->config->get('hostname');
     }
@@ -105,7 +105,7 @@ class Host
         return $this;
     }
 
-    public function getRemoteUser():? string
+    public function getRemoteUser(): ?string
     {
         return $this->config->get('remote_user');
     }
@@ -116,7 +116,7 @@ class Host
         return $this;
     }
 
-    public function getPort():? int
+    public function getPort(): ?int
     {
         return $this->config->get('port');
     }
@@ -127,7 +127,7 @@ class Host
         return $this;
     }
 
-    public function getConfigFile():? string
+    public function getConfigFile(): ?string
     {
         return $this->config->get('config_file');
     }
@@ -138,7 +138,7 @@ class Host
         return $this;
     }
 
-    public function getIdentityFile():? string
+    public function getIdentityFile(): ?string
     {
         return $this->config->get('identity_file');
     }
@@ -149,7 +149,7 @@ class Host
         return $this;
     }
 
-    public function getForwardAgent():? bool
+    public function getForwardAgent(): ?bool
     {
         return $this->config->get('forward_agent');
     }
@@ -160,7 +160,7 @@ class Host
         return $this;
     }
 
-    public function getSshMultiplexing():? bool
+    public function getSshMultiplexing(): ?bool
     {
         return $this->config->get('ssh_multiplexing');
     }
@@ -171,7 +171,7 @@ class Host
         return $this;
     }
 
-    public function getShell():? string
+    public function getShell(): ?string
     {
         return $this->config->get('shell');
     }
@@ -182,7 +182,7 @@ class Host
         return $this;
     }
 
-    public function getDeployPath():? string
+    public function getDeployPath(): ?string
     {
         return $this->config->get('deploy_path');
     }
@@ -193,7 +193,7 @@ class Host
         return $this;
     }
 
-    public function getLabels():? array
+    public function getLabels(): ?array
     {
         return $this->config->get('labels');
     }
@@ -212,12 +212,12 @@ class Host
         return $this;
     }
 
-    public function getSshArguments():? array
+    public function getSshArguments(): ?array
     {
         return $this->config->get('ssh_arguments');
     }
 
-    private function generateTag():? string
+    private function generateTag(): ?string
     {
         if (defined('NO_ANSI')) {
             return $this->getAlias();

--- a/src/Support/Config/verification.php
+++ b/src/Support/Config/verification.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace Deployer;
+
+use Deployer\Exception\TimeoutException;
+
+task('verification', [
+    'verification:timeouts'
+]);
+
+task('verification:timeouts', function () {
+    try {
+        run("php -r 'while(true){}'", timeout: 1);
+    } catch (TimeoutException) {
+        $ps = run("if ps aux | grep '[p]hp -r while(true){}'; then echo still running; else echo ok; fi");
+        if ($ps != 'ok') {
+            throw new \Exception('Process still running.');
+        }
+    }
+});

--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -51,7 +51,7 @@ class Rsync
         $options = $config['options'] ?? [];
         $flags = $config['flags'];
 
-        $connectionOptions = Client::connectionOptions($host);
+        $connectionOptions = Client::connectionOptionsString($host);
         if ($connectionOptions !== '') {
             $options[] = "-e 'ssh $connectionOptions'";
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -311,7 +311,7 @@ function within(string $path, callable $callback)
  *
  * @param string $command Command to run on remote host
  * @param array|null $options Array of options will override passed named arguments.
- * @param int|null $timeout  Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec; see {{default_timeout}}, `null` to disable).
+ * @param int|null $timeout Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec; see {{default_timeout}}, `null` to disable).
  * @param int|null $idle_timeout Sets the process idle timeout (max. time since last output) in seconds.
  * @param string|null $secret Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
  * @param array|null $vars Array of placeholders to replace in command: `run('echo %key%', vars: ['key' => 'anything does here']);`
@@ -396,7 +396,7 @@ function run(string $command, ?array $options = [], ?int $timeout = null, ?int $
  *
  * @param string $command Command to run on localhost.
  * @param array|null $options Array of options will override passed named arguments.
- * @param int|null $timeout  Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec, `null` to disable).
+ * @param int|null $timeout Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec, `null` to disable).
  * @param int|null $idle_timeout Sets the process idle timeout (max. time since last output) in seconds.
  * @param string|null $secret Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
  * @param array|null $vars Array of placeholders to replace in command: `runLocally('echo %key%', vars: ['key' => 'anything does here']);`


### PR DESCRIPTION
Now, it should be not matter what default shell is used on a server: zsh, fish. Deployer will automatically switch to bash (or to user specified shell).

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

