### PR TITLE
update writable deploy recipe to use release_or_current_path

### DIFF
--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -72,7 +72,7 @@ task('deploy:writable', function () {
         throw new \RuntimeException('Absolute path not allowed in config parameter `writable_dirs`.');
     }
 
-    cd('{{release_path}}');
+    cd('{{release_or_current_path}}');
 
     // Create directories if they don't exist
     run("mkdir -p $dirs");


### PR DESCRIPTION
Updating this task to use release_or_current_path (from #2486)  will allow the writable task to be used outside of deployment.

This should probably be done for all tasks after the change in #2486 as it will now be expected to work by others using the software and reading #3337, It has also been done for some more tasks in #2604.

For now, I don't wan to touch more parts of the code without knowing if it will break something else. This does it for `writable` only.

- [ ] Bug fix #…?
- [X] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
