### PR TITLE
Fix typo in comment

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -64,7 +64,7 @@ task('deploy:update_code', function () {
 
     cd($bare);
 
-    // If remote url changed, drop `.git/repo` and reinstall.
+    // If remote url changed, drop `.dep/repo` and reinstall.
     if (run("$git config --get remote.origin.url") !== $repository) {
         cd('{{deploy_path}}');
         run("rm -rf $bare");


### PR DESCRIPTION
The $bare variable points to ".dep/repo" and not ".git/repo"

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

