### PR TITLE
docs(selector): correct env config option to array

### DIFF
--- a/docs/selector.md
+++ b/docs/selector.md
@@ -154,7 +154,8 @@ You can also define labels in YAML recipe. For example:
 hosts:
   web.example.com:
     remote_user: deployer
-    env: production
+    env:
+      environment: production
     labels:
       env: prod
 ```
@@ -164,7 +165,7 @@ But make sure to distinguish between `env` and `labels.env` keys.
 
 ```php
 task('info', function () {
-    writeln('env:' . get('env') . ' labels.env:' . get('labels')['env']);
+    writeln('env:' . get('env')['environment'] . ' labels.env:' . get('labels')['env']);
 });
 ```
 


### PR DESCRIPTION
As the `env` config options is expected to be an array, not a string, the supplied example is throwing errors. This syntax checking of the `env` variable seems to only happen in the YAML config syntax, not with the php config.