### PR TITLE
Fix timeout for heavy tasks in provision recipe

### DIFF
--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -100,7 +100,7 @@ task('provision:update', function () {
 
 desc('Upgrades all packages');
 task('provision:upgrade', function () {
-    run('apt-get upgrade -y', ['env' => ['DEBIAN_FRONTEND' => 'noninteractive']]);
+    run('apt-get upgrade -y', ['env' => ['DEBIAN_FRONTEND' => 'noninteractive'], 'timeout' => 900]);
 })
     ->oncePerNode()
     ->verbose();
@@ -133,7 +133,7 @@ task('provision:install', function () {
         'uuid-runtime',
         'whois',
     ];
-    run('apt-get install -y ' . implode(' ', $packages), ['env' => ['DEBIAN_FRONTEND' => 'noninteractive']]);
+    run('apt-get install -y ' . implode(' ', $packages), ['env' => ['DEBIAN_FRONTEND' => 'noninteractive'], 'timeout' => 900]);
 })
     ->verbose()
     ->oncePerNode();


### PR DESCRIPTION
Testing deployer & the new provision recipe I noticed timeout for heavy tasks such as "Upgrades all packages" and "Installs packages".
The timeout for this tasks now is 15 minutes, WDYT?

![Screenshot from 2021-11-14 18-31-45](https://user-images.githubusercontent.com/16133208/141695347-f89bd2c1-8c2b-45c8-a84a-a485ec6d69cf.png)
![Screenshot from 2021-11-14 18-40-08](https://user-images.githubusercontent.com/16133208/141695350-8cd24a2d-da83-4cbb-93f5-5851e2fcacf7.png)


- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
