### PR TITLE
moved newrelic endpoint to config and used it when posting to api

### DIFF
--- a/contrib/newrelic.php
+++ b/contrib/newrelic.php
@@ -5,6 +5,7 @@
 - `newrelic_app_id` – newrelic's app id
 - `newrelic_api_key` – newrelic's api key
 - `newrelic_description` – message to send
+- `newrelic_endpoint` – newrelic's REST API endpoint
 
 ## Usage
 

--- a/contrib/newrelic.php
+++ b/contrib/newrelic.php
@@ -31,16 +31,18 @@ set('newrelic_revision', function () {
     return runLocally('git log -n 1 --format="%h"');
 });
 
+set('newrelic_endpoint', 'api.newrelic.com');
+
 desc('Notifies New Relic of deployment');
 task('newrelic:notify', function () {
-    if (($appId = get('newrelic_app_id')) && ($apiKey = get('newrelic_api_key'))) {
+    if (($appId = get('newrelic_app_id')) && ($apiKey = get('newrelic_api_key')) && ($endpoint = get('newrelic_endpoint'))) {
         $data = [
             'user' => get('user'),
             'revision' => get('newrelic_revision'),
             'description' => get('newrelic_description'),
         ];
 
-        Httpie::post("https://api.newrelic.com/v2/applications/$appId/deployments.json")
+        Httpie::post("https://$endpoint/v2/applications/$appId/deployments.json")
             ->header("X-Api-Key", $apiKey)
             ->query(['deployment' => $data])
             ->send();

--- a/docs/contrib/newrelic.md
+++ b/docs/contrib/newrelic.md
@@ -17,6 +17,7 @@ require 'contrib/newrelic.php';
 - `newrelic_app_id` – newrelic's app id
 - `newrelic_api_key` – newrelic's api key
 - `newrelic_description` – message to send
+- `newrelic_endpoint` – newrelic's REST API endpoint
 
 ## Usage
 
@@ -60,11 +61,21 @@ return runLocally('git log -n 1 --format="%h"');
 ```
 
 
+### newrelic_endpoint
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L34)
+
+
+
+```php title="Default value"
+api.newrelic.com
+```
+
+
 
 ## Tasks
 
 ### newrelic:notify
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L35)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L37)
 
 Notifies New Relic of deployment.
 

--- a/docs/contrib/newrelic.md
+++ b/docs/contrib/newrelic.md
@@ -17,7 +17,6 @@ require 'contrib/newrelic.php';
 - `newrelic_app_id` – newrelic's app id
 - `newrelic_api_key` – newrelic's api key
 - `newrelic_description` – message to send
-- `newrelic_endpoint` – newrelic's REST API endpoint
 
 ## Usage
 
@@ -67,7 +66,7 @@ return runLocally('git log -n 1 --format="%h"');
 
 
 ```php title="Default value"
-api.newrelic.com
+'api.newrelic.com'
 ```
 
 

--- a/docs/contrib/newrelic.md
+++ b/docs/contrib/newrelic.md
@@ -17,6 +17,7 @@ require 'contrib/newrelic.php';
 - `newrelic_app_id` – newrelic's app id
 - `newrelic_api_key` – newrelic's api key
 - `newrelic_description` – message to send
+- `newrelic_endpoint` – newrelic's REST API endpoint
 
 ## Usage
 
@@ -30,7 +31,7 @@ after('deploy', 'newrelic:notify');
 
 ## Configuration
 ### newrelic_app_id
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L22)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L23)
 
 
 :::info Required
@@ -41,7 +42,7 @@ Throws exception if not set.
 
 
 ### newrelic_description
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L26)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L27)
 
 
 
@@ -51,7 +52,7 @@ return runLocally('git log -n 1 --format="%an: %s" | tr \'"\' "\'"');
 
 
 ### newrelic_revision
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L30)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L31)
 
 
 
@@ -61,7 +62,7 @@ return runLocally('git log -n 1 --format="%h"');
 
 
 ### newrelic_endpoint
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L34)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L35)
 
 
 
@@ -74,7 +75,7 @@ return runLocally('git log -n 1 --format="%h"');
 ## Tasks
 
 ### newrelic:notify
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L37)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L38)
 
 Notifies New Relic of deployment.
 


### PR DESCRIPTION
For EU region the API endpoint is different and users should be able to change it otherwise deploy notifications don't get saved to their projects.

https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/choose-your-data-center/

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
