### PR TITLE
Don't add remote user to setfacl command, if it doesn't exist as an os user

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -109,7 +109,7 @@ task('deploy:writable', function () {
             $setFaclUsers = "-m u:\"$httpUser\":rwX";
             // Check if remote user exists, before adding it to setfacl
             $remoteUserId = run("id -u $remoteUser &>/dev/null 2>&1 || exit 0");
-            if (is_int($remoteUserId)) {
+            if (!empty($remoteUserId)) {
                 $setFaclUsers .= " -m u:$remoteUser:rwX";
             }
             if (empty($sudo)) {

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -106,6 +106,12 @@ task('deploy:writable', function () {
             run("$sudo chmod +a \"$httpUser allow delete,write,append,file_inherit,directory_inherit\" $dirs");
             run("$sudo chmod +a \"$remoteUser allow delete,write,append,file_inherit,directory_inherit\" $dirs");
         } elseif (commandExist('setfacl')) {
+            $setFaclUsers = "-m u:\"$httpUser\":rwX";
+            // Check if remote user exists, before adding it to setfacl
+            $remoteUserId = run("id -u $remoteUser &>/dev/null 2>&1 || exit 0");
+            if (is_int($remoteUserId)) {
+                $setFaclUsers .= " -m u:$remoteUser:rwX";
+            }
             if (empty($sudo)) {
                 // When running without sudo, exception may be thrown
                 // if executing setfacl on files created by http user (in directory that has been setfacl before).
@@ -117,13 +123,13 @@ task('deploy:writable', function () {
                     $hasfacl = run("getfacl -p $dir | grep \"^user:$httpUser:.*w\" | wc -l");
                     // Set ACL for directory if it has not been set before
                     if (!$hasfacl) {
-                        run("setfacl -L $recursive -m u:\"$httpUser\":rwX -m u:$remoteUser:rwX $dir");
-                        run("setfacl -dL $recursive -m u:\"$httpUser\":rwX -m u:$remoteUser:rwX $dir");
+                        run("setfacl -L $recursive $setFaclUsers $dir");
+                        run("setfacl -dL $recursive $setFaclUsers $dir");
                     }
                 }
             } else {
-                run("$sudo setfacl -L $recursive -m u:\"$httpUser\":rwX -m u:$remoteUser:rwX $dirs");
-                run("$sudo setfacl -dL $recursive -m u:\"$httpUser\":rwX -m u:$remoteUser:rwX $dirs");
+                run("$sudo setfacl -L $recursive $setFaclUsers $dirs");
+                run("$sudo setfacl -dL $recursive $setFaclUsers $dirs");
             }
         } else {
             $alias = currentHost()->getAlias();

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -108,8 +108,8 @@ task('deploy:writable', function () {
         } elseif (commandExist('setfacl')) {
             $setFaclUsers = "-m u:\"$httpUser\":rwX";
             // Check if remote user exists, before adding it to setfacl
-            $remoteUserId = run("id -u $remoteUser &>/dev/null 2>&1 || exit 0");
-            if (!empty($remoteUserId)) {
+            $remoteUserExists = test("id -u $remoteUser &>/dev/null 2>&1 || exit 0");
+            if ($remoteUserExists === true) {
                 $setFaclUsers .= " -m u:$remoteUser:rwX";
             }
             if (empty($sudo)) {


### PR DESCRIPTION
Only add the the remote user to setfacl command if it exists as an os user.
Based on this discussion:
https://github.com/deployphp/deployer/discussions/2787

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
