### PR TITLE
Check func_num_args() in get()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -671,9 +671,9 @@ function add(string $name, array $array): void
 function get(string $name, $default = null)
 {
     if (!Context::has()) {
-        return Deployer::get()->config->get($name, $default);
+        return (func_num_args() >= 2) ? Deployer::get()->config->get($name, $default) : Deployer::get()->config->get($name);
     } else {
-        return Context::get()->getConfig()->get($name, $default);
+        return (func_num_args() >= 2) ? Context::get()->getConfig()->get($name, $default) : Context::get()->getConfig()->get($name);
     }
 }
 


### PR DESCRIPTION
- [X] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

The ConfigurationException in the get() function of class Config will never be reached by the get() in functions.php
So if the key doesn't exist always null is returned.
