### PR TITLE
Rsync stats config option

### DIFF
--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -35,7 +35,9 @@ class Rsync
      *
      * - `flags` for overriding the default `-azP` passed to the `rsync` command
      * - `options` with additional flags passed directly to the `rsync` command
-     * - `timeout` for `Process::fromShellCommandline()` (`null` by default)
+     * - `timeout` for `Process::fromShellCommandline()` (`null` by default),
+     * - `progress_bar` to display upload/download progress,
+     * - `display_stats' to display rsync set of statistics.
      *
      * @param string|string[] $source
      * @throws RunException


### PR DESCRIPTION
PR for #2497 

- [ ] Bug fix #…?
- [X ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

PR for rsync stats. I have target php 7.4, but if you prefer 8.0 `strpos` can be replaced with `str_starts_with`
