### PR TITLE
docker: build and push image

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,31 @@
+name: push
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push:
+    name: "Build and push ${{ github.ref_name }}"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v4
+        with:
+          context: "{{defaultContext}}:./"
+          push: true
+          build-args: VERSION=${{ github.ref_name }}
+          tags: ghcr.io/deployphp/deployer:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+## Compile the PHAR in the first multi-stage image ##
+FROM php:8.1-cli-alpine as build
+
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Copy Composer from official image
+COPY --from=composer/composer:2-bin /composer /usr/bin/composer
+
+# Allow to generate .phar files
+RUN echo -e "[PHP]\nphar.readonly = Off" >> /usr/local/etc/php/php.ini
+
+WORKDIR /app/
+
+# Copy sources files
+COPY ./ /app/
+
+ARG VERSION
+
+# Install dependencies and build PHAR, the "v" in the version (e.g. "v6.9.4")
+# will provide the "v" arg and its value directly
+RUN composer install --no-dev --quiet && /app/bin/build -$VERSION \
+    # The file should exist
+    && ls -lh /app/deployer.phar
+
+
+## Create the final image ##
+FROM php:8.1-cli-alpine
+
+# Copy the PHAR file from the first multi-stage image to the final image
+COPY --from=build /app/deployer.phar /usr/local/bin/deployer
+
+## Make deployer executable and check that it can be executed
+RUN chmod +x /usr/local/bin/deployer && deployer --version
+
+# Call deployer automatically
+ENTRYPOINT ["/usr/local/bin/deployer"]

--- a/bin/build
+++ b/bin/build
@@ -15,7 +15,7 @@ $version = 'dev-master';
 if (array_key_exists('v', $opt)) {
     $version = $opt['v'];
     if (!preg_match('/^\d+\.\d+\.\d+(-[\d\w\.]+)?$/i', $version)) {
-        die("Version number must follow semantic versioning.\n");
+        die("Version number must follow semantic versioning, '$version' given.\n");
     }
 }
 


### PR DESCRIPTION
- [x] Bug fix #3118
- [x] New feature?
- [ ] BC breaks?
- [ ] Docs added?

I target 6.x so that 6.x and 7.x (later) could have Docker releases.

I tested it in another project: I created a 0.0.3 tag here https://github.com/alexislefebvre/docker-images/tree/0.0.3 GitHub Actions built an image and pushed it there: https://github.com/alexislefebvre/docker-images/pkgs/container/php-8.1-jakzal-phpqa-gd

Once this will work, people will be able to run something like  `docker run ghcr.io/deployphp/deployer:v6.9.1 dep`, use the image on their CI system, etc.

:warning: I don't know if it may allow a contributor to push *bad* code to a Docker image, sorry.

If you merge it and create a tag, it may fail if the registry is not active yet, IIRC we had the issue too and we had to change the visibility of our GitHub registry to private to public before we could push images.

To test the image: checkout this branch and run `docker build`:

```shell
docker build . --tag deployer --build-arg VERSION=v6.9.1
docker run deployer
```

---

Real test on my fork:
1. workflow: https://github.com/alexislefebvre/deployer/actions/runs/4179168257/jobs/7238799360 (it will expire at some point)
2. resulting image: https://github.com/alexislefebvre/deployer/pkgs/container/deployer
3. it works!

```shell
$ docker run -t --rm ghcr.io/alexislefebvre/deployer:v6.9.3 help
Description:
  Display help for a command

Usage:
  help [options] [--] [<command_name>]

[…]
```