### PR TITLE
Fixing ssh_arguments to not explode to support arguments that contain spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.phar
 .phpunit.result.cache
 docker-compose.override.yml
+/.idea

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -277,9 +277,7 @@ class Host
     {
         $options = [];
         if ($this->has('ssh_arguments')) {
-            foreach ($this->getSshArguments() as $arg) {
-                $options = array_merge($options, explode(' ', $arg));
-            }
+            $options = array_merge($options, $this->getSshArguments());
         }
         if ($this->has('port')) {
             $options = array_merge($options, ['-p', $this->getPort()]);


### PR DESCRIPTION
Fixing ssh_arguments items to not be exploded which has a side effect of causing escapeshellarg to quote into arguments values containing spaces.

For example:

```
->setSshArguments(["-o ProxyCommand='ssh -A jump@1.2.3.4-W %h:%p'"])
```


Fixes this issue: https://github.com/deployphp/deployer/issues/3290
