### PR TITLE
add .gitattributes - exclude tests, docs from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/docs/ export-ignore
+/phpcs.xml export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Just added .gitattributes to exclude tests, docs from archives