### PR TITLE
Add and use new release_or_current_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added support for PHP8.
 - Added slack_channel option to Slack recipe.
 - Chatwork contrib recipe.
+- Added `release_or_current_path` option that fallbacks to the `current_path` when the `release_path` does not exist. [#2486]
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.
@@ -602,6 +603,7 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2486]: https://github.com/deployphp/deployer/pull/2486
 [#2425]: https://github.com/deployphp/deployer/pull/2425
 [#2423]: https://github.com/deployphp/deployer/issues/2423
 [#2393]: https://github.com/deployphp/deployer/pull/2393

--- a/docs/recipe/deploy/release.md
+++ b/docs/recipe/deploy/release.md
@@ -13,6 +13,7 @@
   * [`releases_metainfo`](#releases_metainfo)
   * [`releases_list`](#releases_list)
   * [`release_path`](#release_path)
+  * [`release_or_current_path`](#release_or_current_path)
 * Tasks
   * [`deploy:release`](#deployrelease) — Prepare release. Clean up unfinished releases and prepare next release
 
@@ -36,6 +37,12 @@ Return list of releases on host.
 [Source](https://github.com/deployphp/deployer/search?q=%22release_path%22+in%3Afile+language%3Aphp+path%3Arecipe%2Fdeploy+filename%3Arelease.php)
 
 Return release path.
+
+### release_or_current_path
+[Source](https://github.com/deployphp/deployer/search?q=%22release_or_current_path%22+in%3Afile+language%3Aphp+path%3Arecipe%2Fdeploy+filename%3Arelease.php)
+
+Return the release path during a deployment
+but fallback to the current path otherwise.
 
 
 ## Tasks

--- a/recipe/cakephp.php
+++ b/recipe/cakephp.php
@@ -25,16 +25,16 @@ set('shared_files', [
  * Create plugins' symlinks
  */
 task('deploy:init', function () {
-    run('{{release_path}}/bin/cake plugin assets symlink');
+    run('{{release_or_current_path}}/bin/cake plugin assets symlink');
 })->desc('Initialization');
 
 /**
  * Run migrations
  */
 task('deploy:run_migrations', function () {
-    run('{{release_path}}/bin/cake migrations migrate');
-    run('{{release_path}}/bin/cake schema_cache clear');
-    run('{{release_path}}/bin/cake schema_cachebuild');
+    run('{{release_or_current_path}}/bin/cake migrations migrate');
+    run('{{release_or_current_path}}/bin/cake schema_cache clear');
+    run('{{release_or_current_path}}/bin/cake schema_cachebuild');
 })->desc('Run migrations');
 
 /**

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -89,6 +89,15 @@ set('release_path', function () {
     }
 });
 
+/**
+ * Return the release path during a deployment
+ * but fallback to the current path otherwise.
+ */
+set('release_or_current_path', function () {
+    $releaseExists = test('[ -h {{deploy_path}}/release ]');
+
+    return $releaseExists ? get('release_path') : get('current_path');
+});
 
 desc('Prepare release. Clean up unfinished releases and prepare next release');
 task('deploy:release', function () {

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -29,5 +29,5 @@ task('deploy:vendors', function () {
     if (!commandExist('unzip')) {
         warning('To speed up composer installation setup "unzip" command with PHP zip extension.');
     }
-    run('cd {{release_path}} && {{bin/composer}} {{composer_action}} {{composer_options}} 2>&1');
+    run('cd {{release_or_current_path}} && {{bin/composer}} {{composer_action}} {{composer_options}} 2>&1');
 });

--- a/recipe/flow_framework.php
+++ b/recipe/flow_framework.php
@@ -23,7 +23,7 @@ set('shared_dirs', [
  */
 desc('Apply database migrations');
 task('deploy:run_migrations', function () {
-    run('FLOW_CONTEXT={{flow_context}} {{bin/php}} {{release_path}}/{{flow_command}} doctrine:migrate');
+    run('FLOW_CONTEXT={{flow_context}} {{bin/php}} {{release_or_current_path}}/{{flow_command}} doctrine:migrate');
 });
 
 /**
@@ -31,7 +31,7 @@ task('deploy:run_migrations', function () {
  */
 desc('Publish resources');
 task('deploy:publish_resources', function () {
-    run('FLOW_CONTEXT={{flow_context}} {{bin/php}} {{release_path}}/{{flow_command}} resource:publish');
+    run('FLOW_CONTEXT={{flow_context}} {{bin/php}} {{release_or_current_path}}/{{flow_command}} resource:publish');
 });
 
 /**

--- a/recipe/magento.php
+++ b/recipe/magento.php
@@ -23,17 +23,17 @@ set('writable_dirs', ['var', 'media']);
  */
 desc('Clear cache');
 task('deploy:cache:clear', function () {
-    run("cd {{release_path}} && php -r \"require_once 'app/Mage.php'; umask(0); Mage::app()->cleanCache();\"");
+    run("cd {{release_or_current_path}} && php -r \"require_once 'app/Mage.php'; umask(0); Mage::app()->cleanCache();\"");
 });
 
 /**
  * Remove files that can be used to compromise Magento
  */
 task('deploy:clear_version', function () {
-    run("rm -f {{release_path}}/LICENSE.html");
-    run("rm -f {{release_path}}/LICENSE.txt");
-    run("rm -f {{release_path}}/LICENSE_AFL.txt");
-    run("rm -f {{release_path}}/RELEASE_NOTES.txt");
+    run("rm -f {{release_or_current_path}}/LICENSE.html");
+    run("rm -f {{release_or_current_path}}/LICENSE.txt");
+    run("rm -f {{release_or_current_path}}/LICENSE_AFL.txt");
+    run("rm -f {{release_or_current_path}}/RELEASE_NOTES.txt");
 })->hidden();
 
 after('deploy:update_code', 'deploy:clear_version');

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -58,7 +58,7 @@ set('clear_paths', [
 
 set('magento_version', function () {
     // detect version
-    $versionOutput = run('{{bin/php}} {{release_path}}/bin/magento --version');
+    $versionOutput = run('{{bin/php}} {{release_or_current_path}}/bin/magento --version');
     preg_match('/(\d+\.?)+$/', $versionOutput, $matches);
     return $matches[0] ?? "2.0";
 });
@@ -72,14 +72,14 @@ set('maintenance_mode_status_active', function () {
 // Tasks
 desc('Compile magento di');
 task('magento:compile', function () {
-    run('cd {{release_path}} && {{bin/composer}} dump-autoload -o');
-    run("{{bin/php}} {{release_path}}/bin/magento setup:di:compile");
-    run('cd {{release_path}} && {{bin/composer}} dump-autoload -o');
+    run('cd {{release_or_current_path}} && {{bin/composer}} dump-autoload -o');
+    run("{{bin/php}} {{release_or_current_path}}/bin/magento setup:di:compile");
+    run('cd {{release_or_current_path}} && {{bin/composer}} dump-autoload -o');
 });
 
 desc('Deploy assets');
 task('magento:deploy:assets', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento setup:static-content:deploy --content-version={{content_version}} {{static_content_locales}}");
+    run("{{bin/php}} {{release_or_current_path}}/bin/magento setup:static-content:deploy --content-version={{content_version}} {{static_content_locales}}");
 });
 
 desc('Sync content version');
@@ -114,7 +114,7 @@ task('magento:config:import', function () {
         $configImportNeeded = true;
     } else {
         try {
-            run('{{bin/php}} {{release_path}}/bin/magento app:config:status');
+            run('{{bin/php}} {{release_or_current_path}}/bin/magento app:config:status');
         } catch (RunException $e) {
             if ($e->getExitCode() == CONFIG_IMPORT_NEEDED_EXIT_CODE) {
                 $configImportNeeded = true;
@@ -129,7 +129,7 @@ task('magento:config:import', function () {
             invoke('magento:maintenance:enable');
         }
 
-        run('{{bin/php}} {{release_path}}/bin/magento app:config:import --no-interaction');
+        run('{{bin/php}} {{release_or_current_path}}/bin/magento app:config:import --no-interaction');
 
         if (!get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:disable');
@@ -142,7 +142,7 @@ task('magento:upgrade:db', function () {
     $databaseUpgradeNeeded = false;
 
     try {
-        run('{{bin/php}} {{release_path}}/bin/magento setup:db:status');
+        run('{{bin/php}} {{release_or_current_path}}/bin/magento setup:db:status');
     } catch (RunException $e) {
         if ($e->getExitCode() == DB_UPDATE_NEEDED_EXIT_CODE) {
             $databaseUpgradeNeeded = true;
@@ -156,7 +156,7 @@ task('magento:upgrade:db', function () {
             invoke('magento:maintenance:enable');
         }
 
-        run("{{bin/php}} {{release_path}}/bin/magento setup:upgrade --keep-generated");
+        run("{{bin/php}} {{release_or_current_path}}/bin/magento setup:upgrade --keep-generated");
 
         if (!get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:disable');
@@ -166,7 +166,7 @@ task('magento:upgrade:db', function () {
 
 desc('Flush Magento Cache');
 task('magento:cache:flush', function () {
-    run("{{bin/php}} {{release_path}}/bin/magento cache:flush");
+    run("{{bin/php}} {{release_or_current_path}}/bin/magento cache:flush");
 });
 
 desc('Magento2 deployment operations');

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -37,32 +37,32 @@ set('writable_dirs', [
 set('static_folders', []);
 
 task('sw:update_code', static function () {
-    run('git clone {{repository}} {{release_path}}');
+    run('git clone {{repository}} {{release_or_current_path}}');
 });
 task('sw:system:install', static function () {
-    run('cd {{release_path}} && bin/console system:install');
+    run('cd {{release_or_current_path}} && bin/console system:install');
 });
 task('sw:build', static function () {
-    run('cd {{release_path}}/bin && bash build.sh');
+    run('cd {{release_or_current_path}}/bin && bash build.sh');
 });
 task('sw:system:setup', static function () {
-    run('cd {{release_path}} && bin/console system:setup');
+    run('cd {{release_or_current_path}} && bin/console system:setup');
 });
 task('sw:theme:compile', static function () {
-    run('cd {{release_path}} && bin/console theme:compile');
+    run('cd {{release_or_current_path}} && bin/console theme:compile');
 });
 task('sw:cache:clear', static function () {
-    run('cd {{release_path}} && bin/console cache:clear');
+    run('cd {{release_or_current_path}} && bin/console cache:clear');
 });
 task('sw:cache:warmup', static function () {
-    run('cd {{release_path}} && bin/console cache:warmup');
-    run('cd {{release_path}} && bin/console http:cache:warm:up');
+    run('cd {{release_or_current_path}} && bin/console cache:warmup');
+    run('cd {{release_or_current_path}} && bin/console http:cache:warm:up');
 });
 task('sw:database:migrate', static function () {
-    run('cd {{release_path}} && bin/console database:migrate --all');
+    run('cd {{release_or_current_path}} && bin/console database:migrate --all');
 });
 task('sw:plugin:refresh', function () {
-    run('cd {{release_path}} && bin/console plugin:refresh');
+    run('cd {{release_or_current_path}} && bin/console plugin:refresh');
 });
 /**
  * @return array
@@ -71,7 +71,7 @@ task('sw:plugin:refresh', function () {
  */
 function getSortedPlugins(): array
 {
-    cd('{{release_path}}');
+    cd('{{release_or_current_path}}');
     $plugins = explode("\n", run('bin/console plugin:list'));
 
     // take line over headlines and count "-" to get the size of the cells
@@ -146,7 +146,7 @@ task('sw:plugin:activate:all', static function () {
         ] = $pluginInfo;
 
         if ($installed === 'No' || $active === 'No') {
-            run("cd {{release_path}} && bin/console plugin:install --activate $plugin");
+            run("cd {{release_or_current_path}} && bin/console plugin:install --activate $plugin");
         }
     }
 });
@@ -166,7 +166,7 @@ task('sw:plugin:migrate:all', static function () {
         ] = $pluginInfo;
 
         if ($installed === 'Yes' || $active === 'Yes') {
-            run("cd {{release_path}} && bin/console database:migrate --all $plugin || true");
+            run("cd {{release_or_current_path}} && bin/console database:migrate --all $plugin || true");
         }
     }
 });

--- a/recipe/silverstripe.php
+++ b/recipe/silverstripe.php
@@ -10,7 +10,7 @@ add('recipes', ['silverstripe']);
  */
 
 set('shared_assets', function () {
-    if (test('[ -d {{release_path}}/public ]') || test('[ -d {{deploy_path}}/shared/public ]')) {
+    if (test('[ -d {{release_or_current_path}}/public ]') || test('[ -d {{deploy_path}}/shared/public ]')) {
         return 'public/assets';
     }
     return 'assets';
@@ -34,7 +34,7 @@ set('silverstripe_cli_script', function () {
         'vendor/silverstripe/framework/cli-script.php'
     ];
     foreach ($paths as $path) {
-        if (test('[ -f {{release_path}}/'.$path.' ]')) {
+        if (test('[ -f {{release_or_current_path}}/'.$path.' ]')) {
             return $path;
         }
     }
@@ -45,12 +45,12 @@ set('silverstripe_cli_script', function () {
  */
 desc('Run /dev/build');
 task('silverstripe:build', function () {
-    return run('{{bin/php}} {{release_path}}/{{silverstripe_cli_script}} /dev/build');
+    return run('{{bin/php}} {{release_or_current_path}}/{{silverstripe_cli_script}} /dev/build');
 });
 
 desc('Run /dev/build?flush=all');
 task('silverstripe:buildflush', function () {
-    return run('{{bin/php}} {{release_path}}/{{silverstripe_cli_script}} /dev/build flush=all');
+    return run('{{bin/php}} {{release_or_current_path}}/{{silverstripe_cli_script}} /dev/build flush=all');
 });
 
 /**

--- a/recipe/sulu.php
+++ b/recipe/sulu.php
@@ -11,7 +11,7 @@ add('shared_dirs', ['var/indexes', 'var/sitemaps', 'var/uploads', 'public/upload
 add('writable_dirs', ['public/uploads']);
 
 set('bin/websiteconsole', function () {
-    return parse('{{bin/php}} {{release_path}}/bin/websiteconsole --no-interaction');
+    return parse('{{bin/php}} {{release_or_current_path}}/bin/websiteconsole --no-interaction');
 });
 
 desc('Migrate PHPCR');

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -27,7 +27,7 @@ set('writable_dirs', [
 
 set('migrations_config', '');
 
-set('bin/console', '{{bin/php}} {{release_path}}/bin/console');
+set('bin/console', '{{bin/php}} {{release_or_current_path}}/bin/console');
 
 set('console_options', function () {
     return '--no-interaction';
@@ -37,10 +37,10 @@ desc('Migrate database');
 task('database:migrate', function () {
     $options = '--allow-no-migration';
     if (get('migrations_config') !== '') {
-        $options = "$options --configuration={{release_path}}/{{migrations_config}}";
+        $options = "$options --configuration={{release_or_current_path}}/{{migrations_config}}";
     }
 
-    run("cd {{release_path}} && {{bin/console}} doctrine:migrations:migrate $options {{console_options}}");
+    run("cd {{release_or_current_path}} && {{bin/console}} doctrine:migrations:migrate $options {{console_options}}");
 });
 
 desc('Clear cache');


### PR DESCRIPTION
As discussed in PR https://github.com/deployphp/deployer/pull/2485, This PR enables users to run tasks outside a deployment by providing a new `release_or_current_path` option.

This option will always return the `release_path` if it exists and fallback to the `current_path` if it doesn't.

That way, outside of deployment, we can still run `dep my:task` and expect our task to be executed on the latest active release.

This PR replaces the use of `release_path` with `release_or_current_path` in all the custom tasks of platform-specific recipes — like laravel, symfony, etc. It also replaces the use of `release_path` in the `deploy:vendor` task, allowing users to run `composer install` on the current release if they need to.

Let me know if there are other places that would benefit from this new path.

Let me know what you think. 🙂 

---

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks? No, the existing behaviour stays the same but we're adding the possibility to also run tasks directly to the current release.
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?
