### PR TITLE
Added missing deploy task to recipe/common

### DIFF
--- a/docs/recipe/common.md
+++ b/docs/recipe/common.md
@@ -225,8 +225,21 @@ This task is group task which contains next tasks:
 * [deploy:success](/docs/recipe/common.md#deploysuccess)
 
 
+### deploy
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L156)
+
+Deploys your project.
+
+
+
+
+This task is group task which contains next tasks:
+* [deploy:prepare](/docs/recipe/common.md#deployprepare)
+* [deploy:publish](/docs/recipe/common.md#deploypublish)
+
+
 ### deploy:success
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L158)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L165)
 
 
 
@@ -234,7 +247,7 @@ Prints success message
 
 
 ### deploy:failed
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L167)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L174)
 
 
 
@@ -242,7 +255,7 @@ Hook on deploy failure.
 
 
 ### logs:app
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L177)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/common.php#L184)
 
 Shows application logs.
 

--- a/recipe/common.php
+++ b/recipe/common.php
@@ -152,6 +152,13 @@ task('deploy:publish', [
     'deploy:success',
 ]);
 
+desc('Deploys your project');
+task('deploy', [
+    'deploy:prepare',
+    'deploy:publish',
+]);
+
+
 /**
  * Prints success message
  */


### PR DESCRIPTION
`recipe/common.php` currently does not define a deploy task and is the only recipe that's missing it.
Newcomers may stumble over this behavior, as the documentation asks you to run `dep deploy` as one of the first steps.
This PR fixes this.

It's compatible with recipes that are based on `common`, as overwriting tasks is allowed (e.g. common > symfony > contao).

Note: It appears that this task was previously defined (see #296).


- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added? --> updated.

      Please, regenerate docs by running next command:
      $ php bin/docgen
