### PR TITLE
Update doc provision as root

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,25 +20,25 @@ Now lets cd into the project and run following command:
 dep init
 ```
 
-Deployer will ask you a few question and after finishing you will have a 
-**deploy.php** or **deploy.yaml** file. This is our deployment recipe. 
+Deployer will ask you a few question and after finishing you will have a
+**deploy.php** or **deploy.yaml** file. This is our deployment recipe.
 It contains hosts, tasks and requires other recipes. All framework recipes
 that come with Deployer are based on the [common](recipe/common.md) recipe.
 
 ## Provision
 
 :::note
-If you already have a configured webserver you may skip to 
+If you already have a configured webserver you may skip to
 [deployment](#deploy).
 :::
 
 Let's create a new VPS on Linode, DigitalOcean, Vultr, AWS, GCP, etc.
 
-Make sure the image is **Ubuntu 20.04 LTS** as this version is supported via 
+Make sure the image is **Ubuntu 20.04 LTS** as this version is supported via
 Deployer [provision](recipe/provision.md) recipe.
 
 :::tip
-Configure Reverse DNS or RDNS on your server. This will allow you to ssh into 
+Configure Reverse DNS or RDNS on your server. This will allow you to ssh into
 server using the domain name instead of the IP address.
 :::
 
@@ -53,7 +53,7 @@ host('example.org')
 ```
 
 To connect to remote host we need to specify identity key or private key.
-We can add our identity key directly into host definition, but better to put it 
+We can add our identity key directly into host definition, but better to put it
 in **~/.ssh/config** file:
 
 ```
@@ -67,6 +67,13 @@ only `root` user. We going to override `remote_user` for provision via `-o remot
 ```sh
 dep provision -o remote_user=root
 ```
+:::tip
+If your server doesn't have a `root` user but your remote user can use `sudo` to become root, then use:
+
+```sh
+dep provision -o become=root
+```
+:::
 
 Deployer will ask you a few questions during provisioning: php version,
 database type, etc. You can specify it also in directly in recipe.
@@ -80,8 +87,8 @@ Provision recipe going to do:
 - Configure ssh and firewall,
 - Setup **deployer** user.
 
-Provisioning will take around **5 minutes** and will install everything we need to run a 
-website. It will also setup a `deployer` user, which we will need to use to ssh to our 
+Provisioning will take around **5 minutes** and will install everything we need to run a
+website. It will also setup a `deployer` user, which we will need to use to ssh to our
 host. A new website will be configured at [deploy_path](recipe/common.md#deploy_path).
 
 After we have configured the webserver, let's deploy the project.
@@ -94,7 +101,7 @@ To deploy the project:
 dep deploy
 ```
 
-If deployment will fail, Deployer will print error message and command what was unsuccessful. 
+If deployment will fail, Deployer will print error message and command what was unsuccessful.
 Most likely we need to confiure correct database credentials in _.env_ file or similar.
 
 Ssh to the host, for example, for editing _.env_ file:

--- a/docs/recipe/provision.md
+++ b/docs/recipe/provision.md
@@ -22,14 +22,14 @@ As only Ubuntu 20.04 LTS is supported for provision should be the `focal`.
 
 
 ### sudo_password
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L215)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L216)
 
 
 
 
 
 ### ssh_copy_id
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L221)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L222)
 
 Specify which key to copy to server.
 Set to `false` to disable copy of key.
@@ -77,7 +77,7 @@ Checks pre-required state.
 
 
 ### provision:configure
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L58)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L59)
 
 Collects required params.
 
@@ -85,7 +85,7 @@ Collects required params.
 
 
 ### provision:update
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L81)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L82)
 
 Adds repositories and update.
 
@@ -93,7 +93,7 @@ Adds repositories and update.
 
 
 ### provision:upgrade
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L103)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L104)
 
 Upgrades all packages.
 
@@ -101,7 +101,7 @@ Upgrades all packages.
 
 
 ### provision:install
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L110)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L111)
 
 Installs packages.
 
@@ -109,7 +109,7 @@ Installs packages.
 
 
 ### provision:server
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L144)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L145)
 
 Configures a server.
 
@@ -117,7 +117,7 @@ Configures a server.
 
 
 ### provision:ssh
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L205)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L206)
 
 Configures the ssh.
 
@@ -125,7 +125,7 @@ Configures the ssh.
 
 
 ### provision:deployer
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L224)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L225)
 
 Setups a deployer user.
 
@@ -133,7 +133,7 @@ Setups a deployer user.
 
 
 ### provision:firewall
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L271)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L272)
 
 Setups a firewall.
 
@@ -141,7 +141,7 @@ Setups a firewall.
 
 
 ### provision:verify
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L279)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision.php#L280)
 
 Verifies what provision was successful.
 

--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -40,6 +40,7 @@ task('provision:check', function () {
     if (get('remote_user') !== 'root') {
         warning('');
         warning('Run provision as root: -o remote_user=root');
+        warning('or with a sudo enabled user: -o become=root');
         warning('');
     }
 


### PR DESCRIPTION
Hello,

This is to address issue #2939 by adding a tip on the documentation and more info on the warning banner when provisioning a server.

I'm not sure if the code block will display correctly inside a tip block, or event if a tip block is what you want. If that's an issue, how would you like this info to be displayed?

- [x] Bug fix #2939?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
(done)
