### PR TITLE
Magento2: allow non-zero-downtime deployment

### DIFF
--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -46,7 +46,7 @@ Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recip
 
 
 ### shared_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L30)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L31)
 
 Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/deploy/shared.php`.
 
@@ -71,7 +71,7 @@ Overrides [shared_dirs](/docs/recipe/deploy/shared.md#shared_dirs) from `recipe/
 
 
 ### writable_dirs
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L44)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L45)
 
 Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `recipe/deploy/writable.php`.
 
@@ -88,7 +88,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### clear_paths
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L50)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L51)
 
 Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `recipe/deploy/clear_paths.php`.
 
@@ -107,21 +107,27 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 
 
 ### magento_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L59)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L60)
+
+
+
 
 
 ### maintenance_mode_status_active
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L66)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L67)
+
+
+
 
 
 ### enable_zerodowntime
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L74)
 
-Deployer will only set maintenance mode if there is a database upgrade or a config import. This flag
-disables this ability.
+Deploy without setting maintenance mode if possible
 
-**Note: if you set this flag to false, you will need to enable and disable maintenance mode manually in your
-deployment.**
+```php title="Default value"
+true
+```
 
 
 

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -40,6 +40,7 @@ Overrides [shared_files](/docs/recipe/deploy/shared.md#shared_files) from `recip
 [
     'app/etc/env.php',
     'var/.maintenance.ip',
+    'var/.maintenance.flag',
 ]
 ```
 
@@ -109,21 +110,25 @@ Overrides [clear_paths](/docs/recipe/deploy/clear_paths.md#clear_paths) from `re
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L59)
 
 
-
-
-
 ### maintenance_mode_status_active
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L66)
 
 
+### enable_zerodowntime
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L74)
 
+Deployer will only set maintenance mode if there is a database upgrade or a config import. This flag
+disables this ability.
+
+**Note: if you set this flag to false, you will need to enable and disable maintenance mode manually in your
+deployment.**
 
 
 
 ## Tasks
 
 ### magento:compile
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L74)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L78)
 
 Compiles magento di.
 
@@ -131,7 +136,7 @@ Tasks
 
 
 ### magento:deploy:assets
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L81)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L85)
 
 Deploys assets.
 
@@ -139,7 +144,7 @@ Deploys assets.
 
 
 ### magento:sync:content_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L86)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L90)
 
 Syncs content version.
 
@@ -147,7 +152,7 @@ Syncs content version.
 
 
 ### magento:maintenance:enable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L96)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L100)
 
 Enables maintenance mode.
 
@@ -155,7 +160,7 @@ Enables maintenance mode.
 
 
 ### magento:maintenance:disable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L101)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L105)
 
 Disables maintenance mode.
 
@@ -163,7 +168,7 @@ Disables maintenance mode.
 
 
 ### magento:config:import
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L106)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L110)
 
 Config Import.
 
@@ -171,7 +176,7 @@ Config Import.
 
 
 ### magento:upgrade:db
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L141)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L145)
 
 Upgrades magento database.
 
@@ -179,7 +184,7 @@ Upgrades magento database.
 
 
 ### magento:cache:flush
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L168)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L172)
 
 Flushes Magento Cache.
 
@@ -187,7 +192,7 @@ Flushes Magento Cache.
 
 
 ### deploy:magento
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L173)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L177)
 
 Magento2 deployment operations.
 
@@ -202,7 +207,7 @@ This task is group task which contains next tasks:
 
 
 ### magento:build
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L181)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L185)
 
 Magento2 build operations.
 
@@ -215,7 +220,7 @@ This task is group task which contains next tasks:
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L187)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L191)
 
 Deploys your project.
 

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -26,6 +26,7 @@ set('content_version', function () {
 set('shared_files', [
     'app/etc/env.php',
     'var/.maintenance.ip',
+    'var/.maintenance.flag',
 ]);
 set('shared_dirs', [
     'var/composer_home',
@@ -68,6 +69,9 @@ set('maintenance_mode_status_active', function () {
     $maintenanceModeStatusOutput = run("{{bin/php}} {{release_or_current_path}}/bin/magento maintenance:status");
     return strpos($maintenanceModeStatusOutput, MAINTENANCE_MODE_ACTIVE_OUTPUT_MSG) !== false;
 });
+
+// Deploy without setting maintenance mode if possible
+set('enable_zerodowntime', true);
 
 // Tasks
 desc('Compiles magento di');
@@ -125,13 +129,13 @@ task('magento:config:import', function () {
     }
 
     if ($configImportNeeded) {
-        if (!get('maintenance_mode_status_active')) {
+        if (get('enable_zerodowntime') && !get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:enable');
         }
 
         run('{{bin/php}} {{release_or_current_path}}/bin/magento app:config:import --no-interaction');
 
-        if (!get('maintenance_mode_status_active')) {
+        if (get('enable_zerodowntime') && !get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:disable');
         }
     }
@@ -152,13 +156,13 @@ task('magento:upgrade:db', function () {
     }
 
     if ($databaseUpgradeNeeded) {
-        if (!get('maintenance_mode_status_active')) {
+        if (get('enable_zerodowntime') && !get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:enable');
         }
 
         run("{{bin/php}} {{release_or_current_path}}/bin/magento setup:upgrade --keep-generated --no-interaction");
 
-        if (!get('maintenance_mode_status_active')) {
+        if (get('enable_zerodowntime') && !get('maintenance_mode_status_active')) {
             invoke('magento:maintenance:disable');
         }
     }


### PR DESCRIPTION
Hoping this can make it into the main repo, this addresses #2936, allowing users to disable zero-downtime deployment. The flag defaults to allowing it; users would have to set it in their own `deploy.php` file, and then be required to enable/disable maintenance mode on their own.

This also adds `.maintenance.flag` to the shared files array.

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
