### PR TITLE
Added `artisan:bugsnag:deploy` task

### DIFF
--- a/contrib/bugsnag.php
+++ b/contrib/bugsnag.php
@@ -3,23 +3,39 @@
 
 ## Configuration
 
-- *bugsnag_api_key* – the API Key associated with the project. Informs Bugsnag which project has been deployed. This is the only required field.
+- *bugsnag_api_key* – the API Key associated with the project. Informs BugSnag which project has been deployed. This is the only required field.
 - *bugsnag_provider* – the name of your source control provider. Required when repository is supplied and only for on-premise services.
 - *bugsnag_app_version* – the app version of the code you are currently deploying. Only set this if you tag your releases with semantic version numbers and deploy infrequently. (Optional.)
 
+If you use Laravel, follow the official [BugSnag integration guide](https://docs.bugsnag.com/platforms/php/laravel).
+
 ## Usage
 
-Since you should only notify Bugsnag of a successful deployment, the `bugsnag:notify` task should be executed right at the end.
+Since you should only notify BugSnag of a successful deployment, the `bugsnag:notify` task should be executed right at the end.
 
 ```php
 after('deploy', 'bugsnag:notify');
 ```
+
+If you want to use the Laravel Artisan command, call the `artisan:bugsnag:deploy` task to notify BugSnag of new releases.
+Please note that you have to manually register the BugSnag `DeployCommand` command in your `app/Console/Kernel.php` file.
+
+```php
+after('deploy', 'artisan:bugsnag:deploy');
+```
+
 */
 namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
-desc('Notifies Bugsnag of deployment');
+/*
+ * We will extend the Laravel recipe to simply add BugSnag
+ * provided Artisan command.
+ */
+require_once __DIR__ . '/../recipe/laravel.php';
+
+desc('Notifies BugSnag of deployment');
 task('bugsnag:notify', function () {
     $data = [
         'apiKey'       => get('bugsnag_api_key'),
@@ -34,4 +50,23 @@ task('bugsnag:notify', function () {
     Httpie::post('https://notify.bugsnag.com/deploy')
         ->jsonBody($data)
         ->send();
+});
+
+desc('Notifies BugSnag of releases using the Laravel Artisan console');
+task('artisan:bugsnag:deploy', function () {
+	$data = [
+		'repository' => get('repository'),
+		'revision'   => get('release_revision'),
+		'provider'   => get('bugsnag_provider'),
+		'builder'    => get('user')
+	];
+
+	$options = '';
+	foreach ($data as $key => $value) {
+		if ($value !== null) {
+			$options .= " --$key=\"$value\"";
+		}
+	}
+
+	artisan("bugsnag:deploy $options")();
 });


### PR DESCRIPTION
Added task to notify BugSnag of releases using the Laravel Artisan console.

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

BugSnag provides a Laravel Artisan `bugsnag:deploy` command to report releases. This PR adds a task in `contrib/bugsnag.php` to allow use that command when deploying.

Note: I required the Laravel recipe to allow the use of `artisan` function, not sure if is the right way.

This is related to #3402