### PR TITLE
Sentry recipe fix regarding `git_version_command` with `update_code_strategy` set to `archive`

### DIFF
--- a/contrib/sentry.php
+++ b/contrib/sentry.php
@@ -228,6 +228,12 @@ function getReleaseGitRef(): Closure
 {
     return static function ($config = []): string {
         if (get('update_code_strategy') === 'archive') {
+            if (isset($config['git_version_command'])) {
+                cd('{{deploy_path}}/.dep/repo');
+
+                return trim(run($config['git_version_command']));
+            }
+
             return run('cat {{current_path}}/REVISION');
         }
 


### PR DESCRIPTION
Makes use of `git_version_command` (if defined) even when `update_code_strategy` is set to `archive`