### PR TITLE
Skip adding ssh key to known_hosts if http/https is used for repository

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -27,8 +27,15 @@ task('deploy:update_code', function () {
     $repository = get('repository');
     $target = get('target');
 
-    if (get('auto_ssh_keygen')) {
-        $url = parse_url($repository);
+    $skipKeygen = false;
+    $url = parse_url($repository);
+
+    // Skip keygen, if URL is using http/https as scheme
+    if (isset($url['scheme']) && in_array($url['scheme'], ['http', 'https'])) {
+        $skipKeygen = true;
+    }
+
+    if (get('auto_ssh_keygen') && !$skipKeygen) {
         if (isset($url['scheme']) && $url['scheme'] === 'ssh') {
             $host = $url['host'];
             $port = $url['port'] ?? '22';


### PR DESCRIPTION
In the current master, the *update_code* recipe is trying to add a ssh key to the `~/.ssh/known_hosts` file, even if the repository URL is using http or https as scheme. Additionally it parses the URL incorrectly.

For example I have an repository whose URL looks similar to that:

> https://myuser:mypassword@gitlab.example.com/customer/test.git

The [regular expression](https://github.com/deployphp/deployer/blob/a208879d4681dc7ef218c8452651a1664640b268/recipe/deploy/update_code.php#L35) used for parsing the URL assigns `['//myuser', 'myuser']` to the `$matches` variable. This results in 'myuser' used as host.

After that the command `ssh-keygen -F $host:$port || ssh-keyscan -p $port -H $host >> ~/.ssh/known_hosts` is executed. The debugging output looks like that:

> task deploy:update_code
> [...]
> [test] run ssh-keygen -F myuser:22 || ssh-keyscan -p 22 -H myuser >> ~/.ssh/known_hosts
> [test] getaddrinfo hdo: Temporary failure in name resolution

As you see the username part of the repository URL is used as ssh hostname. Of course this does not make sense. But further more this command may take a long time until ssh returns with a timeout, because it is trying to connect to the port.

This PR prevents the issue by checking the scheme of the URL before entering in the keygen/keyscan block.