### PR TITLE
Update release.php

### DIFF
--- a/docs/recipe/deploy/release.md
+++ b/docs/recipe/deploy/release.md
@@ -16,35 +16,35 @@ The name of the release.
 
 
 ### releases_log
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L14)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L16)
 
 Holds releases log from `.dep/releases_log` file.
 
 
 
 ### releases_list
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L39)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L41)
 
 Return list of release names on host.
 
 
 
 ### release_path
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L66)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L68)
 
 Return release path.
 
 
 
 ### release_revision
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L77)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L79)
 
 Current release revision. Usually a git hash.
 
 
 
 ### release_or_current_path
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L83)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L85)
 
 Return the release path during a deployment
 but fallback to the current path otherwise.
@@ -55,7 +55,7 @@ but fallback to the current path otherwise.
 ## Tasks
 
 ### deploy:release
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L90)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L92)
 
 Prepares release.
 
@@ -63,7 +63,7 @@ Clean up unfinished releases and prepare next release
 
 
 ### releases
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L157)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L159)
 
 Shows releases list.
 

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -6,6 +6,8 @@ use Symfony\Component\Console\Helper\Table;
 
 // The name of the release.
 set('release_name', function () {
+    cd('{{deploy_path}}');
+
     $latest = run('cat .dep/latest_release || echo 0');
     return strval(intval($latest) + 1);
 });

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -6,10 +6,10 @@ use Symfony\Component\Console\Helper\Table;
 
 // The name of the release.
 set('release_name', function () {
-    cd('{{deploy_path}}');
-
-    $latest = run('cat .dep/latest_release || echo 0');
-    return strval(intval($latest) + 1);
+    return within('{{deploy_path}}', function () {
+        $latest = run('cat .dep/latest_release || echo 0');
+        return strval(intval($latest) + 1);
+    });
 });
 
 // Holds releases log from `.dep/releases_log` file.


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

I'm not sure if this is really a bug or not, but if this line is missing, deployer always tries to deploy as release `1` and doesn't take the contents of the `.dep/latest_release` file into account