### PR TITLE
Fix SshCommand not retrieving the host by its alias

### DIFF
--- a/src/Command/SshCommand.php
+++ b/src/Command/SshCommand.php
@@ -47,7 +47,7 @@ class SshCommand extends Command
         $this->telemetry();
         $hostname = $input->getArgument('hostname');
         if (!empty($hostname)) {
-            $host = $this->deployer->hosts->get($hostname);
+            $host = $this->deployer->hosts->findOneByAlias($hostname);
         } else {
             $hostsAliases = [];
             foreach ($this->deployer->hosts as $host) {
@@ -73,7 +73,7 @@ class SshCommand extends Command
                 $question->setErrorMessage('There is no "%s" host.');
 
                 $hostname = $helper->ask($input, $output, $question);
-                $host = $this->deployer->hosts->get($hostname);
+                $host = $this->deployer->hosts->findOneByAlias($hostname);
             }
         }
 

--- a/src/Host/HostCollection.php
+++ b/src/Host/HostCollection.php
@@ -15,6 +15,28 @@ use Deployer\Collection\Collection;
  */
 class HostCollection extends Collection
 {
+    /**
+     * Find and return the first host in the collection with the given alias.
+     *
+     * @throws \InvalidArgumentException if no host is found
+     */
+    public function findOneByAlias(string $alias): Host
+    {
+        $matchingHost = null;
+
+        foreach ($this->values as $key => $host) {
+            if ($host->getAlias() === $alias) {
+                $matchingHost = $host;
+                break;
+            }
+        }
+        if (null === $matchingHost) {
+            $this->throwNotFound($alias);
+        }
+
+        return $matchingHost;
+    }
+
     protected function throwNotFound(string $name): void
     {
         throw new \InvalidArgumentException("Host \"$name\" not found.");

--- a/tests/src/Host/HostCollectionTest.php
+++ b/tests/src/Host/HostCollectionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Deployer\Host;
+
+use PHPUnit\Framework\TestCase;
+
+class HostCollectionTest extends TestCase
+{
+    public function testFindOneByAlias(): HostCollection
+    {
+        $hosts = [];
+        $hosts[] = new Host('host_1');
+        $hosts[] = (new Host('host_2'))->set('alias', 'Aliased_host_2');
+
+        $hostCollection = new HostCollection();
+        $hostsByAlias = [];
+        foreach ($hosts as $host) {
+            $hostCollection->set($host->getHostname(), $host);
+            $hostsByAlias[$host->getAlias()] = $host;
+        }
+
+        foreach ($hostsByAlias as $alias => $host) {
+            $this->assertEquals($host, $hostCollection->findOneByAlias($alias));
+        }
+
+        return $hostCollection;
+    }
+
+    /**
+     * @depends testFindOneByAlias
+     */
+    public function testFindOneByAliasException(HostCollection $hostCollection): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $hostCollection->findOneByAlias('unexpected');
+    }
+}


### PR DESCRIPTION
This PR enforces the use of host aliases by the ssh command.

I'm not sure if this is the intended behaviour though, so let me know if modifications should be made.

I also don't know if this is a breaking change since I never used v6.8 (I'm new to Deployer)

- [x] Bug fix #2528
- [ ] New feature?
- [ ] BC breaks?
- [ ] Deprecations?
- [x] Tests added?
- [ ] Docs updated?
- [ ] Changelog updated?
