### PR TITLE
Use `cleanup_use_sudo` in task `deploy:release`

### DIFF
--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -96,14 +96,15 @@ set('release_path', function () {
 
 desc('Prepare release. Clean up unfinished releases and prepare next release');
 task('deploy:release', function () {
+    $sudo = get('cleanup_use_sudo') ? 'sudo' : '';
     cd('{{deploy_path}}');
 
     // Clean up if there is unfinished release
     $previousReleaseExist = test('[ -h release ]');
 
     if ($previousReleaseExist) {
-        run('rm -rf "$(readlink release)"'); // Delete release
-        run('rm release'); // Delete symlink
+        run("$sudo rm -rf \"$(readlink release)\""); // Delete release
+        run("$sudo rm release"); // Delete symlink
     }
 
     // We need to get releases_list at same point as release_name,


### PR DESCRIPTION
This task failed every time because wie need `sudo` to clean. The code ist 1:1 copy from task `Cleaning up old releases` https://github.com/deployphp/deployer/blob/6.x/recipe/deploy/cleanup.php#L31.

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?
