### PR TITLE
Fix NodeJS 12 warning: update EndBug/add-and-commit action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -33,7 +33,7 @@ jobs:
         run: php bin/docgen
 
       - name: Add & Commit
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           add: 'docs'
           message: '[automatic] Update docs with bin/docgen'


### PR DESCRIPTION
This PR fixes the following warning

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: EndBug/add-and-commit@v7. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Suggested long term solution: replace this action by git commands used directly to minimize maintenance