### PR TITLE
Remove vars

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -258,7 +258,7 @@ Execute a callback within a specific directory and revert back to the initial wo
 ## run()
 
 ```php
-run(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $vars = null, ?array $env = null, ?bool $real_time_output = false): string
+run(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $env = null, ?bool $real_time_output = false): string
 ```
 
 Executes given command on remote host.
@@ -300,10 +300,6 @@ run("echo $path");
   **type**: `string|null `
 
   Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
-- ### vars
-  **type**: `array|null `
-
-  Array of placeholders to replace in command: `run('echo %key%', vars: ['key' => 'anything does here']);`
 - ### env
   **type**: `array|null `
 
@@ -316,7 +312,7 @@ run("echo $path");
 ## runLocally()
 
 ```php
-runLocally(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $vars = null, ?array $env = null): string
+runLocally(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $env = null): string
 ```
 
 Execute commands on a local machine.
@@ -351,10 +347,6 @@ runLocally("echo $user");
   **type**: `string|null `
 
   Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
-- ### vars
-  **type**: `array|null `
-
-  Array of placeholders to replace in command: `runLocally('echo %key%', vars: ['key' => 'anything does here']);`
 - ### env
   **type**: `array|null `
 

--- a/src/Component/ProcessRunner/ProcessRunner.php
+++ b/src/Component/ProcessRunner/ProcessRunner.php
@@ -37,7 +37,6 @@ class ProcessRunner
             'timeout' => $host->get('default_timeout', 300),
             'idle_timeout' => null,
             'cwd' => defined('DEPLOYER_ROOT') ? DEPLOYER_ROOT : null,
-            'vars' => [],
             'real_time_output' => false,
         ];
         $config = array_merge($defaults, $config);
@@ -50,7 +49,6 @@ class ProcessRunner
             $terminalOutput($type, $buffer);
         };
 
-        $command = $this->replacePlaceholders($command, $config['vars']);
         $command = str_replace('%secret%', $config['secret'] ?? '', $command);
         $command = str_replace('%sudo_pass%', $config['sudo_pass'] ?? '', $command);
 
@@ -80,14 +78,5 @@ class ProcessRunner
                 $exception->getExceededTimeout()
             );
         }
-    }
-
-    private function replacePlaceholders(string $command, array $variables): string
-    {
-        foreach ($variables as $placeholder => $replacement) {
-            $command = str_replace("%$placeholder%", $replacement, $command);
-        }
-
-        return $command;
     }
 }

--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -40,7 +40,6 @@ class Client
         $defaults = [
             'timeout' => $host->get('default_timeout', 300),
             'idle_timeout' => null,
-            'vars' => [],
             'real_time_output' => false,
         ];
         $config = array_merge($defaults, $config);
@@ -69,7 +68,6 @@ class Client
         $this->pop->command($host, $command);
         $this->logger->log("[{$host->getAlias()}] run $command");
 
-        $command = $this->replacePlaceholders($command, $config['vars']);
         $command = str_replace('%secret%', $config['secret'] ?? '', $command);
         $command = str_replace('%sudo_pass%', $config['sudo_pass'] ?? '', $command);
 
@@ -172,15 +170,6 @@ class Client
             $this->pop->printBuffer(Process::OUT, $host, $output);
         }
         return (bool)preg_match('/Master running/', $output);
