### PR TITLE
Fix collapsible section's end markers in GitLab CI job output

### DIFF
--- a/src/Executor/Messenger.php
+++ b/src/Executor/Messenger.php
@@ -77,7 +77,7 @@ class Messenger
         if (getenv('GITHUB_WORKFLOW')) {
             $this->output->writeln("::endgroup::");
         } else if (getenv('GITLAB_CI')) {
-            $this->output->writeln("\e[0Ksection_end:{$taskTime}:{$this->startTime}\r\e[0K");
+            $this->output->writeln("\e[0Ksection_end:{$endTime}:{$this->startTime}\r\e[0K");
         } else if ($this->output->isVeryVerbose()) {
             $this->output->writeln("<fg=yellow;options=bold>done</> {$task->getName()} $taskTime");
         }


### PR DESCRIPTION
The current `section_end` markers for GitLab CI do not conform to the syntax described in the [documentation](https://docs.gitlab.com/ee/ci/jobs/#custom-collapsible-sections). Instead of the current timestamp, the text line includes the elapsed task time in a format (e.g. `1s 884ms`) that is not caught by the [regex that GitLab uses](https://gitlab.com/gitlab-org/gitlab/-/blob/4ea0cb1a966167effe1625bd89e7be9c24405911/lib/gitlab/regex.rb#L422).

This issue in practice remains unnoticed until additional output is supposed to be displayed in the job output after the Deployer process has finished. In this case, any additional output is hidden inside the collapsed section of the last Deployer task.