### PR TITLE
Fix contains multiple commands regex

### DIFF
--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -119,7 +119,7 @@ class Importer
                         $wrapRun($script);
                     } else {
                         foreach ($script as $line) {
-                            $containsMultipleCommands = preg_match('/\b&&\b/', $line);
+                            $containsMultipleCommands = preg_match('/\s&&\s/', $line);
                             $startsWithCd = preg_match('/^cd\s(?<path>.+)/i', $line, $matches);
 
                             if ($startsWithCd && ! $containsMultipleCommands) {


### PR DESCRIPTION
My bad I misused the word boundary `\b` on the regex. It simply needs to check for a whitespace.

Not sure I need a changelog for a fix of a fix right? 

- [x] Bug fix #2509?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?
