### PR TITLE
Fixed git submodule command requires checked out worktree.

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -73,7 +73,7 @@ task('deploy:update_code', function () {
 
     // Copy to release_path.
     run("$git remote update 2>&1");
-    run("$git archive $at | tar -x -f - -C {{release_path}} 2>&1");
+    run("$git --work-tree={{release_path}} checkout $at");
 
     // Save revision in releases log.
     $rev = run("$git rev-list $at -1");

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -73,7 +73,7 @@ task('deploy:update_code', function () {
 
     // Copy to release_path.
     run("$git remote update 2>&1");
-    run("$git --work-tree={{release_path}} checkout $at");
+    run("$git --work-tree={{release_path}} checkout --force $at");
 
     // Save revision in releases log.
     $rev = run("$git rev-list $at -1");


### PR DESCRIPTION
Problem
- The [common solution for handling git submodules](https://stackoverflow.com/a/31627058/811306) does not work with Deployer, because Git isn't able to reference the main repo from the archive.

Proposed solution
1. Check out an actual work tree from the bare git repository, so that subsequent deployment commands requiring the repository data can operate.

Example
```yaml
tasks:
  build_app:
    script:
    - cd {{release_path}}
    - git --git-dir={{deploy_path}}/.dep/repo --work-tree=. submodule update --init --recursive
    - npm run install

after:
  deploy:update_code: build_app
```


- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [ ] Tests added?
- [ ] Changelog updated?

      Please, update CHANGELOG.md by running next command:
      $ php bin/changelog
