### PR TITLE
Laravel recipe: Skip database tasks if .env is missing

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -106,19 +106,19 @@ task('artisan:passport:keys', artisan('passport:keys'));
  */
 
 desc('Seeds the database with records');
-task('artisan:db:seed', artisan('db:seed --force', ['showOutput']));
+task('artisan:db:seed', artisan('db:seed --force', ['skipIfNoEnv', 'showOutput']));
 
 desc('Runs the database migrations');
 task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']));
 
 desc('Drops all tables and re-run all migrations');
-task('artisan:migrate:fresh', artisan('migrate:fresh --force'));
+task('artisan:migrate:fresh', artisan('migrate:fresh --force', ['skipIfNoEnv']));
 
 desc('Rollbacks the last database migration');
-task('artisan:migrate:rollback', artisan('migrate:rollback --force', ['showOutput']));
+task('artisan:migrate:rollback', artisan('migrate:rollback --force', ['skipIfNoEnv', 'showOutput']));
 
 desc('Shows the status of each migration');
-task('artisan:migrate:status', artisan('migrate:status', ['showOutput']));
+task('artisan:migrate:status', artisan('migrate:status', ['skipIfNoEnv', 'showOutput']));
 
 /*
  * Cache and optimizations.


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

As discussed [here](https://github.com/deployphp/deployer/discussions/3356) with @peterjaap, database tasks could be omitted if the .env file is missing on the Laravel recipe.

Before:
- `php artisan migrate` => `Your .env file is empty! Skipping...` ✅ 
- `php artisan migrate:rollback` => Crashes the deploy ❌ 

After:
- `php artisan migrate` => `Your .env file is empty! Skipping...` ✅ 
- `php artisan migrate:rollback` => `Your .env file is empty! Skipping...` ✅ 

Let me know if you need me to add anything regarding documentation or tests.
