### PR TITLE
Allow overriding deployer root directory globally

### DIFF
--- a/bin/dep
+++ b/bin/dep
@@ -101,5 +101,5 @@ exit(1);
 run:
 set_include_path($includePath . PATH_SEPARATOR . get_include_path());
 define('DEPLOYER_DEPLOY_FILE', $deployFile);
-define('DEPLOYER_ROOT', dirname($deployFile));
+define('DEPLOYER_ROOT', getenv('DEPLOYER_ROOT') !== false ? getenv('DEPLOYER_ROOT') : dirname($deployFile));
 \Deployer\Deployer::run(DEPLOYER_VERSION, $deployFile);

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -54,6 +54,10 @@
    ``` 
 8. Rename success task in ~~success~~ to `deploy:success`.
 9. Verbosity function (`isDebug()`, etc) deleted. Use `output()->isDebug()` instead.
+10. runLocally() commands are executed relative to the recipe file directory. This behaviour can be overridden via an environment variable:
+    ```bash
+    DEPLOYER_ROOT=. vendor/bin/dep taskname`
+    ```
 
 # Upgrade from 5.x to 6.x
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,3 +126,15 @@ dep autocomplete
 ```
 
 And follow instructions.
+
+### Local root directory
+
+By default `runLocally()` commands are executed relative to the recipe file directory. This can be overridden globally by setting an environment variable:
+```bash
+DEPLOYER_ROOT=. dep taskname`
+```
+
+Alternatively the root directory can be overridden per command via the cwd configuration.
+```php
+runLocally('ls', ['cwd' => '/root/directory']);
+```


### PR DESCRIPTION
Use an environment variable or setting to override the default deployer root
directory used for the runLocally() default cwd configuration.
Resolves #2628

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?