### PR TITLE
feat: add support for hidden keys in yaml files

### DIFF
--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -29,6 +29,7 @@ use function Deployer\set;
 use function Deployer\Support\find_line_number;
 use function Deployer\task;
 use function Deployer\upload;
+use function substr;
 use const ARRAY_FILTER_USE_KEY;
 
 class Importer
@@ -65,7 +66,7 @@ class Importer
                 self::$recipeFilename = basename($path);
                 self::$recipeSource = file_get_contents($path);
                 $root = array_filter(Yaml::parse(self::$recipeSource), static function (string $key) {
-                    return strpos($key, '.') === false;
+                    return substr($key, 0, 1) !== '.';
                 }, ARRAY_FILTER_USE_KEY);
 
                 $schema = 'file://' . __DIR__ . '/../schema.json';

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -15,6 +15,8 @@ use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
 use Symfony\Component\Yaml\Yaml;
+use function array_filter;
+use function array_keys;
 use function Deployer\after;
 use function Deployer\before;
 use function Deployer\cd;
@@ -27,6 +29,7 @@ use function Deployer\set;
 use function Deployer\Support\find_line_number;
 use function Deployer\task;
 use function Deployer\upload;
+use const ARRAY_FILTER_USE_KEY;
 
 class Importer
 {
@@ -61,7 +64,9 @@ class Importer
             } else if (preg_match('/\.ya?ml$/i', $path)) {
                 self::$recipeFilename = basename($path);
                 self::$recipeSource = file_get_contents($path);
-                $root = Yaml::parse(self::$recipeSource);
+                $root = array_filter(Yaml::parse(self::$recipeSource), static function (string $key) {
+                    return strpos($key, '.') === false;
+                }, ARRAY_FILTER_USE_KEY);
 
                 $schema = 'file://' . __DIR__ . '/../schema.json';
                 if (Deployer::isPharArchive()) {

--- a/tests/src/Importer/ImporterTest.php
+++ b/tests/src/Importer/ImporterTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Deployer\Importer;
+
+use Deployer\Deployer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImporterTest extends TestCase
+{
+    private $deployer;
+
+    protected function setUp(): void
+    {
+        $console = new Application();
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $this->deployer = new Deployer($console, $input, $output);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->deployer);
+    }
+
+    public function testImporterIgnoresYamlHiddenKeys(): void
+    {
+        $data = <<<EOL
+.base: &base
+  remote_user: foo
+  labels:
+    stage: production
+
+hosts:
+  acceptance:
+    <<: *base
+    labels:
+      stage: acceptance
+
+  production:
+    <<: *base
+    remote_user: bar
+# test.yaml
+EOL;
+
+        Importer::import("data:text/yaml,$data");
+        self::assertTrue(Deployer::get()->hosts->has('production'));
+        self::assertTrue(Deployer::get()->hosts->has('acceptance'));
+        self::assertEquals('acceptance', Deployer::get()->hosts->get('acceptance')->getLabels()['stage']);
+        self::assertEquals('production', Deployer::get()->hosts->get('production')->getLabels()['stage']);
+        self::assertEquals('foo', Deployer::get()->hosts->get('acceptance')->getRemoteUser());
+        self::assertEquals('bar', Deployer::get()->hosts->get('production')->getRemoteUser());
+    }
+}

--- a/tests/src/Importer/ImporterTest.php
+++ b/tests/src/Importer/ImporterTest.php
@@ -5,25 +5,23 @@ namespace Deployer\Importer;
 
 use Deployer\Deployer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class ImporterTest extends TestCase
 {
-    private $deployer;
+    private $previousInput;
+    private $previousOutput;
 
-    protected function setUp(): void
+    public function setUp(): void
     {
-        $console = new Application();
-        $input = $this->createMock(InputInterface::class);
-        $output = $this->createMock(OutputInterface::class);
-        $this->deployer = new Deployer($console, $input, $output);
+        $deployer = Deployer::get();
+        $this->previousInput = $deployer->input;
+        $this->previousOutput = $deployer->output;
     }
 
-    protected function tearDown(): void
+    public function tearDown(): void
     {
-        unset($this->deployer);
+        Deployer::get()->input = $this->previousInput;
+        Deployer::get()->output = $this->previousOutput;
     }
 
     public function testImporterIgnoresYamlHiddenKeys(): void

--- a/tests/src/Importer/ImporterTest.php
+++ b/tests/src/Importer/ImporterTest.php
@@ -43,12 +43,16 @@ hosts:
   production:
     <<: *base
     remote_user: bar
+  
+  production.beta:
+    <<: *base
 # test.yaml
 EOL;
 
         Importer::import("data:text/yaml,$data");
         self::assertTrue(Deployer::get()->hosts->has('production'));
         self::assertTrue(Deployer::get()->hosts->has('acceptance'));
+        self::assertTrue(Deployer::get()->hosts->has('production.beta'));
         self::assertEquals('acceptance', Deployer::get()->hosts->get('acceptance')->getLabels()['stage']);
         self::assertEquals('production', Deployer::get()->hosts->get('production')->getLabels()['stage']);
         self::assertEquals('foo', Deployer::get()->hosts->get('acceptance')->getRemoteUser());


### PR DESCRIPTION
As discussed in https://github.com/deployphp/deployer/discussions/2709, I'd like to add back support for root level hidden keys in YAML files. 

I've chosen to remove the hidden keys completely after parsing because their references are already resolved during loading, so there is no point in keeping them after that. That's also the reason why I didn't change the JSON schema file that validates the contents of the input data.

- [x] New feature?
- [x] Tests added?