### PR TITLE
Update composer to the latest version before using

### DIFF
--- a/recipe/deploy/vendors.php
+++ b/recipe/deploy/vendors.php
@@ -10,6 +10,9 @@ set('composer_options', '--verbose --prefer-dist --no-progress --no-interaction 
 // download desired phar and place it at `.dep/composer.phar`.
 set('bin/composer', function () {
     if (test('[ -f {{deploy_path}}/.dep/composer.phar ]')) {
+        // Update to the latest version
+        run('{{bin/php}} {{deploy_path}}/.dep/composer.phar self-update');
+        
         return '{{bin/php}} {{deploy_path}}/.dep/composer.phar';
     }
 


### PR DESCRIPTION
At the moment, if composer isn't available system wide, this task installs it into the .dep folder. However, on the next deploy it uses the previously installed composer.

This means, it's never updated. To ensure composer stays up to date this PR runs self-update to update it before using it.

Another option would be to always install composer.phar into the current release so it's always fresh.