### PR TITLE
Support passing `null` as default in get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - .env.local.php in Symfony recipe. [#2506]
 - Fixed regex identifying "cd" commands in YAML scripts. The regex was not taking into account that multiple commands can be executed within the same line — e.g. "cd {{release_path}} && npm run prod". [#2509]
 - Slack default channel null breaks webhook. [#2525]
+- Support passing `null` as default in get(). [#2545]
 
 ### Removed
 - Removed the `artisan:public_disk` task. Use the `artisan:storage:link` task instead. [#2488]
@@ -621,6 +622,7 @@
 - Fixed `DotArray` syntax in `Collection`.
 
 
+[#2545]: https://github.com/deployphp/deployer/issues/2545
 [#2525]: https://github.com/deployphp/deployer/issues/2525
 [#2509]: https://github.com/deployphp/deployer/issues/2509
 [#2506]: https://github.com/deployphp/deployer/issues/2506

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -91,7 +91,7 @@ class Configuration implements \ArrayAccess
             }
         }
 
-        if ($default !== null) {
+        if (func_num_args() >= 2) {
             return $this->parse($default);
         }
 

--- a/tests/src/Host/ConfigurationTest.php
+++ b/tests/src/Host/ConfigurationTest.php
@@ -29,6 +29,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('value', $config->get('string'));
         $this->assertEquals([1, 'two'], $config->get('array'));
         $this->assertEquals('default', $config->get('no', 'default'));
+        $this->assertEquals(null, $config->get('no', null));
         $this->assertEquals('callback', $config->get('callback'));
         $this->assertEquals('is 42', $config->get('parse'));
         $this->assertEquals('has hyphen', $config->get('parse-hyphen'));


### PR DESCRIPTION
- [x] Bug fix #2545?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [x] Tests added?
- [x] Changelog updated?

