### PR TITLE
Prevent type errors when defined timeout options are not numeric

### DIFF
--- a/src/Component/Ssh/Client.php
+++ b/src/Component/Ssh/Client.php
@@ -82,8 +82,8 @@ class Client
         $process = new Process($ssh);
         $process
             ->setInput("( $command ); printf '[exit_code:%s]' $?;")
-            ->setTimeout($config['timeout'])
-            ->setIdleTimeout($config['idle_timeout']);
+            ->setTimeout((null === $config['timeout']) ? null : (float) $config['timeout'])
+            ->setIdleTimeout((null === $config['idle_timeout']) ? null : (float) $config['idle_timeout']);
 
         $callback = function ($type, $buffer) use ($config, $host) {
             $this->logger->printBuffer($host, $type, $buffer);


### PR DESCRIPTION
When using [deployphp/action](https://github.com/deployphp/action), any config option defined in the workflow is supplied to `deployer` as a string. 

This breaks the process in the case of timeout options, because `Symfony\Component\Process\Process::setTimeout` and `Symfony\Component\Process\Process::setIdleTimeout` expect numeric values.



- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
