### PR TITLE
docs(github-action): improve & update

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -27,6 +27,9 @@ jobs:
         with:
           php-version: "8.1"
 
+      - name: Install dependencies
+        run: composer install
+
       - name: Deploy
         uses: deployphp/action@v1
         with:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.0"
+          php-version: "8.1"
 
       - name: Deploy
         uses: deployphp/action@v1


### PR DESCRIPTION
While using the GitHub action example to setup our deployment flow, I noticed the PHP version being outdated & a `composer install` step missing.