### PR TITLE
deployer should exit with error status code on exception

### DIFF
--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -315,6 +315,8 @@ class Deployer extends Container
                 $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
             }
             self::printException($output, $exception);
+            
+            exit(1);
         }
     }
 


### PR DESCRIPTION
Currently if exception happens inside deploy.php CI will mark job as succeeded.

This PR adds exit code to run command in case it fails with an exception.

- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?