### PR TITLE
Issue 2570: Add an option to deploy only a sub-folder of the repository

### DIFF
--- a/docs/recipe/deploy/update_code.md
+++ b/docs/recipe/deploy/update_code.md
@@ -43,7 +43,7 @@ Can be one of:
 
 
 ### sub_directory
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L25)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L31)
 
 Specifies a sub directory within the repository to deploy.
 Works only when [`update_code_strategy`](#update_code_strategy) is set to `archive` (default).
@@ -63,7 +63,7 @@ null
 ## Tasks
 
 ### deploy:update_code
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L25)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L37)
 
 Updates code.
 

--- a/docs/recipe/deploy/update_code.md
+++ b/docs/recipe/deploy/update_code.md
@@ -46,7 +46,13 @@ Can be one of:
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L25)
 
 Specifies a sub directory within the repository to deploy.
-Works only when `update_code_strategy` is set to 'archive' (default).
+Works only when [`update_code_strategy`](#update_code_strategy) is set to `archive` (default).
+
+Example: 
+ - set value to `src` if you want to deploy the folder that lives at `/src/api`.
+ - set value to `src/api` if you want to deploy the folder that lives at `/src/api`.
+
+Note: do not use a leading `/`!
 
 ```php title="Default value"
 null

--- a/docs/recipe/deploy/update_code.md
+++ b/docs/recipe/deploy/update_code.md
@@ -42,6 +42,17 @@ Can be one of:
 ```
 
 
+### sub_directory
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/update_code.php#L25)
+
+Specifies a sub directory within the repository to deploy.
+Works only when `update_code_strategy` is set to 'archive' (default).
+
+```php title="Default value"
+null
+```
+
+
 
 ## Tasks
 

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -20,7 +20,13 @@ set('update_code_strategy', 'archive');
 
 /**
  * Specifies a sub directory within the repository to deploy.
- * Works only when `update_code_strategy` is set to 'archive' (default).
+ * Works only when [`update_code_strategy`](#update_code_strategy) is set to `archive` (default).
+ * 
+ * Example: 
+ *  - set value to `src` if you want to deploy the folder that lives at `/src/api`.
+ *  - set value to `src/api` if you want to deploy the folder that lives at `/src/api`.
+ * 
+ * Note: do not use a leading `/`!
  */
 set('sub_directory', null);
 

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -26,6 +26,7 @@ task('deploy:update_code', function () {
     $git = get('bin/git');
     $repository = get('repository');
     $target = get('target');
+    $subtarget = get('sub_directory') ? "$target:{{sub_directory}}" : $target;
 
     if (get('auto_ssh_keygen')) {
         $url = parse_url($repository);
@@ -65,7 +66,7 @@ task('deploy:update_code', function () {
 
     // Copy to release_path.
     if (get('update_code_strategy') === 'archive') {
-        run("$git archive $target | tar -x -f - -C {{release_path}} 2>&1");
+        run("$git archive $subtarget | tar -x -f - -C {{release_path}} 2>&1");
     } else if (get('update_code_strategy') === 'clone') {
         cd('{{release_path}}');
         run("$git clone -l $bare .");

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -19,6 +19,12 @@ set('auto_ssh_keygen', true);
 set('update_code_strategy', 'archive');
 
 /**
+ * Specifies a sub directory within the repository to deploy.
+ * Works only when `update_code_strategy` is set to 'archive' (default).
+ */
+set('sub_directory', null);
+
+/**
  * Update code at {{release_path}} on host.
  */
 desc('Updates code');


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

Fixes #2570 

This feature adds an option to specify a sub directory in the repository of the project. This can be useful when you only want to deploy a single folder in the repo.

An example use case would be a repository with a separate frontend and backend, each living in their own folder.

When no `sub_directory` is specified, the entire repository will be deployed. Works only when `update_code_strategy` is set to `archive`, which is the default option.