### PR TITLE
deploy:release : Only delete unfinished symlink, not whole release

### DIFF
--- a/docs/recipe/deploy/release.md
+++ b/docs/recipe/deploy/release.md
@@ -63,7 +63,7 @@ Clean up unfinished releases and prepare next release
 
 
 ### releases
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L149)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L148)
 
 Shows releases list.
 

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -84,7 +84,6 @@ task('deploy:release', function () {
 
     // Clean up if there is unfinished release.
     if (test('[ -h release ]')) {
-        run('rm -rf "$(readlink release)"'); // Delete release.
         run('rm release'); // Delete symlink.
     }
 


### PR DESCRIPTION
This fixes #3111 by just not removing the release directory. This is supposedly save to do, since Deployer keeps track of good releases. 

- [x] Bug fix #3111
