### PR TITLE
Fix php-fpm unix socket in provision recipe

### DIFF
--- a/recipe/provision/website.php
+++ b/recipe/provision/website.php
@@ -30,7 +30,7 @@ $domain
 
 root * $deployPath/current/$publicPath
 file_server
-php_fastcgi * unix/run/php/php$phpVersion-fpm.sock {
+php_fastcgi * unix//run/php/php$phpVersion-fpm.sock {
 \tresolve_root_symlink
 }
 


### PR DESCRIPTION
Caddy was unable to proxy request to php-fpm unix socket, after some research found missing `/` in configuration

Reference: https://caddyserver.com/docs/caddyfile/directives/php_fastcgi#examples

- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
