### PR TITLE
Feature/add shared configs for common template only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Refactored `dep init` command.
 - Normalize shopware recipe (require common.php).
 - Removed the `min` and `max` constraints on the `artisan:optimize` and `artisan:optimize:clear` tasks. [#2488]
+- Excluded the `shared_files`, `shared_dirs` and `writable_dirs` configs from the `deploy.yaml` default template unless the `common` template was chosen.
 
 ### Fixed
 - Lots, and lots of long-standing bugs.

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -164,6 +164,8 @@ PHP;
             $h .= "  $host:\n    deploy_path: '~/{{application}}'\n";
         }
 
+        $additionalConfigs = $this->getAdditionalConfigs($template);
+
         return <<<YAML
 import: 
     - recipe/$template.php
@@ -171,13 +173,7 @@ import:
 config:
   application: '$project'
   repository: '$repository'
-  shared_files:
-    - .env
-  shared_dirs:
-    - uploads
-  writable_dirs:
-    - uploads
-
+{$additionalConfigs}
 hosts:
 {$h}
 tasks:
@@ -188,6 +184,23 @@ tasks:
 after:
   deploy:failed: deploy:unlock
 
+YAML;
+    }
+
+    private function getAdditionalConfigs(string $template): string
+    {
+        if ($template !== 'common') {
+            return '';
+        }
+
+        return <<<YAML
+  shared_files:
+    - .env
+  shared_dirs:
+    - uploads
+  writable_dirs:
+    - uploads
+  
 YAML;
     }
 


### PR DESCRIPTION
Hi 👋 

I'm just writing an article on how to get started with Laravel and Deployer 7 and I've noticed that I've got to tell the readers to remove a bunch of options that conflict with the default values provided by the Laravel recipe.

<img width="1180" alt="Capture 2021-04-05T15 35 44@2x" src="https://user-images.githubusercontent.com/3642397/113585812-a2d83700-9624-11eb-9421-88f81278fca8.png">

This is because, I'm using the `YAML` format in that tutorial and it cannot make use of `add('shared_files', [])` like the `deploy.php` file can.

When using project template like the one provided by Laravel, these values are already set up with some good defaults inside the recipe file. But when adding the `shared_files`, `shared_dirs` and `writable_dirs` options to the YAML file it will override these values with something irrelevant to the type of project. E.g. here Laravel does not have an `uploads` folder. 

This PR fixes this by removing these values from the `deploy.yaml` template **unless** the provided template was `common`.

What do you think?

---

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?