### PR TITLE
Add  Doctrine mapping files validation

### DIFF
--- a/docs/recipe/symfony.md
+++ b/docs/recipe/symfony.md
@@ -66,8 +66,15 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 
-### bin/console
+### doctrine_schema_validate_config
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L28)
+
+
+
+
+
+### bin/console
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L30)
 
 
 
@@ -77,7 +84,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### console_options
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L30)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L32)
 
 
 
@@ -87,15 +94,23 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 ## Tasks
 
 ### database:migrate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L35)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L37)
 
 Migrates database.
 
 
 
 
+### doctrine:schema:validate
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L47)
+
+Validate the Doctrine mapping files.
+
+
+
+
 ### deploy:cache:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L45)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L52)
 
 Clears cache.
 
@@ -103,7 +118,7 @@ Clears cache.
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L54)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/symfony.php#L61)
 
 Deploys project.
 

--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -25,6 +25,8 @@ set('writable_dirs', [
 
 set('migrations_config', '');
 
+set('doctrine_schema_validate_config', '');
+
 set('bin/console', '{{bin/php}} {{release_or_current_path}}/bin/console');
 
 set('console_options', function () {
@@ -39,6 +41,11 @@ task('database:migrate', function () {
     }
 
     run("cd {{release_or_current_path}} && {{bin/console}} doctrine:migrations:migrate $options {{console_options}}");
+});
+
+desc('Validate the Doctrine mapping files');
+task('doctrine:schema:validate', function () {
+    run("cd {{release_or_current_path}} && {{bin/console}} doctrine:schema:validate {{doctrine_schema_validate_config}} {{console_options}}");
 });
 
 desc('Clears cache');


### PR DESCRIPTION
This pull request add the Doctrine mapping files validation (*with `--skip-*` option*) as a (*possible*) deploy task.

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?
