### PR TITLE
Allow setting of composer variables

### DIFF
--- a/docs/recipe/deploy/vendors.md
+++ b/docs/recipe/deploy/vendors.md
@@ -28,12 +28,25 @@
 ```
 
 
-### bin/composer
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/vendors.php#L11)
+### composer_env_vars
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/vendors.php#L8)
+```php title="Default value"
+''
+```
+Allows composer to run different composer.json and composer.lock based on different environments.
+```shell
+COMPOSER=composer-dev.json
+```
 
-Returns Composer binary path in found. Otherwise try to install latest
-composer version to `.dep/composer.phar`. To use specific composer version
-download desired phar and place it at `.dep/composer.phar`.
+
+
+
+### bin/composer
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/vendors.php#L13)
+
+Returns Composer binary path if found. Otherwise try to install latest
+composer version to `.dep/composer.phar`. To use a specific composer version
+download the desired phar and place it in `.dep/composer.phar`.
 
 
 
@@ -41,7 +54,7 @@ download desired phar and place it at `.dep/composer.phar`.
 ## Tasks
 
 ### deploy:vendors
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/vendors.php#L27)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/vendors.php#L29)
 
 Installs vendors.
 

--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -5,6 +5,8 @@ set('composer_action', 'install');
 
 set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction --no-dev --optimize-autoloader');
 
+set('composer_env_vars', '');
+
 // Returns Composer binary path in found. Otherwise try to install latest
 // composer version to `.dep/composer.phar`. To use specific composer version
 // download desired phar and place it at `.dep/composer.phar`.
@@ -28,5 +30,5 @@ task('deploy:vendors', function () {
     if (!commandExist('unzip')) {
         warning('To speed up composer installation setup "unzip" command with PHP zip extension.');
     }
-    run('cd {{release_or_current_path}} && {{bin/composer}} {{composer_action}} {{composer_options}} 2>&1');
+    run('cd {{release_or_current_path}} && {{composer_env_vars}} {{bin/composer}} {{composer_action}} {{composer_options}} 2>&1');
 });


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

We deploy different composer.json file based on the environment we want to deploy on, this change will allow the user to set the composer.json based on the host. The default is '' which will just use the default composer.json. Sample usage:

```
host('test')
    ->set('composer_env_vars', 'COMPOSER=composer-test.json')
    ->set('deploy_path', '/var/www/html);

host('dev')
    ->set('composer_env_vars', 'COMPOSER=composer-dev.json')
    ->set('deploy_path', '/var/www/html);
```