### PR TITLE
ci/release: Do not omit the autoload section from composer.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          cat composer.json | jq 'del(.autoload) | del(.scripts) | del(.require) | del(."require-dev") | setpath(["bin"]; "dep")' > composer-new.json
+          cat composer.json | jq 'del(.scripts) | del(.require) | del(."require-dev") | setpath(["bin"]; "dep")' > composer-new.json
           mv composer-new.json composer.json
           git add composer.json
 


### PR DESCRIPTION
Ever since https://github.com/deployphp/deployer/pull/3051, many keys in the `composer.json` file are omitted when releasing a new Deployer version in order to have no version constraints for the package. This is all fine when just using deployer as-is, but becomes problematic when building on top of Deployer and depend on the namespaces and classes to be available.

With this change, external applications can make use of the internal Deployer classes, while the requirements are not being propagated through Composer.