### PR TITLE
Make Magento 2 recipe suitable for push strategy deployments

### DIFF
--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -22,28 +22,15 @@ in you deployer script.
 ```
 
 
-### push_strategy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L26)
-
-By default, the deployment strategy for this recipe is
-pull instead of push, to make it backwards compatible with Deployer 6.
-If you change this to push, you will have to push the generated & compiled
-files yourself, for example by adding a rsync hook after deploy:release
-
-```php title="Default value"
-false
-```
-
-
 ### content_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L28)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L22)
 
 
 
 
 
 ### shared_files
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L32)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L26)
 
 Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recipe/deploy/shared.php`.
 
@@ -58,7 +45,7 @@ Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recip
 
 
 ### shared_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L36)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L30)
 
 Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/deploy/shared.php`.
 
@@ -83,7 +70,7 @@ Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/
 
 
 ### writable_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L50)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L44)
 
 Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`.
 
@@ -100,7 +87,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### clear_paths
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L56)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L50)
 
 Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `recipe/deploy/clear_paths.php`.
 
@@ -119,14 +106,14 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 
 
 ### magento_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L65)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L59)
 
 
 
 
 
 ### maintenance_mode_status_active
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L72)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L66)
 
 
 
@@ -136,7 +123,7 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 ## Tasks
 
 ### magento:compile
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L80)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L74)
 
 Compile magento di.
 
@@ -144,7 +131,7 @@ Tasks
 
 
 ### magento:deploy:assets
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L87)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L81)
 
 Deploy assets.
 
@@ -152,7 +139,7 @@ Deploy assets.
 
 
 ### magento:sync:content_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L92)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L86)
 
 Sync content version.
 
@@ -160,7 +147,7 @@ Sync content version.
 
 
 ### magento:maintenance:enable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L102)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L96)
 
 Enable maintenance mode.
 
@@ -168,7 +155,7 @@ Enable maintenance mode.
 
 
 ### magento:maintenance:disable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L107)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L101)
 
 Disable maintenance mode.
 
@@ -176,7 +163,7 @@ Disable maintenance mode.
 
 
 ### magento:config:import
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L112)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L106)
 
 Config Import.
 
@@ -184,7 +171,7 @@ Config Import.
 
 
 ### magento:upgrade:db
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L147)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L141)
 
 Upgrade magento database.
 
@@ -192,7 +179,7 @@ Upgrade magento database.
 
 
 ### magento:cache:flush
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L174)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L168)
 
 Flush Magento Cache.
 
@@ -200,7 +187,7 @@ Flush Magento Cache.
 
 
 ### deploy:magento
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L179)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L173)
 
 Magento2 deployment operations.
 
@@ -208,12 +195,27 @@ Magento2 deployment operations.
 
 
 This task is group task which contains next tasks:
+* [magento:build](/docs/recipe/magento2.md#magentobuild)
 * [magento:config:import](/docs/recipe/magento2.md#magentoconfigimport)
 * [magento:upgrade:db](/docs/recipe/magento2.md#magentoupgradedb)
+* [magento:cache:flush](/docs/recipe/magento2.md#magentocacheflush)
+
+
+### magento:build
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L181)
+
+Magento2 build operations.
+
+
+
+
+This task is group task which contains next tasks:
+* [magento:compile](/docs/recipe/magento2.md#magentocompile)
+* [magento:deploy:assets](/docs/recipe/magento2.md#magentodeployassets)
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L186)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L187)
 
 Deploy your project.
 
@@ -222,6 +224,7 @@ Deploy your project.
 
 This task is group task which contains next tasks:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare)
+* [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors)
 * [deploy:clear_paths](/docs/recipe/deploy/clear_paths.md#deployclear_paths)
 * [deploy:magento](/docs/recipe/magento2.md#deploymagento)
 * [deploy:publish](/docs/recipe/common.md#deploypublish)

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -22,15 +22,28 @@ in you deployer script.
 ```
 
 
+### push_strategy
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L26)
+
+By default, the deployment strategy for this recipe is
+pull instead of push, to make it backwards compatible with Deployer 6.
+If you change this to push, you will have to push the generated & compiled
+files yourself, for example by adding a rsync hook after deploy:release
+
+```php title="Default value"
+false
+```
+
+
 ### content_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L22)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L28)
 
 
 
 
 
 ### shared_files
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L26)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L32)
 
 Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recipe/deploy/shared.php`.
 
@@ -45,7 +58,7 @@ Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recip
 
 
 ### shared_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L30)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L36)
 
 Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/deploy/shared.php`.
 
@@ -70,7 +83,7 @@ Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/
 
 
 ### writable_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L44)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L50)
 
 Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`.
 
@@ -87,7 +100,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### clear_paths
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L50)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L56)
 
 Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `recipe/deploy/clear_paths.php`.
 
@@ -106,14 +119,14 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 
 
 ### magento_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L59)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L65)
 
 
 
 
 
 ### maintenance_mode_status_active
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L66)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L72)
 
 
 
@@ -123,7 +136,7 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 ## Tasks
 
 ### magento:compile
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L74)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L80)
 
 Compile magento di.
 
@@ -131,7 +144,7 @@ Tasks
 
 
 ### magento:deploy:assets
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L81)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L87)
 
 Deploy assets.
 
@@ -139,7 +152,7 @@ Deploy assets.
 
 
 ### magento:sync:content_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L86)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L92)
 
 Sync content version.
 
@@ -147,7 +160,7 @@ Sync content version.
 
 
 ### magento:maintenance:enable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L96)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L102)
 
 Enable maintenance mode.
 
@@ -155,7 +168,7 @@ Enable maintenance mode.
 
 
 ### magento:maintenance:disable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L101)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L107)
 
 Disable maintenance mode.
 
