### PR TITLE
Select the appropriate cachetool url based on the PHP version

### DIFF
--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -51,7 +51,13 @@ http://gordalina.github.io/cachetool/
 namespace Deployer;
 
 set('cachetool', '');
-set('cachetool_url', 'https://github.com/gordalina/cachetool/releases/download/7.0.0/cachetool.phar');
+set('cachetool_url', function () {
+    if (PHP_VERSION_ID < 81000) {
+        return 'https://github.com/gordalina/cachetool/releases/download/8.0.0/cachetool.phar';
+    }
+
+    return 'https://github.com/gordalina/cachetool/releases/download/9.0.0/cachetool.phar';
+});
 set('cachetool_args', '');
 set('bin/cachetool', function () {
     if (!test('[ -f {{release_or_current_path}}/cachetool.phar ]')) {


### PR DESCRIPTION
Small QoL change. The current recipe will always download version 7.0.0 of Cachetool, which is compatible with PHP 7.3 and up.

For future releases we could bump to 8.0.0 and 9.0.0 (see https://github.com/gordalina/cachetool#compatibility for the exact versions). Only <8.1 and >8.1 are included in this PR because the v8 branch only supports ^8.0.