### PR TITLE
Fix #3396. Displays the start timestamp to each task

### DIFF
--- a/src/Executor/Messenger.php
+++ b/src/Executor/Messenger.php
@@ -48,23 +48,14 @@ class Messenger
 
     public function startTask(Task $task): void
     {
-        $this->startTime = round(microtime(true) * 1000);
+        $this->startTime = time();
         if (getenv('GITHUB_WORKFLOW')) {
             $this->output->writeln("::group::task {$task->getName()}");
         } else if (getenv('GITLAB_CI')) {
             $this->output->writeln("\e[0Ksection_start:{$this->startTime}:{$this->startTime}[collapsed=true]\r\e[0K{$task->getName()}");
-        } else if ($this->output->isVeryVerbose()) {
-            // option `-vv` displays task start time with milliseconds accuracy
-            $timestamp = (int) floor($this->startTime / 1000);
-            $millis = sprintf("%03d", $this->startTime % 1000);
-
-            $taskStartTime = date("Y-d-m H:i:s", $timestamp);
-            $this->output->writeln("[{$taskStartTime}.{$millis}] <fg=cyan;options=bold>task</> {$task->getName()}");
         } else if ($this->output->isVerbose()) {
             // option `-v` displays task start time
-            $timestamp = (int) floor($this->startTime / 1000);
-
-            $taskStartTime = date("Y-d-m H:i:s", $timestamp);
+            $taskStartTime = date("Y-d-m H:i:s", $this->startTime);
             $this->output->writeln("[{$taskStartTime}] <fg=cyan;options=bold>task</> {$task->getName()}");
         } else {
             $this->output->writeln("<fg=cyan;options=bold>task</> {$task->getName()}");
@@ -78,14 +69,12 @@ class Messenger
     public function endTask(Task $task, bool $error = false): void
     {
         if (empty($this->startTime)) {
-            $this->startTime = round(microtime(true) * 1000);
+            $this->startTime = time();
         }
 
-        $endTime = round(microtime(true) * 1000);
-        $millis = $endTime - $this->startTime;
-        $seconds = floor($millis / 1000);
-        $millis = $millis - $seconds * 1000;
-        $taskTime = ($seconds > 0 ? "{$seconds}s " : "") . "{$millis}ms";
+        $endTime = time();
+        $seconds = $endTime - $this->startTime;
+        $taskTime = "{$seconds}s ";
 
         if (getenv('GITHUB_WORKFLOW')) {
             $this->output->writeln("::endgroup::");

--- a/src/Executor/Messenger.php
+++ b/src/Executor/Messenger.php
@@ -53,6 +53,19 @@ class Messenger
             $this->output->writeln("::group::task {$task->getName()}");
         } else if (getenv('GITLAB_CI')) {
             $this->output->writeln("\e[0Ksection_start:{$this->startTime}:{$this->startTime}[collapsed=true]\r\e[0K{$task->getName()}");
+        } else if ($this->output->isVeryVerbose()) {
+            // option `-vv` displays task start time with milliseconds accuracy
+            $timestamp = (int) floor($this->startTime / 1000);
+            $millis = $this->startTime % 1000;
+
+            $taskStartTime = date("Y-d-m H:i:s", $timestamp);
+            $this->output->writeln("[{$taskStartTime}.{$millis}] <fg=cyan;options=bold>task</> {$task->getName()}");
+        } else if ($this->output->isVerbose()) {
+            // option `-v` displays task start time
+            $timestamp = (int) floor($this->startTime / 1000);
+
+            $taskStartTime = date("Y-d-m H:i:s", $timestamp);
+            $this->output->writeln("[{$taskStartTime}] <fg=cyan;options=bold>task</> {$task->getName()}");
         } else {
             $this->output->writeln("<fg=cyan;options=bold>task</> {$task->getName()}");
         }

--- a/src/Executor/Messenger.php
+++ b/src/Executor/Messenger.php
@@ -56,7 +56,7 @@ class Messenger
         } else if ($this->output->isVeryVerbose()) {
             // option `-vv` displays task start time with milliseconds accuracy
             $timestamp = (int) floor($this->startTime / 1000);
-            $millis = $this->startTime % 1000;
+            $millis = sprintf("%03d", $this->startTime % 1000);
 
             $taskStartTime = date("Y-d-m H:i:s", $timestamp);
             $this->output->writeln("[{$taskStartTime}.{$millis}] <fg=cyan;options=bold>task</> {$task->getName()}");


### PR DESCRIPTION
Fixes #3396 

Option `-v` adds the task start time, while `-vv` displays the task start time with milliseconds accuracy

Normal
```
$ dep deploy
task deploy:1
[localhost] 1
task deploy:2
[localhost] 2
task deploy:3
[localhost] 3
```

With verbose option
```
$ dep deploy -v
[2023-02-03 17:39:02] task deploy:1
[localhost] 1
[2023-02-03 17:39:02] task deploy:2
[localhost] 2
[2023-02-03 17:39:02] task deploy:3
[localhost] 3
```

With very verbose option
```
$ dep deploy -vv
[2023-02-03 17:39:05.112] task deploy:1
[localhost] 1
done on localhost
done deploy:1 99ms
[2023-02-03 17:39:05.211] task deploy:2
[localhost] 2
done on localhost
done deploy:2 60ms
[2023-02-03 17:39:05.271] task deploy:3
[localhost] 3
done on localhost
done deploy:3 61ms
```


- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
