### PR TITLE
Teams, Telegram, Slack contrib recipe no longer fails silently if no webhook is configured

### DIFF
--- a/contrib/ms-teams.php
+++ b/contrib/ms-teams.php
@@ -92,6 +92,7 @@ set('teams_failure_color', '#ff0909');
 desc('Notifies Teams');
 task('teams:notify', function () {
     if (!get('teams_webhook', false)) {
+        warning('No MS Teams webhook configured');
         return;
     }
 
@@ -106,6 +107,7 @@ task('teams:notify', function () {
 desc('Notifies Teams about deploy finish');
 task('teams:notify:success', function () {
     if (!get('teams_webhook', false)) {
+        warning('No MS Teams webhook configured');
         return;
     }
 
@@ -120,6 +122,7 @@ task('teams:notify:success', function () {
 desc('Notifies Teams about deploy failure');
 task('teams:notify:failure', function () {
     if (!get('teams_webhook', false)) {
+        warning('No MS Teams webhook configured');
         return;
     }
 

--- a/contrib/slack.php
+++ b/contrib/slack.php
@@ -98,6 +98,7 @@ function checkSlackAnswer($result)
 desc('Notifies Slack');
 task('slack:notify', function () {
     if (!get('slack_webhook', false)) {
+        warning('No Slack webhook configured');
         return;
     }
 
@@ -117,6 +118,7 @@ task('slack:notify', function () {
 desc('Notifies Slack about deploy finish');
 task('slack:notify:success', function () {
     if (!get('slack_webhook', false)) {
+        warning('No Slack webhook configured');
         return;
     }
 
@@ -137,6 +139,7 @@ task('slack:notify:success', function () {
 desc('Notifies Slack about deploy failure');
 task('slack:notify:failure', function () {
     if (!get('slack_webhook', false)) {
+        warning('No Slack webhook configured');
         return;
     }
 
@@ -156,6 +159,7 @@ task('slack:notify:failure', function () {
 desc('Notifies Slack about rollback');
 task('slack:notify:rollback', function () {
     if (!get('slack_webhook', false)) {
+        warning('No Slack webhook configured');
         return;
     }
 

--- a/contrib/telegram.php
+++ b/contrib/telegram.php
@@ -89,7 +89,7 @@ task('telegram:notify', function () {
     }
 
     if (!get('telegram_chat_id', false)) {
-        warning('No Slack chat id configured');
+        warning('No Telegram chat id configured');
         return;
     }
 
@@ -120,7 +120,7 @@ task('telegram:notify', function () {
       }
 
       if (!get('telegram_chat_id', false)) {
-          warning('No Slack chat id configured');
+          warning('No Telegram chat id configured');
           return;
       }
 
@@ -151,7 +151,7 @@ task('telegram:notify', function () {
     }
 
     if (!get('telegram_chat_id', false)) {
-        warning('No Slack chat id configured');
+        warning('No Telegram chat id configured');
         return;
     }
 

--- a/contrib/telegram.php
+++ b/contrib/telegram.php
@@ -84,10 +84,12 @@ set('telegram_failure_text', 'Deploy to *{{target}}* failed');
 desc('Notifies Telegram');
 task('telegram:notify', function () {
     if (!get('telegram_token', false)) {
+        warning('No Telegram token configured');
         return;
     }
 
     if (!get('telegram_chat_id', false)) {
+        warning('No Slack chat id configured');
         return;
     }
 
@@ -113,10 +115,12 @@ task('telegram:notify', function () {
   desc('Notifies Telegram about deploy finish');
   task('telegram:notify:success', function () {
       if (!get('telegram_token', false)) {
+          warning('No Telegram token configured');
           return;
       }
 
       if (!get('telegram_chat_id', false)) {
+          warning('No Slack chat id configured');
           return;
       }
 
@@ -141,13 +145,15 @@ task('telegram:notify', function () {
 
   desc('Notifies Telegram about deploy failure');
   task('telegram:notify:failure', function () {
-      if (!get('telegram_token', false)) {
-          return;
-      }
+    if (!get('telegram_token', false)) {
+        warning('No Telegram token configured');
+        return;
+    }
 
-      if (!get('telegram_chat_id', false)) {
-          return;
-      }
+    if (!get('telegram_chat_id', false)) {
+        warning('No Slack chat id configured');
+        return;
+    }
 
       $telegramUrl = get('telegram_url') . '?' . http_build_query (
           Array (

--- a/docs/contrib/ms-teams.md
+++ b/docs/contrib/ms-teams.md
@@ -166,7 +166,7 @@ Notifies Teams.
 
 
 ### teams:notify:success
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/ms-teams.php#L107)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/ms-teams.php#L108)
 
 Notifies Teams about deploy finish.
 
@@ -174,7 +174,7 @@ Notifies Teams about deploy finish.
 
 
 ### teams:notify:failure
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/ms-teams.php#L121)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/ms-teams.php#L123)
 
 Notifies Teams about deploy failure.
 

--- a/docs/contrib/slack.md
+++ b/docs/contrib/slack.md
@@ -194,7 +194,7 @@ Notifies Slack.
 
 
 ### slack:notify:success
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L118)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L119)
 
 Notifies Slack about deploy finish.
 
@@ -202,7 +202,7 @@ Notifies Slack about deploy finish.
 
 
 ### slack:notify:failure
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L138)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L140)
 
 Notifies Slack about deploy failure.
 
@@ -210,7 +210,7 @@ Notifies Slack about deploy failure.
 
 
 ### slack:notify:rollback
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L157)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/slack.php#L160)
 
 Notifies Slack about rollback.
 


### PR DESCRIPTION
Some contrib recipes would fail silently if there was no required config configured. Now the following throw a warning which I believe contributes to a better user experience.
* `contrib/ms-teams.php`
* `contrib/telegram.php`
* `contrib/slack.php`

- [x] Bug fix?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
