### PR TITLE
Add artisan event:cache to Laravel deployment task

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -224,6 +224,7 @@ task('deploy', [
     'artisan:config:cache',
     'artisan:route:cache',
     'artisan:view:cache',
+    'artisan:event:cache',
     'artisan:migrate',
     'deploy:publish',
 ]);


### PR DESCRIPTION
This adds event caching to Laravel apps.  This does not appear to harm Laravel apps with event discovery disabled but will speed up applications that do use it.  Feature first introduced with Laravel 5.8.9 and added as a stand alone task in deployer https://github.com/deployphp/deployer/commit/a6ff2eb4c6eb87052f94fdf9d4f9c4aad42d7c9c

https://laravel.com/docs/9.x/events#event-discovery-in-production

> In production, it is not efficient for the framework to scan all of your listeners on every request. Therefore, during your deployment process, you should run the `event:cache` Artisan command to cache a manifest of all of your application's events and listeners. 

Running on a Laravel application without custom `app/events` or `app/listeners` simply creates a manifest in `bootstrap/cache/events.php` with

```
<?php return array (
  'App\\Providers\\EventServiceProvider' => 
  array (
    'Illuminate\\Auth\\Events\\Registered' => 
    array (
      0 => 'Illuminate\\Auth\\Listeners\\SendEmailVerificationNotification',
    ),
  ),
);
```

I'm assuming people still running past end of life Laravel < 5.8.9 apps would also be running a previous version of deployer.

Discussion: https://github.com/deployphp/deployer/discussions/3034

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
