### PR TITLE
chore: add task name to replace exception message

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -200,7 +200,7 @@ function task(string $name, $body = null): Task
         $existingTask = $deployer->tasks->get($name);
         if (get_class($existingTask) !== get_class($task)) {
             // There is no "up" or "down"casting in PHP.
-            throw new \Exception('Tried to replace a Task with a GroupTask or vice-versa. This is not supported. If you are sure you want to do that, remove the old task `Deployer::get()->tasks->remove(<taskname>)` and then re-add the task.');
+            throw new \Exception('Tried to replace Task \'' . $name . '\' with a GroupTask or vice-versa. This is not supported. If you are sure you want to do that, remove the old task `Deployer::get()->tasks->remove(<taskname>)` and then re-add the task.');
         }
         if ($existingTask instanceof GroupTask) {
             $existingTask->setGroup($body);


### PR DESCRIPTION
To clarify which task is causing the exception.