### PR TITLE
Removed temporary workaround as it is for a version which is a year old

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -156,19 +156,6 @@ task('sw-build-without-db:get-remote-config', static function () {
 
         run('./bin/console theme:dump');
         download('{{deploy_path}}/current/files/theme-config', './files/');
-
-        // Temporary workaround to remove absolute file paths in Shopware <6.4.6.0
-        // See:
-        // - https://github.com/shopware/platform/commit/01c8ff86c7d8d3bee1888a26c24c9dc9b4529cbc
-        // - https://issues.shopware.com/issues/NEXT-17720
-        // - https://github.com/deployphp/deployer/issues/2754
-        $deployPath = get('deploy_path');
-        if (substr($deployPath, -1, 1) !== '/') {
-            $deployPath .= '/';
-        }
-        $deployPath .= 'releases/[0-9a-zA-Z]*/';
-        $escapedDeployPath = str_replace('/', '\\\\/', $deployPath);
-        runLocally("sed -iE 's#${escapedDeployPath}##g' files/theme-config/* || true");
     });
 });
 


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

This was a temporary workaround and the version with the fix was released nearly a year ago. There were multiple security updates in between, therefore running the old version is negligent anyway. In my opinion this can be deleted.