### PR TITLE
import() can now load URLs and recipes from third party and private composer repositories

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+/* (c) Anton Medvedev <anton@medv.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Deployer\Command;
+
+use Deployer\Deployer;
+use Deployer\Importer\Importer;
+use Deployer\Utility\Httpie;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\PhpProcess;
+use Symfony\Component\Process\Process;
+
+class ImportCommand extends Command
+{
+    use CommandCommon;
+
+    private InputInterface $input;
+    private OutputInterface $output;
+
+    protected function configure()
+    {
+        $this
+            ->setName('import')
+            ->setDescription('Import a remote recipe')
+            ->addOption('mode', 'm', InputOption::VALUE_REQUIRED, 'Can be either url or composer')
+            ->addArgument('path', InputArgument::REQUIRED, 'Recipe file (can be URL or a path in the repo when using composer mode)')
+            ->addArgument('package', InputArgument::OPTIONAL, 'Composer package name (can have an appended version string)')
+            ->addArgument('repository', InputArgument::OPTIONAL, 'Composer package repository url')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        $io = new SymfonyStyle($input, $output);
+        $path = $input->getArgument('path');
+        $package = $input->getArgument('package');
+        $repository = $input->getArgument('repository');
+
+        if(!Deployer::isWorker()) { // is worker is not returning the correct value, as this command is runnning before the symfony console is initialized and running
+            // maybe the question should be asked only once (save the result), or not even be asked at all?
+            if (!$io->askQuestion(new ConfirmationQuestion("<question>Do you really want to trust this remote recipe: $path?</question>", true))) {
+                return 1;
+            }
+        }
+
+        if(Importer::isUrl($path)) {
+            $this->importUrl($path);
+        }
+
+        elseif(Importer::isRepo($path)) {
+            $this->importComposer($path, $package, $repository);
+        }
+        else {
+            throw new \Exception("Unrecognized path $path, make sure its a valid URL or a valid 'composer/package'");
+        }
+
+        return 0;
+    }
+
+    protected function importUrl(string $path)
+    {
+        if ($data = Httpie::get($path)->send()) {
+            $tmpfname = tempnam("/tmp", "deployer_remote_recipe").".php";
+            $tmpfhandle = fopen($tmpfname, "w");
+            fwrite($tmpfhandle, $data);
+            fclose($tmpfhandle);
+            Deployer::get()->importer->import($tmpfname);
+        } else {
+            throw new \Exception("Could not download $path for import.");
+        }
+    }
+
+    protected function importComposer(string $path, string $package, string $repository = null)
+    {
+
+        if(!$this->composerJsonExists()) {
+            try {
+                $process = Process::fromShellCommandline("composer init --no-interaction --name deployer/project", dirname(DEPLOYER_DEPLOY_FILE));
+                $output = trim($process->mustRun()->getOutput());
+            } catch (RuntimeException $e) {
+                throw new \Exception($e->getMessage());
+            }
+            echo "Initialized composer.json for you\n";
+        }
+
+        if($repository) {
+            $repoName = "deployer/".parse_url($repository, PHP_URL_HOST);
+
+            try {
+                $process = Process::fromShellCommandline("composer config repositories.$repoName composer $repository", dirname(DEPLOYER_DEPLOY_FILE));
+                $output = trim($process->mustRun()->getOutput());
+            } catch (RuntimeException $e) {
+                throw new \Exception($e->getMessage());
+            }
+            if ($this->output->isVerbose()) {
+                echo "Added repository to composer.json\n";
+            }
+        }
+
+        try {
+            $process = Process::fromShellCommandline("composer require --dev --no-plugins \"$package\"", dirname(DEPLOYER_DEPLOY_FILE));
+            $output = trim($process->mustRun()->getOutput());
+        } catch (RuntimeException $e) {
+            throw new \Exception($e->getMessage());
+        }
+        if ($this->output->isVerbose()) {
+            echo "Added require-dev package to composer.json\n";
+        }
+
+        list($packageWithoutVersion, $version) = explode(":", $package);
+        $target = dirname(DEPLOYER_DEPLOY_FILE) . "/vendor/".$packageWithoutVersion."/".$path;
+        if(file_exists($target)) {
+            Importer::import($target);
+        } else {
+            throw new \Exception("Could not find imported composer file in ".$target);
+        }
+    }
+
+    protected function getComposerJsonFile()
+    {
+        return dirname(DEPLOYER_DEPLOY_FILE) . "/composer.json";
+    }
+
+    private function composerJsonExists()
+    {
+        return file_exists($this->getComposerJsonFile());
+    }
+
+}

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -8,6 +8,7 @@
 
 namespace Deployer\Importer;
 
+use Deployer\Command\ImportCommand;
 use Deployer\Deployer;
 use Deployer\Exception\ConfigurationException;
 use Deployer\Exception\Exception;
@@ -15,6 +16,8 @@ use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Yaml\Yaml;
 use function array_filter;
 use function array_keys;
@@ -100,6 +103,26 @@ class Importer
                 throw new Exception("Unknown file format: $path\nOnly .php and .yaml supported.");
             }
         }
+    }
+
+    public static function isUrl(string $path): bool {
+        return (bool) preg_match('/^https:\/\//i', $path);
+    }
+
+    public static function isRepo(string $path): bool {
+        list($repo, $version) = explode(":", $path);
+        return (bool) preg_match('@^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$@', $repo);
+    }
+
+    public static function importUrl(string $url)
+    {
+
+        (new ImportCommand())->run(new ArrayInput(['--mode'=> 'url', 'path' => $url]), new ConsoleOutput());
+    }
+
+    public static function importComposer(string $file, string $package, string $repo = null)
+    {
+        (new ImportCommand())->run(new ArrayInput(['--mode'=> 'composer', 'path' => $file, 'package' => $package, 'repository' => $repo]), new ConsoleOutput());
     }
 
     protected static function hosts(array $hosts)

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -110,7 +110,7 @@ class Importer
     }
 
     public static function isRepo(string $path): bool {
-        list($repo, $version) = explode(":", $path);
+        list($repo, $version) = explode(":", $path.":");
         return (bool) preg_match('@^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$@', $repo);
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -152,9 +152,16 @@ function selectedHosts(): array
  *
  * @throws Exception
  */
