### PR TITLE
UPGRADE: remove version form title

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,6 +1,8 @@
-# Upgrade from 6.x to 7.x
+# Upgrade a major version
 
-## Step 1: Update deploy.php
+## Upgrade from 6.x to 7.x
+
+### Step 1: Update deploy.php
 1. Change config `hostname` to `alias`.
 2. Change config `real_hostname` to `hostname`.
 3. Change config `user` to `remote_user`.
@@ -62,7 +64,7 @@
 11. Replace `local()` tasks with combination of `once()` and `runLocally()` func.
 12. Replace `locateBinaryPath()` with `which()` func.
 
-## Step 2: Deploy
+### Step 2: Deploy
 
 Since the release history numbering is not compatible between v6 and v7, you need to specify the `release_name` manually for the first time. Otherwise you start with release 1.
 
@@ -83,9 +85,7 @@ ln -nfs releases/42 current
 In case there are multiple hosts with different release names, you should create a `{{deploy_path}}/.dep/latest_release` file in each host with the current release number of that particular host.
 :::
 
-## Other versions
-
-### Upgrade from 5.x to 6.x
+## Upgrade from 5.x to 6.x
 
 1. Changed branch option priority
 
@@ -124,7 +124,7 @@ In case there are multiple hosts with different release names, you should create
     
     * `set('env', 'prod');` → `set('symfony_env', 'prod');`
 
-### Upgrade from 4.x to 5.x
+## Upgrade from 4.x to 5.x
 
 1. Servers to Hosts
    
@@ -198,7 +198,7 @@ In case there are multiple hosts with different release names, you should create
    * `onlyOnStage` to `onStage`
    
 
-### Upgrade from 3.x to 4.x
+## Upgrade from 3.x to 4.x
 
 1. Namespace for functions
 
@@ -230,7 +230,7 @@ In case there are multiple hosts with different release names, you should create
 
    Due to changes in release management, the new cleanup task will ignore any prior releases deployed with 3.x.  These will need to be manually removed after migrating to and successfully releasing via 4.x.
 
-### Upgrade from 2.x to 3.x
+## Upgrade from 2.x to 3.x
 
 1. ### `->path('...')`
 


### PR DESCRIPTION
- [x] Bug fix #…?
- [x] New feature?
- [x] BC breaks?
- [x] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

The title of the page was misleading, it shown the version on the left menu:

> ![image](https://user-images.githubusercontent.com/2071331/173890801-c7f8a470-4985-4268-80bb-742cada0b384.png)

But the page list upgrades for other versions.