### PR TITLE
Removed not existing directory

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -46,7 +46,6 @@ set('writable_dirs', [
     'config/jwt',
     'custom/plugins',
     'files',
-    'press_files',
     'public/bundles',
     'public/css',
     'public/fonts',


### PR DESCRIPTION
This should have never been added, because it has nothing to do with Shopware. I have forgotten to remove it from my Gist.