### PR TITLE
fix(typo): Missing backtick on deploy:cleanup command in upgrade.md

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -53,7 +53,7 @@
      deploy:vendors:
        - run: 'cd {{release_path}} && echo {{bin/composer}} {{composer_options}} 2>&1'
    ``` 
-8. Rename task `success` to `deploy:success` and `cleanup` to deploy:cleanup`.
+8. Rename task `success` to `deploy:success` and `cleanup` to `deploy:cleanup`.
 9. Verbosity function (`isDebug()`, etc) deleted. Use `output()->isDebug()` instead.
 10. runLocally() commands are executed relative to the recipe file directory. This behaviour can be overridden via an environment variable:
     ```


### PR DESCRIPTION
- [X] Bug fix #…?
- [X] New feature?
- [X] BC breaks?
- [x] Tests added?
- [X] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

Today on https://deployer.org/docs/7.x/UPGRADE
![image](https://user-images.githubusercontent.com/10236029/185396406-a76590cd-6167-4ab0-8e93-01aac7ec5219.png)
