### PR TITLE
Fix regex that identifies "cd" commands in YAML scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fixed "dep run" suggestion in ACL error message. [#2501]
 - TypeError, port is int on escapeshellarg. [#2503]
 - .env.local.php in Symfony recipe. [#2506]
+- Fixed regex identifying "cd" commands in YAML scripts. The regex was not taking into account that multiple commands can be executed within the same line — e.g. "cd {{release_path}} && npm run prod". [#2509]
 
 ### Removed
 - Removed the `artisan:public_disk` task. Use the `artisan:storage:link` task instead. [#2488]
@@ -616,6 +617,7 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2509]: https://github.com/deployphp/deployer/issues/2509
 [#2506]: https://github.com/deployphp/deployer/issues/2506
 [#2503]: https://github.com/deployphp/deployer/issues/2503
 [#2501]: https://github.com/deployphp/deployer/pull/2501

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -119,7 +119,10 @@ class Importer
                         $wrapRun($script);
                     } else {
                         foreach ($script as $line) {
-                            if (preg_match('/^cd\s(?<path>.+)/i', $line, $matches)) {
+                            $containsMultipleCommands = preg_match('/\b&&\b/', $line);
+                            $startsWithCd = preg_match('/^cd\s(?<path>.+)/i', $line, $matches);
+
+                            if ($startsWithCd && ! $containsMultipleCommands) {
                                 cd($matches['path']);
                             } else {
                                 $wrapRun($line);


### PR DESCRIPTION
When providing an array of string to the `script` key inside a YAML task, each line goes through a regex that identifies whether its a `cd` command or not. That way, the following script array:

```yaml
  yarn:run:prod:
    script:
      - 'cd {{release_or_current_path}}'
      - 'yarn run prod'
```

becomes:

```php
cd('{{release_or_current_path}}');
run('yarn run prod');
```

However, the regex did not take into account that multiple commands can be run within the same line like so.

```yaml
  yarn:run:prod:
    script:
      - 'cd {{release_or_current_path}} && yarn run prod'
```

Thus, the script array above became:

```php
cd('{{release_or_current_path}} && yarn run prod');
```

Making the task no execute anything.

This PR fixes this by adding an extra regex that looks for `\b&&\b` within the script line before wrapping it inside a `cd` function.

**EDIT**: I forgot to mention that the default `deploy.yaml` generated by the `dep init` command generates a task following this exact format which can cause newcomers to be confused when they don't see their tasks being executed.

---

- [x] Bug fix #2509
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [x] Changelog updated?
