### PR TITLE
Laravel recipe: Add horizon publish command

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -204,6 +204,9 @@ task('artisan:horizon:status', artisan('horizon:status', ['showOutput']));
 desc('Terminates the master supervisor so it can be restarted');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
 
+desc('Publish all of the Horizon resources');
+task('artisan:horizon:publish', artisan('horizon:publish'));
+
 /*
  * Telescope.
  */


### PR DESCRIPTION
One of base command to publish your application with Horizon
```
$ php artisan horizon:publish
Copied Directory [/vendor/laravel/horizon/public] To [/public/vendor/horizon]
Publishing complete.
```

