### PR TITLE
Fix controlPath (length < 104)

### DIFF
--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -259,7 +259,7 @@ class Client
                     $controlPath = "$homeDir/.ssh/deployer_$connectionData";
             }
             $tryLongestPossible++;
-        } while (strlen($controlPath) + $connectionHashLength > $unixMaxPath); // Unix socket max length
+        } while (strlen($controlPath) + $connectionHashLength >= $unixMaxPath); // Unix socket max length
 
         return $controlPath;
     }


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

In my case the string had exactly 104 chars and I got the error:
> unix_listener: [...] too long for Unix domain socket

With 103 chars it is working (I temporally changed return line to `return substr($controlPath, 0, -1)`).