### PR TITLE
Add artisan tasks that generate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Chatwork contrib recipe.
 - Added `release_or_current_path` option that fallbacks to the `current_path` when the `release_path` does not exist. [#2486]
 - Added `contrib/php-fpm.php` recipe that provides a task to reload PHP-fpm. [#2487]
+- Added tasks `artisan:key:generate` and `artisan:passport:keys` to the Laravel recipe.
 
 ### Changed
 - Refactored executor engine, up to 2x faster than before.

--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -19,6 +19,8 @@
 * Tasks
   * [`artisan:down`](#artisandown) — Put the application into maintenance / demo mode
   * [`artisan:up`](#artisanup) — Bring the application out of maintenance mode
+  * [`artisan:key:generate`](#artisankeygenerate) — Set the application key
+  * [`artisan:passport:keys`](#artisanpassportkeys) — Create the encryption keys for API authentication
   * [`artisan:db:seed`](#artisandbseed) — Seed the database with records
   * [`artisan:migrate`](#artisanmigrate) — Run the database migrations
   * [`artisan:migrate:fresh`](#artisanmigratefresh) — Drop all tables and re-run all migrations
@@ -94,6 +96,16 @@
 
 ### artisan:up
 [Source](https://github.com/deployphp/deployer/search?q=%22artisan%3Aup%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Alaravel.php)
+
+
+
+### artisan:key:generate
+[Source](https://github.com/deployphp/deployer/search?q=%22artisan%3Akey%3Agenerate%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Alaravel.php)
+
+
+
+### artisan:passport:keys
+[Source](https://github.com/deployphp/deployer/search?q=%22artisan%3Apassport%3Akeys%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Alaravel.php)
 
 
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -96,6 +96,16 @@ desc('Bring the application out of maintenance mode');
 task('artisan:up', artisan('up', ['runInCurrent', 'showOutput']));
 
 /*
+ * Generate keys.
+ */
+
+desc('Set the application key');
+task('artisan:key:generate', artisan('key:generate'));
+
+desc('Create the encryption keys for API authentication');
+task('artisan:passport:keys', artisan('passport:keys'));
+
+/*
  * Database and migrations.
  */
 


### PR DESCRIPTION
Co-Authored-By: Kundan <198781+kundancool@users.noreply.github.com>

Sorry for the bombardment of PRs haha.

I thought of another useful artisan task that is missing: `artisan:key:generate`. This can help users during their initial deployment since it is a Laravel requirement to set up the `APP_KEY`.

I saw another PR that included a similar task for Passport that generates clients IDs and Secrets. Therefore, I bundled them together here and credited the author of PR #2403 in this PR.

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?