### PR TITLE
Fix ssh command to work on Windows

### DIFF
--- a/src/Command/SshCommand.php
+++ b/src/Command/SshCommand.php
@@ -86,7 +86,11 @@ class SshCommand extends Command
         $options = Client::connectionOptionsString($host);
         $deployPath = $host->get('deploy_path', '~');
 
-        passthru("ssh -t $options {$host->getConnectionString()} 'cd $deployPath/current 2>/dev/null || cd $deployPath; $shell_path'");
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            passthru("ssh -t $options {$host->getConnectionString()} \"cd $deployPath/current 2>/dev/null || cd $deployPath; $shell_path\"");
+        } else {
+            passthru("ssh -t $options {$host->getConnectionString()} 'cd $deployPath/current 2>/dev/null || cd $deployPath; $shell_path'");
+        }
         return 0;
     }
 }


### PR DESCRIPTION
- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Hi everybody ! 

I'm unable to deploy on Windows ( 10 or 11 ). I always get this error 

```bash
php .\vendor\bin\dep ssh
The specified path was not found.
The specified path was not found.
```

The only thing I found is to change simple quote to double quote for ssh command. 
It works on Windows but fails on MacOS. That's why I  check PHP_OS constant.

My tests on Windows were on real machine with Windows 10 and virtual machine on Windows 11. The results are sames. 

Thanks a lot for your review !