-    }
-
-    private function replacePlaceholders(string $command, array $variables): string
-    {
-        foreach ($variables as $placeholder => $replacement) {
-            $command = str_replace("%$placeholder%", $replacement, $command);
-        }
-
-        return $command;
     }
 
     public static function connectionOptionsString(Host $host): string

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -86,7 +86,7 @@ function env_stringify(array $array): string
 {
     return implode(' ', array_map(
         function ($key, $value) {
-            return sprintf("%s='%s'", $key, $value);
+            return sprintf("%s=%s", $key, escapeshellarg($value));
         },
         array_keys($array),
         $array

--- a/src/functions.php
+++ b/src/functions.php
@@ -314,16 +314,15 @@ function within(string $path, callable $callback)
  * @param int|null $timeout Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec; see {{default_timeout}}, `null` to disable).
  * @param int|null $idle_timeout Sets the process idle timeout (max. time since last output) in seconds.
  * @param string|null $secret Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
- * @param array|null $vars Array of placeholders to replace in command: `run('echo %key%', vars: ['key' => 'anything does here']);`
  * @param array|null $env Array of environment variables: `run('echo $KEY', env: ['key' => 'value']);`
  * @param bool|null $real_time_output Print command output in real-time.
  *
  * @throws Exception\Exception|RunException|TimeoutException
  */
-function run(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $vars = null, ?array $env = null, ?bool $real_time_output = false): string
+function run(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $env = null, ?bool $real_time_output = false): string
 {
     $namedArguments = [];
-    foreach (['timeout', 'idle_timeout', 'secret', 'vars', 'env', 'real_time_output'] as $arg) {
+    foreach (['timeout', 'idle_timeout', 'secret', 'env', 'real_time_output'] as $arg) {
         if ($$arg !== null) {
             $namedArguments[$arg] = $$arg;
         }
@@ -399,15 +398,14 @@ function run(string $command, ?array $options = [], ?int $timeout = null, ?int $
  * @param int|null $timeout Sets the process timeout (max. runtime). The timeout in seconds (default: 300 sec, `null` to disable).
  * @param int|null $idle_timeout Sets the process idle timeout (max. time since last output) in seconds.
  * @param string|null $secret Placeholder `%secret%` can be used in command. Placeholder will be replaced with this value and will not appear in any logs.
- * @param array|null $vars Array of placeholders to replace in command: `runLocally('echo %key%', vars: ['key' => 'anything does here']);`
  * @param array|null $env Array of environment variables: `runLocally('echo $KEY', env: ['key' => 'value']);`
  *
  * @throws RunException
  */
-function runLocally(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $vars = null, ?array $env = null): string
+function runLocally(string $command, ?array $options = [], ?int $timeout = null, ?int $idle_timeout = null, ?string $secret = null, ?array $env = null): string
 {
     $namedArguments = [];
-    foreach (['timeout', 'idle_timeout', 'secret', 'vars', 'env'] as $arg) {
+    foreach (['timeout', 'idle_timeout', 'secret', 'env'] as $arg) {
         if ($$arg !== null) {
             $namedArguments[$arg] = $$arg;
         }

--- a/tests/e2e/recipe/functions.php
+++ b/tests/e2e/recipe/functions.php
@@ -1,13 +1,14 @@
 <?php declare(strict_types=1);
+
 namespace Deployer;
 
 // we need to user require instead of require_once, as the hosts HAVE to be loaded multiple times
 require_once __DIR__ . '/hosts.php';
 
 task('test:functions:run-with-placeholders', function (): void {
-    $cmd = "echo 'placeholder %foo% %baz%'";
-    $vars = [ 'foo' => '{{bar}}', 'baz' => 'xyz%' ];
+    $cmd = 'echo "placeholder $foo $baz"';
+    $env = ['foo' => '{{bar}}', 'baz' => 'xyz%'];
 
-    $output = run($cmd, [ 'vars' => $vars ]);
+    $output = run($cmd, ['env' => $env]);
     output()->writeln($output); // we use this to skip \Deployer\parse() being called in normal \Deployer\writeln()
 })->shallow();

--- a/tests/joy/recipe/named_arguments.php
+++ b/tests/joy/recipe/named_arguments.php
@@ -5,18 +5,18 @@ namespace Deployer;
 localhost();
 
 task('named_arguments', function () {
-    run('echo Hello, %name%!', vars: ['name' => 'world']);
+    run('echo "Hello, $name!"', env: ['name' => 'world']);
 });
 
 task('options', function () {
-    run('echo Hello, %name%!', ['vars' => ['name' => 'Anton']]);
+    run('echo "Hello, $name!"', ['env' => ['name' => 'Anton']]);
 });
 
 task('options_with_named_arguments', function () {
     // The `options:` arg has higher priority than named arguments.
-    run('echo Hello, %name%!', ['vars' => ['name' => 'override']], vars: ['name' => 'world']);
+    run('echo "Hello, $name!"', ['env' => ['name' => 'override']], env: ['name' => 'world']);
 });
 
 task('run_locally_named_arguments', function () {
-    runLocally('echo Hello, %name%!', vars: ['name' => 'world']);
+    runLocally('echo "Hello, $name!"', env: ['name' => 'world']);
 });

--- a/tests/src/FunctionsTest.php
+++ b/tests/src/FunctionsTest.php
@@ -134,25 +134,6 @@ class FunctionsTest extends TestCase
         self::assertEquals('overwritten', $output);
     }
 
-    public function testRunLocallyWithTwoPlaceholders(): void
-    {
-        $cmd = "echo 'placeholder %foo% %baz%'";
-        $vars = [ 'foo' => '{{bar}}', 'baz' => 'xyz%' ];
-
-        $output = runLocally($cmd, [ 'vars' => $vars ]);
-        self::assertEquals('placeholder {{bar}} xyz%', $output);
-    }
-
-    public function testRunLocallyWithPlaceholdersAndParsedValues(): void
-    {
-        $cmd = "echo 'placeholder %foo%; parsed {{baz}}'";
-        $vars = [ 'foo' => '{{bar}}' ];
-        Context::get()->getConfig()->set('baz', 'xyz');
-
-        $output = runLocally($cmd, [ 'vars' => $vars ]);
-        self::assertEquals("placeholder {{bar}}; parsed xyz", $output);
-    }
-
     public function testWithinSetsWorkingPaths()
     {
         Context::get()->getConfig()->set('working_path', '/foo');


### PR DESCRIPTION
As we already have `env`, let's not duplicate and remove `vars` from `run()` function.