### PR TITLE
Feature: Skip tasks if files unchanged.

### DIFF
--- a/src/Executor/Worker.php
+++ b/src/Executor/Worker.php
@@ -35,7 +35,11 @@ class Worker
 
             $context = new Context($host, $this->deployer->input, $this->deployer->output);
             $context->setIsLocal($task->isLocal());
-            $task->run($context);
+            if ($task->shouldSkip($context)) {
+                $task->skip($context);
+            } else {
+                $task->run($context);
+            }
 
             if ($task->getName() !== 'connect') {
                 $this->deployer->messenger->endOnHost($host);

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -26,6 +26,11 @@ class Task
     private $verbose = false;
 
     /**
+     * @var string[] $watch A list of glob files to check for changes before running the task.
+     */
+    public $watch = [];
+
+    /**
      * Task constructor.
      * @param mixed $name
      */
@@ -48,6 +53,19 @@ class Task
 
             Context::pop();
         }
+    }
+
+    public function shouldSkip(Context $context): bool {
+        // By default, never skip tasks - to maintain backwards compatibility.
+        if (count($this->watch) == 0) {
+            return false;
+        }
+
+        // @todo Implement Task->shouldSkip()
+    }
+
+    public function skip(Context $context): void {
+        // @todo Implement Task->skip()
     }
 
     /**


### PR DESCRIPTION
This PR Allows tasks to be skipped if their dependencies haven't changed, As mentioned in issue #1786.

Examples:
- [ ] Skip `deploy:vendor` if `composer.json` and `composer.lock` haven't changed.
- [ ] [Hard] Skip `yarn:build` if `package.json`, `yarn.lock`, files have changed, also `webpack.config.js`, and files referenced in `package.json`.

Todos:
- [x] Add `$watch` property to `Task`, containing list of globs for files that should be watched.
- [ ] Before running a `Task`, check that none of the `$watch`ed files have changed since the last release.
- [ ] Never skip tasks during the first release.
- [ ] Add text/icon indicator to tasks in CLI, to inform the user that a Task was skipped.
  - [ ] Also show the file(s) that triggered the change?
