### PR TITLE
Fix a little typo and improve a little clarity.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -63,7 +63,7 @@ composer require deployer/deployer --dev
 Deployer comes with an autocomplete support for bash & zsh, so you don't need to 
 remember task names and options. 
 
-Add next line to you `.bash_profile`:
+Add next line to your `~/.bash_profile` or `~/.zshrc`:
 
 ```shell
 eval "$(dep autocomplete)"


### PR DESCRIPTION
Fix a typo.

Added "~/" to be clear that this is in user's "Home" directory.

Added `~/.zshrc` as some user uses ZSH terminal.
