### PR TITLE
Shopware Flex has no `build.sh` anymore

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -161,7 +161,7 @@ task('sw-build-without-db:get-remote-config', static function () {
 });
 
 task('sw-build-without-db:build', static function () {
-    runLocally('CI=1 SHOPWARE_SKIP_BUNDLE_DUMP=1 ./bin/build.sh');
+    runLocally('CI=1 SHOPWARE_SKIP_BUNDLE_DUMP=1 ./bin/build-js.sh');
 });
 
 task('sw-build-without-db', [


### PR DESCRIPTION
The new [Shopware template](https://developer.shopware.com/docs/guides/installation/template) does not have a `bin/build.sh` file anymore. The missing executable executed `composer install` and `bin/build-js.sh`. Since requiring the new Symfony flex recipe requires running `composer` manually, we just execute `bin/build-js.sh` now.

This could be a breaking change for some users. Don't know if you want to state that somewhere or allow a way to restore the old behavior via flag? (Although one can just override the `sw-build-without-db:build` task anytime)

- [ ] Bug fix #…?
- [ ] New feature?
- [x] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
