### PR TITLE
Fix default value of `shell` in docs

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -109,7 +109,7 @@ Default is `true`.
 
 ### `shell` 
 
-Default is `bash -ls`.
+Default is `bash -s`.
 
 ### `deploy_path` 
 


### PR DESCRIPTION
This PR fixes the docs showing an incorrect default value of the `shell` parameter. The code uses `bash -s`, see [ProcessRunner](https://github.com/deployphp/deployer/blob/master/src/Component/ProcessRunner/ProcessRunner.php#L48).