### PR TITLE
Prepend the relevant bin/php

### DIFF
--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -14,7 +14,7 @@ set('bin/composer', function () {
     }
 
     if (commandExist('composer')) {
-        return which('composer');
+        return '{{bin/php}} '.which('composer');
     }
 
     warning("Composer binary wasn't found. Installing latest composer to \"{{deploy_path}}/.dep/composer.phar\".");


### PR DESCRIPTION
At the moment if bin/php is modified and composer exists at a global level, it is executed with the global php. We need it to execute with the modified bin/php version.
