### PR TITLE
Magento: Do not disable maintenance mode after failed deployment

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -218,4 +218,3 @@ task('deploy', [
     'deploy:publish',
 ]);
 
-after('deploy:failed', 'magento:maintenance:disable');


### PR DESCRIPTION
A failed deployment is likely not in a usable state. Also if it failed because of missing bin/magento, this command will also fail and the the process stops before deploy:unlock can be executed

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
