### PR TITLE
Add --with-deletes flag to contao:migrate task

### DIFF
--- a/docs/recipe/contao.md
+++ b/docs/recipe/contao.md
@@ -47,6 +47,16 @@ Run Contao migrations.
 
 This task updates the database. A database backup is saved automatically as a default.
 
+#### --with-deletes
+
+To automatically drop the obsolete database structures, you can override the task as follows:
+
+```php
+task('contao:migrate', function () {
+    run('{{bin/php}} {{bin/console}} contao:migrate --with-deletes {{console_options}}');
+});
+```
+
 
 ### contao:manager:download
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L45)

--- a/docs/recipe/contao.md
+++ b/docs/recipe/contao.md
@@ -41,13 +41,11 @@ Overrides [bin/console](/docs/recipe/symfony.md#bin/console) from `recipe/symfon
 ## Tasks
 
 ### contao:migrate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L39)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L47)
 
 Run Contao migrations.
 
 This task updates the database. A database backup is saved automatically as a default.
-
-#### --with-deletes
 
 To automatically drop the obsolete database structures, you can override the task as follows:
 
@@ -59,7 +57,7 @@ task('contao:migrate', function () {
 
 
 ### contao:manager:download
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L45)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L53)
 
 Download the Contao Manager.
 
@@ -67,7 +65,7 @@ Downloads the `contao-manager.phar.php` into the public path.
 
 
 ### contao:install:lock
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L51)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L59)
 
 Lock the Contao Install Tool.
 
@@ -75,7 +73,7 @@ Locks the Contao install tool which is useful if you don't use it.
 
 
 ### contao:manager:lock
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L57)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L65)
 
 Lock the Contao Manager.
 
@@ -83,7 +81,7 @@ Locks the Contao Manager which is useful if you only need the API of the Manager
 
 
 ### contao:maintenance:enable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L63)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L71)
 
 Enable maintenance mode.
 
@@ -91,7 +89,7 @@ Enable maintenance mode.
 
 
 ### contao:maintenance:disable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L78)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L86)
 
 Disable maintenance mode.
 
@@ -99,7 +97,7 @@ Disable maintenance mode.
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L90)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L98)
 
 Deploy the project.
 

--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -37,7 +37,7 @@ set('contao_version', function () {
 // This task updates the database. A database backup is saved automatically as a default.
 desc('Run Contao migrations');
 task('contao:migrate', function () {
-    run('{{bin/php}} {{bin/console}} contao:migrate {{console_options}}');
+    run('{{bin/php}} {{bin/console}} contao:migrate --with-deletes {{console_options}}');
 });
 
 // Downloads the `contao-manager.phar.php` into the public path.

--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -35,6 +35,14 @@ set('contao_version', function () {
 });
 
 // This task updates the database. A database backup is saved automatically as a default.
+//
+// To automatically drop the obsolete database structures, you can override the task as follows:
+//
+// ```php
+// task('contao:migrate', function () {
+//     run('{{bin/php}} {{bin/console}} contao:migrate --with-deletes {{console_options}}');
+// });
+// ```
 desc('Run Contao migrations');
 task('contao:migrate', function () {
     run('{{bin/php}} {{bin/console}} contao:migrate {{console_options}}');

--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -37,7 +37,7 @@ set('contao_version', function () {
 // This task updates the database. A database backup is saved automatically as a default.
 desc('Run Contao migrations');
 task('contao:migrate', function () {
-    run('{{bin/php}} {{bin/console}} contao:migrate --with-deletes {{console_options}}');
+    run('{{bin/php}} {{bin/console}} contao:migrate {{console_options}}');
 });
 
 // Downloads the `contao-manager.phar.php` into the public path.


### PR DESCRIPTION
- [x] New feature?

Since Contao 4.13 the `contao:migrate` performs the automatic database backup task, so I think we should enable `--with-deletes` flag by default.

/cc @richardhj 