### PR TITLE
Implemented basic version of replacing tasks, fixes #2878

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -44,6 +44,15 @@ class Collection implements Countable, IteratorAggregate
         $this->values[$name] = $object;
     }
 
+    public function remove(string $name): void
+    {
+        if ($this->has($name)) {
+            unset($this->values[$name]);
+        } else {
+            $this->throwNotFound($name);
+        }
+    }
+
     public function count(): int
     {
         return count($this->values);

--- a/src/Task/GroupTask.php
+++ b/src/Task/GroupTask.php
@@ -43,4 +43,9 @@ class GroupTask extends Task
     {
         return $this->group;
     }
+
+    public function setGroup(array $group): void
+    {
+        $this->group = $group;
+    }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -194,8 +194,27 @@ function task(string $name, $body = null): Task
         throw new \InvalidArgumentException('Task body should be a function or an array.');
     }
 
+    if ($deployer->tasks->has($name)) {
+        // If task already exists, try to replace.
+        $existingTask = $deployer->tasks->get($name);
+        if (get_class($existingTask) !== get_class($task)) {
+            // There is no "up" or "down"casting in PHP.
+            throw new \Exception('Tried to replace a Task with a GroupTask or vice-versa. This is not supported. If you are sure you want to do that, remove the old task `Deployer::get()->tasks->remove(<taskname>)` and then re-add the task.');
+        }
+        if ($existingTask instanceof Task) {
+            $existingTask->setCallback($body);
+        } elseif ($existingTask instanceof GroupTask) {
+            $existingTask->setGroup($body);
+        } else {
+            throw new \LogicException('Unexpected Task type.');
+        }
+        $task = $existingTask;
+    } else {
+        // If task does not exist, add it to the Collection.
+        $deployer->tasks->set($name, $task);
+    }
+
     $task->saveSourceLocation();
-    $deployer->tasks->set($name, $task);
 
     if (!empty(desc())) {
         $task->desc(desc());


### PR DESCRIPTION
- [x] Bug fix #2878?
- [ ] New feature?
- [x] BC breaks? Behavior changed (hooks are preserved) and replacing a `Task` with a `GroupTask` (or other way around) is now forbidden. Could be fixed, but I think it is cleaner to require removing a task and then re-add it.
- [ ] Tests added?
- [ ] Docs added?