### PR TITLE
Feature/fix symfony4 acl on var shared subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## master
+[v6.8.0...master](https://github.com/deployphp/deployer/compare/v6.8.0...master)
+
+### Fixed
+- Symfony 4 recipe log and session folders ACL check [#2932]
+
+
 ## v6.8.0
 [v6.7.3...v6.8.0](https://github.com/deployphp/deployer/compare/v6.7.3...v6.8.0)
 
@@ -565,6 +572,7 @@
 - Fixed remove of shared dir on first deploy
 
 
+[#2932]: https://github.com/deployphp/deployer/issues/2932
 [#1994]: https://github.com/deployphp/deployer/issues/1994
 [#1990]: https://github.com/deployphp/deployer/issues/1990
 [#1989]: https://github.com/deployphp/deployer/issues/1989

--- a/recipe/symfony4.php
+++ b/recipe/symfony4.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/common.php';
 
 set('shared_dirs', ['var/log', 'var/sessions']);
 set('shared_files', ['.env.local.php', '.env.local']);
-set('writable_dirs', ['var']);
+set('writable_dirs', ['var/cache', 'var/log', 'var/sessions']);
 set('migrations_config', '');
 
 set('bin/console', function () {


### PR DESCRIPTION
- [x] Bug fix #2932
- [ ] New feature
- [ ] BC breaks
- [ ] Tests added
- [ ] Docs added : no -> `Could not open input file: bin/docgen`

The description of the problem and resolution has been detailed on the linked issue.

I saw that the recipes code has been updated for the master (7.x) version but I think as the 6.x is still the current stable version, it is OK to target this branch.
If needed I can do the same fix for the master branch.