### PR TITLE
Fix chgrp

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -83,7 +83,7 @@ task('deploy:writable', function () {
     } elseif ($mode === 'chgrp') {
         // Change group ownership.
         // -L    traverse every symbolic link to a directory encountered
-        run("$sudo chgrp -H $recursive {{http_group}} $dirs");
+        run("$sudo chgrp -L $recursive {{http_group}} $dirs");
         run("$sudo chmod $recursive g+rwx $dirs");
     } elseif ($mode === 'chmod') {
         run("$sudo chmod $recursive {{writable_chmod_mode}} $dirs");


### PR DESCRIPTION
This fixes #2832.

The second commit replaces `-H` with `-L` (as the comment says) and adds `-L` to `chmod`.
This is currently not actually a problem for me, but the current status looks kind of arbitrary to me? Why is `writable_mode=chmod` using `-L` but `writable_mode=chgrp` is using `-H` for `chgrp` and nothing for `chmod`?