### PR TITLE
Allow artisan commands to run in the current release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Better parallel execution support, configurable per task.
 - Refactored `dep init` command.
 - Normalize shopware recipe (require common.php).
+- Allow artisan commands to run in the current release. [#2485]
 
 ### Fixed
 - Lots, and lots of long-standing bugs.
@@ -602,6 +603,7 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2485]: https://github.com/deployphp/deployer/pull/2485
 [#2425]: https://github.com/deployphp/deployer/pull/2425
 [#2423]: https://github.com/deployphp/deployer/issues/2423
 [#2393]: https://github.com/deployphp/deployer/pull/2393

--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -15,6 +15,7 @@
   * [`shared_files`](#shared_files)
   * [`writable_dirs`](#writable_dirs)
   * [`log_files`](#log_files)
+  * [`laravel_base_path`](#laravel_base_path)
   * [`laravel_version`](#laravel_version)
 * Tasks
   * [`artisan:up`](#artisanup) — Disable maintenance mode
@@ -70,6 +71,11 @@
 
 ### log_files
 [Source](https://github.com/deployphp/deployer/search?q=%22log_files%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Alaravel.php)
+
+
+
+### laravel_base_path
+[Source](https://github.com/deployphp/deployer/search?q=%22laravel_base_path%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Alaravel.php)
 
 
 


### PR DESCRIPTION
Hi 👋 

So today I've been doing some tests with Deploy7 and Laravel applications.

I ran into an issue regarding the way we run artisan commands as Deployer tasks.

Since we always expect the `release_path` to be available, we actually cannot use them directly using `dep artisan:*`.

For example, say you change your `.env` file and then want to reset the config cache for the changes to be live. One would expect that running `dep artisan:config:cache` would do the trick but it actually returns the following error:

```
'The "release_path" ({{deploy_path}}/release) does not exist.
```

However, in this instance we're not inside a deployment so we should not be using the `release_path` but the `current_path` instead.

This PR fixes this by providing a new dynamic option `laravel_base_path` that first tries to get the `release_path` and falls back to the `current_path` if it does not exist. It then uses that option inside the artisan tasks with the exception of `artisan:up` and `artisan:down` that should _always_ run in the current directory. That is, even during a deployment, we want the current release to be marked as `down`.

Whilst this fixes the issue on Laravel land, I wonder if there should be a consideration for a more generic solution since it's common to need to run some tasks directly outside a deployment and all of these would fail.

Let me know if that's something you'd be interested in and I can think of a more generic PR.

---

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks? No, the existing behaviour stays the same but we're adding the possibility to also run tasks directly to the current release.
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?