### PR TITLE
[httpie] Add encoding

### DIFF
--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -146,6 +146,7 @@ class Httpie
         }
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $this->body);
+        curl_setopt($ch, CURLOPT_ENCODING, '');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_MAXREDIRS, 10);


### PR DESCRIPTION
If an empty string, '', is set, a header containing all supported encoding types is sent

https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