@@ -163,7 +176,7 @@ Disable maintenance mode.
 
 
 ### magento:config:import
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L106)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L112)
 
 Config Import.
 
@@ -171,7 +184,7 @@ Config Import.
 
 
 ### magento:upgrade:db
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L141)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L147)
 
 Upgrade magento database.
 
@@ -179,7 +192,7 @@ Upgrade magento database.
 
 
 ### magento:cache:flush
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L168)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L174)
 
 Flush Magento Cache.
 
@@ -187,7 +200,7 @@ Flush Magento Cache.
 
 
 ### deploy:magento
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L173)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L179)
 
 Magento2 deployment operations.
 
@@ -195,14 +208,12 @@ Magento2 deployment operations.
 
 
 This task is group task which contains next tasks:
-* [magento:compile](/docs/recipe/magento2.md#magentocompile)
-* [magento:deploy:assets](/docs/recipe/magento2.md#magentodeployassets)
 * [magento:config:import](/docs/recipe/magento2.md#magentoconfigimport)
 * [magento:upgrade:db](/docs/recipe/magento2.md#magentoupgradedb)
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L182)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L186)
 
 Deploy your project.
 
@@ -211,7 +222,6 @@ Deploy your project.
 
 This task is group task which contains next tasks:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare)
-* [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors)
 * [deploy:clear_paths](/docs/recipe/deploy/clear_paths.md#deployclear_paths)
 * [deploy:magento](/docs/recipe/magento2.md#deploymagento)
 * [deploy:publish](/docs/recipe/common.md#deploypublish)

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -19,12 +19,6 @@ add('recipes', ['magento2']);
 // in you deployer script.
 set('static_content_locales', 'en_US');
 
-// By default, the deployment strategy for this recipe is
-// pull instead of push, to make it backwards compatible with Deployer 6.
-// If you change this to push, you will have to push the generated & compiled
-// files yourself, for example by adding a rsync hook after deploy:release
-set('push_strategy', false);
-
 set('content_version', function () {
     return time();
 });
@@ -177,25 +171,25 @@ task('magento:cache:flush', function () {
 
 desc('Magento2 deployment operations');
 task('deploy:magento', [
+    'magento:build',
     'magento:config:import',
     'magento:upgrade:db',
-    'magento:cache:flush'
+    'magento:cache:flush',
+]);
+
+desc('Magento2 build operations');
+task('magento:build', [
+    'magento:compile',
+    'magento:deploy:assets',
 ]);
 
 desc('Deploy your project');
 task('deploy', [
     'deploy:prepare',
+    'deploy:vendors',
     'deploy:clear_paths',
     'deploy:magento',
     'deploy:publish',
 ]);
-
-if (get('push_strategy') === false) {
-    after('deploy_prepare', 'deploy:vendors');
-    before('magento:config:import', 'magento:compile');
-    before('magento:config:import', 'magento:deploy:assets');
-} else {
-    task('deploy:update_code')->disabled();
-}
 
 after('deploy:failed', 'magento:maintenance:disable');

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -195,9 +195,7 @@ if (get('push_strategy') === false) {
     before('magento:config:import', 'magento:compile');
     before('magento:config:import', 'magento:deploy:assets');
 } else {
-    task('deploy:update_code', function () {
-        // Do not update code when using push strategy
-    });
+    task('deploy:update_code')->disabled();
 }
 
 after('deploy:failed', 'magento:maintenance:disable');


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

When refactoring our Deployer 6 recipes for Magento 2 to Deployer 7, I was eventually left with this code block in all our deployment configurations;

```php
// Override default recipe tasks since we use a push-approach instead of a pull-approach
task('deploy', [
    'deploy:prepare',
//    'deploy:vendors', // We run composer install in the CI pipeline
    'deploy:clear_paths',
    'deploy:magento',
    'deploy:publish',
]);
task('deploy:magento', [
    //'magento:compile', // We run bin/magento setup:di:compile in the CI pipeline
    //'magento:deploy:assets', // We run bin/magento setup:static-content:deploy in the CI pipeline
    'magento:config:import',
    'magento:upgrade:db',
    'magento:cache:flush'
]);
task('deploy:prepare', [
    'deploy:info',
    'deploy:setup',
    'deploy:lock',
    'deploy:release',
    //`deploy:update_code`, // We do not push or pull the Git repo
    'deploy:shared',
    'deploy:writable',
]);
```

This is because we don't compile DI and generate static assets on the production server but instead in our CI/CD pipeline. I know for a fact a large number of other Magento 2 developers also do this, so they will also need to override in some way what we did above.

To facilitate the push (instead of pull) deployment strategy, I have introduced a setting `push_strategy` which by default is set to `false`. This will make sure the recipe is backwards compatible.

However, if the `push_strategy` is set to true (or, non-false), the following tasks will not be run;

- `deploy:vendors`
- `magento:compile`
- `magento:deploy:assets`
- `deploy:update_code`

Technically, the `deploy:update_code` will run, but the task is set to do nothing. This is because this task lives in the common recipe, so we can't add a Magento-specific check there. This will only be a problem in edge cases where somebody configured an after hook on `deploy:update_code` which will assume the code is actually updated.

Merging this PR will make our `deploy.php` file a lot cleaner and easier to grasp. It will also make upgrading to future versions easier/less error-prone since there is less code overridden.

Edit:

Using `disabled()` makes this a lot easier. This PR is now updated to move the build steps into its own group, so we can disable the pull approach by adding 3 lines;

```php
task('deploy:vendors')->disabled();
task('deploy:update_code')->disabled();
task('magento:build')->disabled();
```