### PR TITLE
DRAFT: First activate plugins/themes THEN build them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Fixed regex identifying "cd" commands in YAML scripts. The regex was not taking into account that multiple commands can be executed within the same line — e.g. "cd {{release_path}} && npm run prod". [#2509]
 - Slack default channel null breaks webhook. [#2525]
 - Support passing `null` as default in get(). [#2545]
+- Shopware recipe: First activate plugins THEN build them to avoid breaking theme:compile with unbuild themes (which were activated AFTER build).
 
 ### Removed
 - Removed the `artisan:public_disk` task. Use the `artisan:storage:link` task instead. [#2488]

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -196,10 +196,10 @@ task('sw:plugin:upgrade:all', static function () {
  * Grouped SW deploy tasks
  */
 task('sw:deploy', [
-    'sw:build',
     'sw:plugin:activate:all',
     'sw:database:migrate',
     'sw:plugin:migrate:all',
+    'sw:build',
     'sw:theme:compile',
     'sw:cache:clear',
 ]);


### PR DESCRIPTION
Currently the first step is to run bin/build.sh which builds all *ACTIVATED* themes. After this step we activate all composer-registered plugins (which in my case are all the themes) and THEN compile them. For new themes that means, that they are *NOT* build because they are activated AFTER building.

This PR fixes that and activated first and builds second.

- [X] Bug fix
- [x] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