-function import(string $file): void
+function import(string $file, string $package = null, string $repo = null): void
 {
-    Importer::import($file);
+    if($file && $package) {
+        Importer::importComposer($file, $package, $repo);
+    }
+    elseif(Importer::isUrl($file)) {
+        Importer::importUrl($file);
+    } else {
+        Importer::import($file);
+    }
 }
 
 /**


### PR DESCRIPTION
This is a quick proof of concept for this discussion/idea: https://github.com/deployphp/deployer/discussions/3475

It extends the existing include() function, so that URLs can be included in the deploy.php file. Also files from composer repositories can be included too. The included packages will be loaded automatically by creating a composer.json or adding them to an existing one.

Example usage in deploy.php with urls:
```
<?php
namespace Deployer;
import("https://pastebin.com/raw/bUpKm80E");
task("deploy", function() {
    writeln("deploy!");
    invoke("test");
});
localhost();
```
Output of dep deploy:
```
mhinz@dev:/srv/htdocs/deployer$ bin/dep deploy
 Do you really want to trust this remote recipe: https://pastebin.com/raw/bUpKm80E? (yes/no) [yes]:
 > y
task deploy
[localhost] deploy!
task test
[localhost] test!
```

Example usage in deploy.php with private composer repo:
```
<?php
namespace Deployer;
import("recipe/test.php", "some/custommodule:dev-master", "https://composer.example.org");
task("deploy", function() {
    writeln("deploy!");
    invoke("test");
});
localhost();
```
Output of dep deploy:
```
mhinz@dev:/srv/htdocs/deployer$ bin/dep deploy
 Do you really want to trust this remote recipe: recipe/test.php? (yes/no) [yes]:
 > y
task deploy
[localhost] deploy!
task test
[localhost] test!
```



This is especially useful when running a lot of projects with similar custom recipes (e.g. in agencies). The automated composer require is probably not really needed, as we could just throw an exception for missing composer packages. But i thought its a bit nicer for the dev experience.

There is still a lot of room for improvement, for example: the deploy.php configuration is loaded before the main symfony console application is running, this results in various little problems (to ask a user an interactive question, a command has to be run manually. Deployer::isWorker() always returns false, because the value is set too late (when the worker command is executed). 

Should the user even be asked for confirmation? In theory it is a risk, but in comparison running the usual `wget URL | bash` commands are risky too. 


- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?