### PR TITLE
Fix definition of {{bin/console}} parameter in Contao recipe

### DIFF
--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -27,7 +27,7 @@ add('shared_dirs', [
 ]);
 
 set('bin/console', function () {
-    return '{{release_or_current_path}}/vendor/bin/contao-console';
+    return '{{bin/php}} {{release_or_current_path}}/vendor/bin/contao-console';
 });
 
 set('contao_version', function () {
@@ -45,7 +45,7 @@ set('contao_version', function () {
 // ```
 desc('Run Contao migrations');
 task('contao:migrate', function () {
-    run('{{bin/php}} {{bin/console}} contao:migrate {{console_options}}');
+    run('{{bin/console}} contao:migrate {{console_options}}');
 });
 
 // Downloads the `contao-manager.phar.php` into the public path.
@@ -57,7 +57,7 @@ task('contao:manager:download', function () {
 // Locks the Contao install tool which is useful if you don't use it.
 desc('Lock the Contao Install Tool');
 task('contao:install:lock', function () {
-    run('{{bin/php}} {{bin/console}} contao:install:lock {{console_options}}');
+    run('{{bin/console}} contao:install:lock {{console_options}}');
 });
 
 // Locks the Contao Manager which is useful if you only need the API of the Manager rather than the UI.
@@ -78,7 +78,7 @@ task('contao:maintenance:enable', function () {
         }
 
         cd($path);
-        run('{{bin/php}} {{bin/console}} contao:maintenance-mode enable {{console_options}}');
+        run('{{bin/console}} contao:maintenance-mode enable {{console_options}}');
     }
 });
 
@@ -90,7 +90,7 @@ task('contao:maintenance:disable', function () {
         }
 
         cd($path);
-        run('{{bin/php}} {{bin/console}} contao:maintenance-mode disable {{console_options}}');
+        run('{{bin/console}} contao:maintenance-mode disable {{console_options}}');
     }
 });
 


### PR DESCRIPTION
- [x] Bug fix

This changes the definition of `{{bin/console}}` parameter to always use PHP version defined by user. It is consistent with the way it's done in Symfony recipe, which this recipe is based on.

Fixes minor bug, where `contao_version` task fails to run (can be verified by running `deployer config`, for example).
