### PR TITLE
Feature: fallback on environnement variables for strings parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /vendor/
 *.phar
 .phpunit.result.cache

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -26,6 +26,16 @@ after:
   deploy:failed: deploy:unlock
 ```
 
+If `release_path` is not set in php using the set() function, it can be done by setting it as an environnement variable:
+
+``release_path=/var/foo/bar vendor/bin/dep deploy``
+
+or by loading an .env file where this variable has been defined:
+
+``env $(cat ./.env.local | xargs) vendor/bin/dep deploy``
+
+or by setting it using your CI/CD tool.
+
 YAML recipes can include recipes written in PHP. For example, some tasks maybe written in PHP and imported into YAML.
 
 Conversely, it's also possible to import a YAML recipe from PHP using the [import()](api.md#import) function.

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -52,10 +52,7 @@ class Configuration implements \ArrayAccess
     public function has(string $name): bool
     {
         // Check from less populated array to the more one
-        if (array_key_exists($name, $this->values)
-            || array_key_exists($name, $_ENV)
-            || array_key_exists($name, $_SERVER)
-        ) {
+        if (array_key_exists($name, $this->values) || array_key_exists($name, \getenv())) {
             return true;
         }
 
@@ -98,10 +95,9 @@ class Configuration implements \ArrayAccess
             }
         }
 
-        // $_SERVER has priority over $_ENV, like in Symfony
-        if (null !== $fromEnvVar = $_SERVER[$name] ?? $_ENV[$name] ?? null) {
+        if (array_key_exists($name, \getenv())) {
             // Some trailing \n can come from .env files
-            return \trim($fromEnvVar);
+            return \trim(\getenv($name));
         }
 
         if ($this->parent) {

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -51,13 +51,16 @@ class Configuration implements \ArrayAccess
 
     public function has(string $name): bool
     {
-        // Check from less populated array to the more one
-        if (array_key_exists($name, $this->values) || array_key_exists($name, \getenv())) {
+        if (array_key_exists($name, $this->values)) {
             return true;
         }
 
         if ($this->parent) {
             return $this->parent->has($name);
+        }
+
+        if (array_key_exists($name, \getenv())) {
+            return true;
         }
 
         return false;
@@ -95,11 +98,6 @@ class Configuration implements \ArrayAccess
             }
         }
 
-        if (array_key_exists($name, \getenv())) {
-            // Some trailing \n can come from .env files
-            return \trim(\getenv($name));
-        }
-
         if ($this->parent) {
             $rawValue = $this->parent->fetch($name);
             if ($rawValue !== null) {
@@ -113,6 +111,11 @@ class Configuration implements \ArrayAccess
 
         if (func_num_args() >= 2) {
             return $this->parse($default);
+        }
+
+        if (array_key_exists($name, \getenv())) {
+            // Some trailing \n can come from .env files
+            return \trim(\getenv($name));
         }
 
         throw new ConfigurationException("Config option \"$name\" does not exist.");

--- a/tests/src/Configuration/ConfigurationTest.php
+++ b/tests/src/Configuration/ConfigurationTest.php
@@ -3,17 +3,47 @@
 namespace Deployer\Configuration;
 
 use Deployer\Exception\ConfigurationException;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
 {
-    public function testParse()
+    /**
+     * @dataProvider parseProvider
+     */
+    public function testParse(Configuration $config, string $stringToParse, string $expectedResult): void
+    {
+        self::assertEquals($expectedResult, $config->parse($stringToParse));
+    }
+
+    public function parseProvider(): Generator
     {
         $config = new Configuration();
         $config->set('foo', 'a');
         $config['bar'] = 'b';
+        yield 'Assert parsing can be donne using Configuration setting' => [$config, '{{foo}} {{bar}}', 'a b'];
 
-        self::assertEquals('a b', $config->parse('{{foo}} {{bar}}'));
+        $config = new Configuration();
+        $_SERVER['foo'] = 'a';
+        $_ENV['bar'] = 'b';
+        yield 'Assert parsing can be donne using env vars' => [$config, '{{foo}} {{bar}}', 'a b'];
+
+        $config = new Configuration();
+        $config->set('foo', 'c');
+        $config['bar'] = 'd';
+        $_SERVER['foo'] = 'a';
+        $_ENV['bar'] = 'b';
+        yield 'Assert env vars reading is a fallback, not the first choice' => [$config, '{{foo}} {{bar}}', 'c d'];
+
+        $config = new Configuration();
+        $_SERVER['foo'] = 'a';
+        $_ENV['foo'] = 'b';
+        yield 'Assert $_SERVER env vars have priority over $_ENV ones' => [$config, '{{foo}}', 'a'];
+
+        $config = new Configuration();
+        $_SERVER['foo'] = "a\n";
+        $_ENV['bar'] = ' b ';
+        yield 'Assert trim is done' => [$config, '{{foo}}{{bar}}', 'ab'];
     }
 
     public function testUnset()

--- a/tests/src/Configuration/ConfigurationTest.php
+++ b/tests/src/Configuration/ConfigurationTest.php
@@ -24,25 +24,18 @@ class ConfigurationTest extends TestCase
         yield 'Assert parsing can be donne using Configuration setting' => [$config, '{{foo}} {{bar}}', 'a b'];
 
         $config = new Configuration();
-        $_SERVER['foo'] = 'a';
-        $_ENV['bar'] = 'b';
-        yield 'Assert parsing can be donne using env vars' => [$config, '{{foo}} {{bar}}', 'a b'];
+        \putenv('foo=a');
+        yield 'Assert parsing can be donne using env vars' => [$config, '{{foo}}', 'a'];
 
         $config = new Configuration();
         $config->set('foo', 'c');
         $config['bar'] = 'd';
-        $_SERVER['foo'] = 'a';
-        $_ENV['bar'] = 'b';
+        \putenv('foo=a');
         yield 'Assert env vars reading is a fallback, not the first choice' => [$config, '{{foo}} {{bar}}', 'c d'];
 
         $config = new Configuration();
-        $_SERVER['foo'] = 'a';
-        $_ENV['foo'] = 'b';
-        yield 'Assert $_SERVER env vars have priority over $_ENV ones' => [$config, '{{foo}}', 'a'];
-
-        $config = new Configuration();
-        $_SERVER['foo'] = "a\n";
-        $_ENV['bar'] = ' b ';
+        \putenv("foo=a\n");
+        \putenv('bar= b ');
         yield 'Assert trim is done' => [$config, '{{foo}}{{bar}}', 'ab'];
     }
 


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [x] Tests added?
- [ ] Docs added?

As I prefer yaml files for configuration, I have a made a little modification to make phpdeployer able to fallback on environnement variables when trying to parse a string, in order to get a clean yaml configuration file which can be standard across project, and gitlab-ci (and I think github actions too) compatible.

Given this yaml file and the corresponding environnement variables set into the CI/CD pipeline, everything should be fine 👍 
```yaml
config:
  application: '{{APP_NAME}}'
  release_name: '{{ARCHIVE_RELEASE_NAME}}'
  http_user: '{{HOST_HTTP_USER}}'
  keep_releases: 5
  writable_mode: 'chown'

hosts:
  staging:
    hostname: '{{STAGING_HOST}}'
    remote_user: '{{STAGING_REMOTE_USER}}'
    deploy_path: '~/{{application}}/{{alias}}'
  preprod:
    hostname: '{{PREPROD_HOST}}'
    remote_user: '{{PREPROD_REMOTE_USER}}'
    deploy_path: '~/{{application}}/{{alias}}'
  prod:
    hostname: '{{PROD_HOST}}'
    remote_user: '{{PROD_REMOTE_USER}}'
    deploy_path: '~/{{application}}/{{alias}}'

after:
  deploy:failed: 'deploy:unlock'
```

What do you think about?