### PR TITLE
Fix symfony cache:clear running twice on deployment

### DIFF
--- a/docs/recipe/symfony.md
+++ b/docs/recipe/symfony.md
@@ -20,7 +20,6 @@
 * Tasks
   * [`database:migrate`](#databasemigrate) — Migrate database
   * [`deploy:cache:clear`](#deploycacheclear) — Clear cache
-  * [`deploy:cache:warmup`](#deploycachewarmup) — Warm up cache
   * [`deploy`](#deploy) — Deploy project
 
 ## Config
@@ -72,11 +71,6 @@
 
 
 
-### deploy:cache:warmup
-[Source](https://github.com/deployphp/deployer/search?q=%22deploy%3Acache%3Awarmup%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Asymfony.php)
-
-
-
 ### deploy
 [Source](https://github.com/deployphp/deployer/search?q=%22deploy%22+in%3Afile+language%3Aphp+path%3Arecipe+filename%3Asymfony.php)
 
@@ -86,7 +80,6 @@ This task is group task which contains next tasks:
 * [`deploy:prepare`](/docs/recipe/common.md#deployprepare)
 * [`deploy:vendors`](/docs/recipe/deploy/vendors.md#deployvendors)
 * [`deploy:cache:clear`](/docs/recipe/symfony.md#deploycacheclear)
-* [`deploy:cache:warmup`](/docs/recipe/symfony.md#deploycachewarmup)
 * [`deploy:publish`](/docs/recipe/common.md#deploypublish)
 
 

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -44,12 +44,11 @@ task('database:migrate', function () {
 
 desc('Clear cache');
 task('deploy:cache:clear', function () {
-    run('{{bin/console}} cache:clear {{console_options}} --no-warmup');
-});
-
-desc('Warm up cache');
-task('deploy:cache:warmup', function () {
-    run('{{bin/console}} cache:warmup {{console_options}}');
+    // composer install scripts usually clear and warmup symfony cache
+    // so we only need to do it if composer install was run with --no-scripts
+    if (false !== strpos(get('composer_options', ''), '--no-scripts')) {
+        run('{{bin/console}} cache:clear {{console_options}}');
+    }
 });
 
 desc('Deploy project');
@@ -57,6 +56,5 @@ task('deploy', [
     'deploy:prepare',
     'deploy:vendors',
     'deploy:cache:clear',
-    'deploy:cache:warmup',
     'deploy:publish',
 ]);


### PR DESCRIPTION
Any standard symfony app is running cache:clear on composer install ever since.
I.e. in composer.json

```
"scripts": {
    "auto-scripts": {
      "cache:clear": "symfony-cmd",
      "assets:install %PUBLIC_DIR%": "symfony-cmd"
    },
    "post-install-cmd": [
      "@auto-scripts"
    ],
    "post-update-cmd": [
      "@auto-scripts"
    ]
  },
```

This prevents cache clearing being run twice for no reason.

- [ ] Bug fix #…?
- [ ] New feature?
- [x] BC breaks?
I've removed the task deploy:cache:warmup as it is now part of cache:clear which only runs if composer was run with --no-scripts
Since deployer is in beta, I think it's the right thing to do now.

- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
