### PR TITLE
Increase min-version of react/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ext-json": "*",
         "justinrainbow/json-schema": "^5.2",
         "psr/http-message": "^1",
-        "react/http": "^1",
+        "react/http": "^1.5",
         "symfony/console": "^5",
         "symfony/polyfill-php80": "^1.22",
         "symfony/process": "^5",


### PR DESCRIPTION
- [x] Bug fix?
- [ ] New feature?
- [x] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

`Deployer\Executor\Server` uses `React\Http\HttpServer`, but that class is only available in `react/http:^1.5`, therefore I changed the min-requirement