### PR TITLE
fix storing `releases_log` when running deploy on windows

### DIFF
--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -123,7 +123,11 @@ task('deploy:release', function () {
     ];
 
     // Save metainfo about release.
-    $json = escapeshellarg(json_encode($metainfo));
+    if (PHP_OS_FAMILY === "Windows") {
+        $json = addcslashes(json_encode($metainfo), '\\"');
+    } else {
+        $json = escapeshellarg(json_encode($metainfo));
+    }
     run("echo $json >> .dep/releases_log");
 
     // Make new release.

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -124,7 +124,7 @@ task('deploy:release', function () {
 
     // Save metainfo about release.
     if (PHP_OS_FAMILY === "Windows") {
-        $json = addcslashes(json_encode($metainfo), '\\"');
+        $json = "'" . str_replace("'", '`', json_encode($metainfo)) . "'";
     } else {
         $json = escapeshellarg(json_encode($metainfo));
     }

--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -123,12 +123,8 @@ task('deploy:release', function () {
     ];
 
     // Save metainfo about release.
-    if (PHP_OS_FAMILY === "Windows") {
-        $json = "'" . str_replace("'", '`', json_encode($metainfo)) . "'";
-    } else {
-        $json = escapeshellarg(json_encode($metainfo));
-    }
-    run("echo $json >> .dep/releases_log");
+    $json = str_replace("'", '`', json_encode($metainfo));
+    run("echo '$json' >> .dep/releases_log");
 
     // Make new release.
     run("mkdir -p $releasePath");


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

the implementation for `escapeshellarg` differs between linux and windows. from documentation (https://www.php.net/manual/en/function.escapeshellarg.php):

> escapeshellarg() adds single quotes around a string and quotes/escapes any existing single quotes allowing you to pass a string directly to a shell function and having it be treated as a single safe argument. This function should be used to escape individual arguments to shell functions coming from user input. The shell functions include exec(), system() and the backtick operator.

> On Windows, escapeshellarg() instead replaces percent signs, exclamation marks (delayed variable substitution) and double quotes with spaces and adds double quotes around the string. Furthermore, each streak of consecutive backslashes (\) is escaped by one additional backslash.

i am releasing from windows machine and previous change merged in https://github.com/deployphp/deployer/pull/3328 made my `releases_log` file look like this:
```
{"created_at":"2022-11-26T18:58:41+0000","release_name":"1","user":"samuel","target":"develop"}
{"created_at":"2022-11-26T19:54:38+0000","release_name":"2","user":"samuel","target":"master "}
{"created_at":"2022-11-27T19:53:04+0000","release_name":"3","user":"samuel","target":"master "}
{"created_at":"2022-11-27T17:36:11+0000","release_name":"4","user":"samuel","target":"master "}
{"created_at":"2022-11-27T17:47:13+0000","release_name":"5","user":"samuel","target":"master "}
{"created_at":"2022-11-29T17:42:39+0000","release_name":"6","user":"samuel","target":"master "}
{"created_at":"2022-12-03T23:23:42+0000","release_name":"7","user":"samuel","target":"master "}
{"created_at":"2022-12-18T23:42:57+0000","release_name":"8","user":"samuel","target":"develop"}
{"created_at":"2022-12-18T23:47:02+0000","release_name":"9","user":"samuel","target":"develop"}
{ created_at : 2023-03-06T21:46:42+0000 , release_name : 10 , user : samuel , target : develop }
{ created_at : 2023-03-21T19:54:32+0000 , release_name : 11 , user : samuel , target : master }
{ created_at : 2023-04-03T21:26:39+0000 , release_name : 12 , user : samuel , target : develop }
{ created_at : 2023-04-06T19:28:11+0000 , release_name : 13 , user : samuel , target : develop }
```

notice the missing double quotes in releases 10-13. since that is not a valid json, the lines became "invisible" for deployer.
seemed like no big deal, releases (at least successful, i had no failing one) were deployed fine, but i notice my old release folders were not deleted during a cleanup. so i found this discussion: https://github.com/deployphp/deployer/discussions/3511
and after digging deeper i found a case. this is it. for the windows environment, it basically replaces the single quotes with an apostrophe () and surrounds the json with single quotes

fixes https://github.com/deployphp/deployer/issues/3507 fixes https://github.com/deployphp/deployer/discussions/3511

note about checking the OS: https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family
