### PR TITLE
[Docs] GitLab CI/CD

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -26,7 +26,7 @@ deploy:
     - eval $(ssh-agent -s)
     - echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
     - chmod 644 ~/.ssh/known_hosts
-    - echo "${SSH_PRIVATE_KEY}" | tr -d '\r' | ssh-add - > /dev/null
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
   script:
     - dep deploy -vvv
   resource_group: production
@@ -38,3 +38,18 @@ deploy:
 Only one deployment job runs at a time with the [`resource_group` keyword](https://docs.gitlab.com/ee/ci/yaml/index.html#resource_group) in .gitlab-ci.yml.
 
 In addition, you can ensure that older deployment jobs are cancelled automatically when a newer deployment runs by enabling the [Skip outdated deployment jobs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#skip-outdated-deployment-jobs) feature.
+
+###Deploy secrets
+Since it is not recommended pushing secrets in the repository, you could use a GitLab variable to store them.
+
+Many frameworks use dotenv to store secrets, let's create a GitLab file variable named `DOTENV`, so it can be deployed along with the code.
+
+Set up a deployer task to copy secrets to the server:
+
+```php
+task('deploy:secrets', function () {
+    upload(getenv('DOTENV'), get('deploy_path') . '/shared/.env');
+});
+```
+
+Run the task immediately after updating the code.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,10 +4,10 @@
 
 Set the following variables in GitLab project:
 
-- `SSH_PRIVATE_KEY`: Content of `~/.ssh/known_hosts` file. 
+- `SSH_KNOW_HOSTS`: Content of `~/.ssh/known_hosts` file. 
 The public SSH keys for a host may be obtained using the utility `ssh-keyscan`. 
 For example: `ssh-keyscan deployer.org`.
-- `SSH_KNOW_HOSTS`: Private key for connecting to remote hosts. 
+- `SSH_PRIVATE_KEY`: Private key for connecting to remote hosts. 
 To generate private key: `ssh-keygen -t ed25519 -C 'gitlab@deployer.org'`.
 
 Create .gitlab-ci.yml file with following content:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,6 +1,6 @@
 # CI/CD
 
-### GitLab CI/CD
+## GitLab CI/CD
 
 Set the following variables in GitLab project:
 
@@ -29,6 +29,12 @@ deploy:
     - echo "${SSH_PRIVATE_KEY}" | tr -d '\r' | ssh-add - > /dev/null
   script:
     - dep deploy -vvv
+  resource_group: production
   only:
     - master
 ```
+
+###Deployment concurrency
+Only one deployment job runs at a time with the [`resource_group` keyword](https://docs.gitlab.com/ee/ci/yaml/index.html#resource_group) in .gitlab-ci.yml.
+
+In addition, you can ensure that older deployment jobs are cancelled automatically when a newer deployment runs by enabling the [Skip outdated deployment jobs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#skip-outdated-deployment-jobs) feature.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,3 +1,34 @@
 # CI/CD
 
-TODO
+### GitLab CI/CD
+
+Set the following variables in GitLab project:
+
+- `SSH_PRIVATE_KEY`: Content of `~/.ssh/known_hosts` file. 
+The public SSH keys for a host may be obtained using the utility `ssh-keyscan`. 
+For example: `ssh-keyscan deployer.org`.
+- `SSH_KNOW_HOSTS`: Private key for connecting to remote hosts. 
+To generate private key: `ssh-keygen -t ed25519 -C 'gitlab@deployer.org'`.
+
+Create .gitlab-ci.yml file with following content:
+
+```yml
+stages:
+  - deploy
+
+deploy:
+  stage: deploy
+  image:
+    name: debreczeniandras/deployerphp:7-beta
+    entrypoint: [""]
+  before_script:
+    - mkdir -p ~/.ssh
+    - eval $(ssh-agent -s)
+    - echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+    - chmod 644 ~/.ssh/known_hosts
+    - echo "${SSH_PRIVATE_KEY}" | tr -d '\r' | ssh-add - > /dev/null
+  script:
+    - dep deploy -vvv
+  only:
+    - master
+```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -39,6 +39,9 @@ Only one deployment job runs at a time with the [`resource_group` keyword](https
 
 In addition, you can ensure that older deployment jobs are cancelled automatically when a newer deployment runs by enabling the [Skip outdated deployment jobs](https://docs.gitlab.com/ee/ci/pipelines/settings.html#skip-outdated-deployment-jobs) feature.
 
+###Deploy code
+Since by default every GitLab CI job already clone the repo, you could use [`rsync`](contrib/rsync.md#usage) task instead of `deploy:update_code` to upload the code from the job to the host.
+
 ###Deploy secrets
 Since it is not recommended pushing secrets in the repository, you could use a GitLab variable to store them.
 


### PR DESCRIPTION
With this PR I tried to illustrate the deployment process, in a synthetic and simple way, through GitLab CI/CD.
The [docker image](https://github.com/debreczeniandras/deployerphp) used to run deployer is based on latest PHP 7 CLI Alpine and Composer 2.
Obviously it would be nice to have an official docker image.
Let me know what you think :wink: 

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [X] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
