### PR TITLE
Laravel: Add Route Cache to Deploy Tasks

### DIFF
--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -376,8 +376,9 @@ This task is group task which contains next tasks:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare)
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors)
 * [artisan:storage:link](/docs/recipe/laravel.md#artisanstoragelink)
-* [artisan:view:cache](/docs/recipe/laravel.md#artisanviewcache)
 * [artisan:config:cache](/docs/recipe/laravel.md#artisanconfigcache)
+* [artisan:route:cache](/docs/recipe/laravel.md#artisanroutecache)
+* [artisan:view:cache](/docs/recipe/laravel.md#artisanviewcache)
 * [artisan:migrate](/docs/recipe/laravel.md#artisanmigrate)
 * [deploy:publish](/docs/recipe/common.md#deploypublish)
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -221,8 +221,9 @@ task('deploy', [
     'deploy:prepare',
     'deploy:vendors',
     'artisan:storage:link',
-    'artisan:view:cache',
     'artisan:config:cache',
+    'artisan:route:cache',
+    'artisan:view:cache',
     'artisan:migrate',
     'deploy:publish',
 ]);


### PR DESCRIPTION
Caching Routes has been recommended since the early 5.x days to improve performace or production apps.
https://laravel.com/docs/8.x/deployment#optimizing-route-loading

Reorder optimization commands to same order as Laravel docs.