### PR TITLE
Make the importer extendable

### DIFF
--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -63,9 +63,9 @@ class Importer
                     }
                 });
             } else if (preg_match('/\.ya?ml$/i', $path)) {
-                static::$recipeFilename = basename($path);
-                static::$recipeSource = file_get_contents($path);
-                $root = array_filter(Yaml::parse(static::$recipeSource), static function (string $key) {
+                self::$recipeFilename = basename($path);
+                self::$recipeSource = file_get_contents($path);
+                $root = array_filter(Yaml::parse(self::$recipeSource), static function (string $key) {
                     return substr($key, 0, 1) !== '.';
                 }, ARRAY_FILTER_USE_KEY);
 
@@ -79,7 +79,7 @@ class Importer
                 $validator = new Validator(new Factory($schemaStorage));
                 $validator->validate($root, $yamlSchema, Constraint::CHECK_MODE_TYPE_CAST);
                 if (!$validator->isValid()) {
-                    $msg = "YAML " . static::$recipeFilename . " does not validate. Violations:\n";
+                    $msg = "YAML " . self::$recipeFilename . " does not validate. Violations:\n";
                     foreach ($validator->getErrors() as $error) {
                         $msg .= "[{$error['property']}] {$error['message']}\n";
                     }
@@ -145,8 +145,8 @@ class Importer
                             try {
                                 run($run);
                             } catch (Exception $e) {
-                                $e->setTaskFilename(static::$recipeFilename);
-                                $e->setTaskLineNumber(find_line_number(static::$recipeSource, $run));
+                                $e->setTaskFilename(self::$recipeFilename);
+                                $e->setTaskLineNumber(find_line_number(self::$recipeSource, $run));
                                 throw $e;
                             }
                         };
@@ -163,8 +163,8 @@ class Importer
                             try {
                                 runLocally($run_locally);
                             } catch (Exception $e) {
-                                $e->setTaskFilename(static::$recipeFilename);
-                                $e->setTaskLineNumber(find_line_number(static::$recipeSource, $run_locally));
+                                $e->setTaskFilename(self::$recipeFilename);
+                                $e->setTaskLineNumber(find_line_number(self::$recipeSource, $run_locally));
                                 throw $e;
                             }
                         };

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -63,9 +63,9 @@ class Importer
                     }
                 });
             } else if (preg_match('/\.ya?ml$/i', $path)) {
-                self::$recipeFilename = basename($path);
-                self::$recipeSource = file_get_contents($path);
-                $root = array_filter(Yaml::parse(self::$recipeSource), static function (string $key) {
+                static::$recipeFilename = basename($path);
+                static::$recipeSource = file_get_contents($path);
+                $root = array_filter(Yaml::parse(static::$recipeSource), static function (string $key) {
                     return substr($key, 0, 1) !== '.';
                 }, ARRAY_FILTER_USE_KEY);
 
@@ -79,7 +79,7 @@ class Importer
                 $validator = new Validator(new Factory($schemaStorage));
                 $validator->validate($root, $yamlSchema, Constraint::CHECK_MODE_TYPE_CAST);
                 if (!$validator->isValid()) {
-                    $msg = "YAML " . self::$recipeFilename . " does not validate. Violations:\n";
+                    $msg = "YAML " . static::$recipeFilename . " does not validate. Violations:\n";
                     foreach ($validator->getErrors() as $error) {
                         $msg .= "[{$error['property']}] {$error['message']}\n";
                     }
@@ -87,7 +87,7 @@ class Importer
                 }
 
                 foreach (array_keys($root) as $key) {
-                    self::$key($root[$key]);
+                    static::$key($root[$key]);
                 }
             } else {
                 throw new Exception("Unknown file format: $path\nOnly .php and .yaml supported.");
@@ -145,8 +145,8 @@ class Importer
                             try {
                                 run($run);
                             } catch (Exception $e) {
-                                $e->setTaskFilename(self::$recipeFilename);
-                                $e->setTaskLineNumber(find_line_number(self::$recipeSource, $run));
+                                $e->setTaskFilename(static::$recipeFilename);
+                                $e->setTaskLineNumber(find_line_number(static::$recipeSource, $run));
                                 throw $e;
                             }
                         };
@@ -163,8 +163,8 @@ class Importer
                             try {
                                 runLocally($run_locally);
                             } catch (Exception $e) {
-                                $e->setTaskFilename(self::$recipeFilename);
-                                $e->setTaskLineNumber(find_line_number(self::$recipeSource, $run_locally));
+                                $e->setTaskFilename(static::$recipeFilename);
+                                $e->setTaskLineNumber(find_line_number(static::$recipeSource, $run_locally));
                                 throw $e;
                             }
                         };

--- a/tests/src/Importer/ImporterTest.php
+++ b/tests/src/Importer/ImporterTest.php
@@ -24,6 +24,29 @@ class ImporterTest extends TestCase
         Deployer::get()->output = $this->previousOutput;
     }
 
+    public function testCanOneOverrideStaticMethod(): void
+    {
+        $extendedImporter = new class extends Importer
+        {
+            public static $config = [];
+
+            protected static function config(array $config)
+            {
+                static::$config = $config;
+            }
+        };
+
+        $data = <<<EOL
+config:
+    foo: bar
+# test.yaml
+EOL;
+
+        $extendedImporter::import("data:text/yaml,$data");
+
+        static::assertSame(['foo' => 'bar'], $extendedImporter::$config);
+    }
+
     public function testImporterIgnoresYamlHiddenKeys(): void
     {
         $data = <<<EOL


### PR DESCRIPTION
Although it seems to be a new feature, I think this could be treated as a bugfix.

I wanted to extend (not override) the `shared_dirs` configuration from YAML file, but it occurred that the `Importer` uses the `set()` function instead of `add()`. Thus, I wanted to extend the class, because the methods are protected and not private, but it was not possible because it uses `self::` instead of `static::`.

```yaml
config:
    shared_dirs:
        - my_extra_shared_folder
```

This pull requests makes the `Importer` class extendable, for example:

```php
class ExtendedImporter extends \Deployer\Importer\Importer
{
    protected static function config(array $config)
    {
        foreach ($config as $key => $value) {
            add($key, $value);
        }
    }
}

ExtendedImporter::import('deploy-hosts.yml');
```