### PR TITLE
Add PHP 8.1 in the PHP provision recipe

### DIFF
--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -2,7 +2,7 @@
 namespace Deployer;
 
 set('php_version', function () {
-    return ask(' What PHP version to install? ', '8.0', ['5.6', '7.4', '8.0', '8.1']);
+    return ask(' What PHP version to install? ', '8.1', ['5.6', '7.4', '8.0', '8.1']);
 });
 
 desc('Installs PHP packages');

--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -2,7 +2,7 @@
 namespace Deployer;
 
 set('php_version', function () {
-    return ask(' What PHP version to install? ', '8.0', ['5.4', '7.4', '8.0']);
+    return ask(' What PHP version to install? ', '8.0', ['5.6', '7.4', '8.0']);
 });
 
 desc('Installs PHP packages');

--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -2,7 +2,7 @@
 namespace Deployer;
 
 set('php_version', function () {
-    return ask(' What PHP version to install? ', '8.0', ['5.6', '7.4', '8.0']);
+    return ask(' What PHP version to install? ', '8.0', ['5.6', '7.4', '8.0', '8.1']);
 });
 
 desc('Installs PHP packages');


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Update the PHP provision script.

PHP 5.4 is provided anymore by the Ubuntu LTS. Replace it by PHP 5.6.

Add PHP 8.1 as it's now released a available in default Ubuntu APT packages. Set it as the default version.