### PR TITLE
Replace unmaintained satackey/push-prebuilt-action by a maintained fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.8
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
 
       - name: Build the docker-compose stack


### PR DESCRIPTION
The unmaintained version uses Node12.