### PR TITLE
Fixed process args not being escaped in Master

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,8 @@ name: check
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   phpstan:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,9 @@ name: check
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   docgen:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,8 @@ name: test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   unit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: test
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     ],
     "require": {
         "marcj/topsort": "^2.0",
+        "nikic/iter": "^2.1",
         "psr/http-message": "^1",
         "react/http": "^1",
         "symfony/console": "^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b35ae79e1110869b883a0ae6f3961566",
+    "content-hash": "2fe14537806113eee8ac153ee37f5f7a",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -106,6 +106,61 @@
                 }
             ],
             "time": "2020-09-24T12:39:55+00:00"
+        },
+        {
+            "name": "nikic/iter",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/iter.git",
+                "reference": "a7f3aa313c1315e14cf1d7e520c0f781f584a42f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/iter/zipball/a7f3aa313c1315e14cf1d7e520c0f781f584a42f",
+                "reference": "a7f3aa313c1315e14cf1d7e520c0f781f584a42f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/iter.func.php",
+                    "src/iter.php",
+                    "src/iter.rewindable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Iteration primitives using generators",
+            "keywords": [
+                "functional",
+                "generator",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/iter/issues",
+                "source": "https://github.com/nikic/iter/tree/v2.1.0"
+            },
+            "time": "2020-09-19T15:58:13+00:00"
         },
         {
             "name": "psr/container",
@@ -4435,5 +4490,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,7 @@
  * [`download()`](#download)
  * [`info()`](#info)
  * [`warning()`](#warning)
+ * [`write()`](#write)
  * [`writeln()`](#writeln)
  * [`parse()`](#parse)
  * [`set()`](#set)
@@ -475,10 +476,19 @@ warning(string $message): void
 Writes an warning message.
 
 
+## write()
+
+```php
+write(string $message, int $options = 0): void
+```
+
+Writes a message to the output.
+
+
 ## writeln()
 
 ```php
-writeln($message, int $options = 0): void
+writeln(string $message, int $options = 0): void
 ```
 
 Writes a message to the output and adds a newline at the end.

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -219,6 +219,7 @@ class Master
                 $this->server->getPort(),
             ],
             [Stringify::verbosity($this->output->getVerbosity())],
+            $this->output->isDecorated() ? ['--decorated'] : [],
             Arrayify::options($this->input)
         ));
 

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -14,7 +14,7 @@ use Deployer\Exception\Exception;
 use Deployer\Host\Host;
 use Deployer\Host\Localhost;
 use Deployer\Selector\Selector;
-use Deployer\Support\Stringify;
+use Deployer\Support\Arrayify;
 use Deployer\Task\Task;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -205,18 +205,22 @@ class Master
 
     protected function createProcess(Host $host, Task $task): Process
     {
-        $dep = PHP_BINARY . ' ' . DEPLOYER_BIN;
-        $options = Stringify::options($this->input, $this->output);
-        if ($task->isVerbose() && $this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL) {
-            $options .= ' -v';
-        }
-        $command = "$dep worker --task $task --host {$host->getAlias()} --port {$this->server->getPort()} {$options}";
-
-        if ($this->output->isDebug()) {
-            $this->output->writeln("[$host] $command");
-        }
-
-        return Process::fromShellCommandline($command);
+        return new Process(array_merge(
+            [
+                PHP_BINARY,
+                DEPLOYER_BIN,
+                'worker',
+                '--task',
+                $task,
+                '--host',
+                $host->getAlias(),
+                '--port',
+                $this->server->getPort(),
+            ],
+            $task->isVerbose() && $this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
+                ? ['-v'] : [],
+            Arrayify::options($this->input)
+        ));
     }
 
     /**

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -15,6 +15,7 @@ use Deployer\Host\Host;
 use Deployer\Host\Localhost;
 use Deployer\Selector\Selector;
 use Deployer\Support\Arrayify;
+use Deployer\Support\Stringify;
 use Deployer\Task\Task;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -218,13 +218,12 @@ class Master
                 '--port',
                 $this->server->getPort(),
             ],
-            $task->isVerbose() && $this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
-                ? ['-v'] : [],
+            [Stringify::verbosity($this->output->getVerbosity())],
             Arrayify::options($this->input)
         ));
 
         if ($this->output->isDebug()) {
-            $this->output->writeln("[$host] {$process->getCommandLine()}}");
+            $this->output->writeln("[$host] {$process->getCommandLine()}");
         }
 
         return $process;

--- a/src/Executor/Master.php
+++ b/src/Executor/Master.php
@@ -205,7 +205,7 @@ class Master
 
     protected function createProcess(Host $host, Task $task): Process
     {
-        return new Process(array_merge(
+        $process = new Process(array_merge(
             [
                 PHP_BINARY,
                 DEPLOYER_BIN,
@@ -221,6 +221,12 @@ class Master
                 ? ['-v'] : [],
             Arrayify::options($this->input)
         ));
+
+        if ($this->output->isDebug()) {
+            $this->output->writeln("[$host] {$process->getCommandLine()}}");
+        }
+
+        return $process;
     }
 
     /**

--- a/src/Support/Arrayify.php
+++ b/src/Support/Arrayify.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Deployer\Support;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+final class Arrayify
+{
+    public static function options(InputInterface $input): array
+    {
+        $options = array_filter($input->getOptions());
+
+        return iterator_to_array(
+            \iter\flatten(
+                \iter\zip(
+                    \iter\map(fn ($name) => "--$name", \iter\keys($options)),
+                    \iter\values($options)
+                )
+            )
+        );
+    }
+}

--- a/src/Support/Arrayify.php
+++ b/src/Support/Arrayify.php
@@ -1,6 +1,4 @@
-<?php
-declare(strict_types=1);
-
+<?php declare(strict_types=1);
 namespace Deployer\Support;
 
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Support/Arrayify.php
+++ b/src/Support/Arrayify.php
@@ -2,6 +2,10 @@
 namespace Deployer\Support;
 
 use Symfony\Component\Console\Input\InputInterface;
+use function iter\flatten;
+use function iter\map;
+use function iter\mapWithKeys;
+use function iter\toArray;
 
 final class Arrayify
 {
@@ -9,11 +13,13 @@ final class Arrayify
     {
         $options = array_filter($input->getOptions());
 
-        return iterator_to_array(
-            \iter\flatten(
-                \iter\zip(
-                    \iter\map(fn ($name) => "--$name", \iter\keys($options)),
-                    \iter\values($options)
+        return toArray(
+            flatten(
+                mapWithKeys(
+                    fn ($v, $k) => is_array($v)
+                        ? map(fn ($v) => ["--$k", $v], $v)
+                        : ["--$k", $v],
+                    $options
                 )
             )
         );

--- a/src/functions.php
+++ b/src/functions.php
@@ -600,7 +600,7 @@ function warning(string $message): void
 /**
  * Writes a message to the output.
  */
-function write(string|iterable $message, int $options = 0): void
+function write(string $message, int $options = 0): void
 {
     output()->write(parse($message), false, $options);
 }
@@ -608,7 +608,7 @@ function write(string|iterable $message, int $options = 0): void
 /**
  * Writes a message to the output and adds a newline at the end.
  */
-function writeln(string|iterable $message, int $options = 0): void
+function writeln(string $message, int $options = 0): void
 {
     $host = currentHost();
     output()->writeln("[$host] " . parse($message), $options);

--- a/src/functions.php
+++ b/src/functions.php
@@ -598,10 +598,17 @@ function warning(string $message): void
 }
 
 /**
- * Writes a message to the output and adds a newline at the end.
- * @param string|array $message
+ * Writes a message to the output.
  */
-function writeln($message, int $options = 0): void
+function write(string|iterable $message, int $options = 0): void
+{
+    output()->write(parse($message), false, $options);
+}
+
+/**
+ * Writes a message to the output and adds a newline at the end.
+ */
+function writeln(string|iterable $message, int $options = 0): void
 {
     $host = currentHost();
     output()->writeln("[$host] " . parse($message), $options);

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -48,7 +48,7 @@ abstract class AbstractTest extends TestCase
         $this->tester = new ApplicationTester($console);
 
         $this->deployer = new Deployer($console);
-        $this->deployer->importer->import($recipe);
+        $this->deployer->importer::import($recipe);
         $this->deployer->init();
         $this->deployer->config->set('deploy_path', __TEMP_DIR__ . '/{{hostname}}');
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,10 +30,10 @@ require_once __DIR__ . '/AbstractTest.php';
 // Init repository
 $repository = __REPOSITORY__;
 
-`cd $repository && git init`;
+`cd "$repository" && git init`;
 $branch = trim(`git rev-parse --abbrev-ref HEAD`);
-`cd $repository && git checkout -B $branch 2>&1`;
-`cd $repository && git add .`;
-`cd $repository && git config user.name 'Anton Medvedev'`;
-`cd $repository && git config user.email 'anton.medv@example.com'`;
-`cd $repository && git commit -m 'first commit'`;
+`cd "$repository" && git checkout -B $branch 2>&1`;
+`cd "$repository" && git add .`;
+`cd "$repository" && git config user.name 'Anton Medvedev'`;
+`cd "$repository" && git config user.email 'anton.medv@example.com'`;
+`cd "$repository" && git commit -m 'first commit'`;

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /project
 
 
 
-FROM php:8.0-apache AS server
+FROM php:7.3-apache AS server
 RUN apt-get update && apt-get install -y \
         acl \
         git \

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine AS composer
+FROM php:8.0-cli-alpine AS composer
 RUN apk add wget
 COPY ./scripts/install-composer.sh /tmp/install-composer.sh
 RUN sh /tmp/install-composer.sh
@@ -7,7 +7,7 @@ RUN sh /tmp/install-composer.sh
 
 
 
-FROM php:7.3-cli-alpine AS deployer
+FROM php:8.0-cli-alpine AS deployer
 RUN apk add \
         git \
         openssh-client \
@@ -22,7 +22,8 @@ RUN ssh-keygen \
 RUN git config --global user.email "e2e@deployer.test" \
     && git config --global user.name "E2E Deployer"
 
-ARG XDEBUG_VERSION=2.9.8
+ARG XDEBUG_VERSION=3.0.4
+ENV XDEBUG_MODE coverage
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
 	pecl install xdebug-$XDEBUG_VERSION; \
@@ -40,7 +41,7 @@ WORKDIR /project
 
 
 
-FROM php:7.3-apache AS server
+FROM php:8.0-apache AS server
 RUN apt-get update && apt-get install -y \
         acl \
         git \


### PR DESCRIPTION
* Restored `write()` function.

- [x] Bug fix #2450 
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

## Todo

@antonmedv I left a few things out, mostly relating to things `Stringify::options` did. Hope you don't mind picking those up:

* Forwarding verbosity (not sure why this is needed since there's already a `-v` switch added in the calling method?)
* Forwarding `--decorated` option.
* Adding test for `Arrayify::options`.
* Removing `Stringify::options` and accompanying test (no longer used).