### PR TITLE
[httpie] Delete Content-Length

### DIFF
--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -91,7 +91,6 @@ class Httpie
         $http->body = $body;
         $http->headers = array_merge($http->headers, [
             'Content-Type' => 'application/json',
-            'Content-Length' => strlen($http->body),
         ]);
         return $http;
     }
@@ -102,7 +101,6 @@ class Httpie
         $http->body = json_encode($data, JSON_PRETTY_PRINT);
         $http->headers = array_merge($http->headers, [
             'Content-Type' => 'application/json',
-            'Content-Length' => strlen($http->body),
         ]);
         return $http;
     }
@@ -113,7 +111,6 @@ class Httpie
         $http->body = http_build_query($data);
         $http->headers = array_merge($this->headers, [
             'Content-type' => 'application/x-www-form-urlencoded',
-            'Content-Length' => strlen($http->body),
         ]);
         return $http;
     }


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

Curl add it automatically. ~And also change it if it isn't correct~.
If we add the `Content-Length` will replace the internal one created by Curl.
