### PR TITLE
Fix artifact file generation when "from_repo" option is enabled

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -374,7 +374,7 @@ task('artifact:package', function() {
             "No artifact excludes file provided, provide one at artifacts/excludes or change location"
         );
     }
-    run('{{bin/tar}} --exclude-from={{artifact_excludes_file}} -czf {{artifact_path}} {{release_or_current_path}}');
+    run('{{bin/tar}} --exclude-from={{artifact_excludes_file}} -czf {{artifact_path}} -C {{release_or_current_path}} .');
 });
 
 desc('Uploads artifact in release folder for extraction.');


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Fixes a bug introduced with the PR #3456

When the option "from_repo" is enabled (magento2 recipe), the tar artifact is not generated properly.
It is generated with the following structure:

```
artifacts/
    repo/
        [magento project]
```

Whereas it should be:

```
./
   [magento project]
```

This PR fixes this issue.
The artifact is now generated correctly with or without the option enabled.