### PR TITLE
Typo in docs "oncePerNode"

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -55,7 +55,7 @@ host('bar')->setHostname('example.com');
 host('pro')->setHostname('another.com');
 
 task('apt:update', function () {
-    // This task will be executed twise, only on "foo" and "pro" hosts.
+    // This task will be executed twice, only on "foo" and "pro" hosts.
     run('apt-get update');
 })->oncePerNode();
 ```


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
