### PR TITLE
Fix Caddy install

### DIFF
--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -84,7 +84,7 @@ task('provision:update', function () {
     run('apt-add-repository ppa:ondrej/php -y', ['env' => ['DEBIAN_FRONTEND' => 'noninteractive']]);
 
     // Caddy
-    run("curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' > /etc/apt/trusted.gpg.d/caddy-stable.asc");
+    run("curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg");
     run("curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list");
 
     // Nodejs


### PR DESCRIPTION
Fixes this problem with Caddy installation:

```
Err:7 https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABA1F9B8875A6661

GPG error: https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY ABA1F9B8875A6661
E: The repository 'https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease' is not signed.
```

[https://caddyserver.com/docs/install#debian-ubuntu-raspbian](https://caddyserver.com/docs/install#debian-ubuntu-raspbian)