### PR TITLE
Escape metainfo to prevent bash syntax errors

### DIFF
--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -130,8 +130,8 @@ task('deploy:release', function () {
     ];
 
     // Save metainfo about release.
-    $json = json_encode($metainfo);
-    run("echo '$json' >> .dep/releases_log");
+    $json = escapeshellarg(json_encode($metainfo));
+    run("echo $json >> .dep/releases_log");
 
     // Make new release.
     run("mkdir -p $releasePath");


### PR DESCRIPTION
Uses the [`escapeshellarg()`](https://www.php.net/escapeshellarg) function to wrap the JSON with single quotes and escape all other single quotes present in the JSON string.  Closes #3260.

- [x] Bug fix #3260
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
