### PR TITLE
fix(docs): typos in supervisord-monitor example

### DIFF
--- a/contrib/supervisord-monitor.php
+++ b/contrib/supervisord-monitor.php
@@ -66,11 +66,11 @@ set('supervisord', [
 
 host('staging.myproject.com')
     ->set('branch', 'develop')
-    ->set('labels' => ['stage' => 'staging']);
+    ->set('labels', ['stage' => 'staging']);
 
 host('myproject.com')
     ->set('branch', 'main')
-    ->set('labels' => ['stage' => 'production']);
+    ->set('labels', ['stage' => 'production']);
 
 // Tasks
 task('build', function () {
@@ -80,7 +80,7 @@ task('build', function () {
 task('deploy', [
     'build',
     'supervisord',
-])
+]);
 
 task('supervisord', ['supervisord-monitor:restart'])
     ->select('stage=production');

--- a/docs/contrib/supervisord-monitor.md
+++ b/docs/contrib/supervisord-monitor.md
@@ -78,11 +78,11 @@ set('supervisord', [
 
 host('staging.myproject.com')
     ->set('branch', 'develop')
-    ->set('labels' => ['stage' => 'staging']);
+    ->set('labels', ['stage' => 'staging']);
 
 host('myproject.com')
     ->set('branch', 'main')
-    ->set('labels' => ['stage' => 'production']);
+    ->set('labels', ['stage' => 'production']);
 
 Tasks
 task('build', function () {
@@ -92,7 +92,7 @@ task('build', function () {
 task('deploy', [
     'build',
     'supervisord',
-])
+]);
 
 task('supervisord', ['supervisord-monitor:restart'])
     ->select('stage=production');


### PR DESCRIPTION
Just fixes a few syntax typos on one of the pages in the docs