### PR TITLE
artisan commands launch from project root directory

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -65,10 +65,11 @@ function artisan($command, $options = [])
             return;
         }
 
-        $artisan = '{{release_or_current_path}}/artisan';
-
         // Run the artisan command.
-        $output = run("{{bin/php}} $artisan $command");
+        $output = within('{{release_or_current_path}}', function () use ($command) {
+            $artisan = '{{release_or_current_path}}/artisan';
+            return run("{{bin/php}} $artisan $command");
+        });
 
         // Output the results when appropriate.
         if (in_array('showOutput', $options)) {


### PR DESCRIPTION
some artisan commands are waiting to launch from root directory

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
