### PR TITLE
Fix Magento 2 version check task

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -59,8 +59,8 @@ set('clear_paths', [
 set('magento_version', function () {
     // detect version
     $versionOutput = run('{{bin/php}} {{release_or_current_path}}/bin/magento --version');
-    preg_match('/(\d+\.?)+$/', $versionOutput, $matches);
-    return $matches[0] ?? "2.0";
+    preg_match("/(?:Magento\s|Magento\sCLI\s)*((?:[0-9]+\.?)+)/i", $versionOutput, $matches);
+    return $matches[1] ?? "2.0";
 });
 
 set('maintenance_mode_status_active', function () {

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -59,8 +59,8 @@ set('clear_paths', [
 set('magento_version', function () {
     // detect version
     $versionOutput = run('{{bin/php}} {{release_or_current_path}}/bin/magento --version');
-    preg_match("/(?:Magento\s|Magento\sCLI\s)*((?:[0-9]+\.?)+)/i", $versionOutput, $matches);
-    return $matches[1] ?? "2.0";
+    preg_match("#\d+(?:\.\d+)+#", $versionOutput, $matches);
+    return $matches[0] ?? "2.0";
 });
 
 set('maintenance_mode_status_active', function () {


### PR DESCRIPTION
Magento 2 now outputs 'Magento CLI 2.4.3-p1' (or similar) when running `bin/magento --version`. The regex incorrectly returned `1`, making the version check think it was < 2.2.0 and never running app:config:import (see https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L111).

This PR fixes the version check with backwards compatibility;

```php
php > $versionOutput = '2.4.3';
php > preg_match("#\d+(?:\.\d+)+#", $versionOutput, $matches);
php > print_r($matches);
Array
(
    [0] => 2.4.3
)
php > $versionOutput = 'Magento 2.4.3';
php > preg_match("#\d+(?:\.\d+)+#", $versionOutput, $matches);
php > print_r($matches);
Array
(
    [0] => 2.4.3
)
php > $versionOutput = 'Magento CLI 2.4.3';
php > preg_match("#\d+(?:\.\d+)+#", $versionOutput, $matches);
php > print_r($matches);
Array
(
    [0] => 2.4.3
)
php > $versionOutput = 'Magento CLI 2.4.3-p1';
php > preg_match("#\d+(?:\.\d+)+#", $versionOutput, $matches);
php > print_r($matches);
Array
(
    [0] => 2.4.3
)
```