### PR TITLE
changes for using latest shopware flex template

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -8,12 +8,20 @@
  * set('repository', 'git@github.com:shopware/production.git');
  * ```
  *
+ * configure host:
+ * host('SSH-HOSTNAME')
+ *     ->setRemoteUser('SSH-USER')
+ *     ->set('deploy_path', '/var/www/shopware') // This is the path, where deployer will create its directory structure
+ *     ->set('http_user', 'www-data') // Not needed, if the `user` is the same user, the webserver is running with 
+ *     ->set('writable_mode', 'chmod');
+ * 
  * :::note
  * Please remember that the installation must be modified so that it can be
  * [build without database](https://developer.shopware.com/docs/guides/hosting/installation-updates/deployments/build-w-o-db#compiling-the-storefront-without-database).
  * :::
  */
 namespace Deployer;
+
 
 require_once __DIR__ . '/common.php';
 
@@ -22,6 +30,8 @@ add('recipes', ['shopware']);
 set('bin/console', '{{bin/php}} {{release_or_current_path}}/bin/console');
 
 set('default_timeout', 3600); // Increase when tasks take longer than that.
+
+//set host configuration and repository here
 
 // These files are shared among all releases.
 set('shared_files', [
@@ -83,6 +93,10 @@ task('sw:theme:refresh', function () {
     run('cd {{release_path}} && {{bin/console}} theme:refresh');
 });
 
+task('sw:theme:compile', function () {
+    run('cd {{release_path}} && {{bin/console}} theme:compile');
+});
+
 function getPlugins(): array
 {
     $output = explode("\n", run('cd {{release_path}} && {{bin/console}} plugin:list'));
@@ -132,10 +146,11 @@ task('sw:writable:jwt', static function () {
 /**
  * Grouped SW deploy tasks.
  */
+
 task('sw:deploy', [
     'sw:database:migrate',
     'sw:plugin:refresh',
-    'sw:theme:refresh',
+    'sw:theme:compile',
     'sw:cache:clear',
     'sw:plugin:update:all',
     'sw:cache:clear',
@@ -151,7 +166,6 @@ task('deploy', [
     'deploy:publish',
 ]);
 
-
 task('sw-build-without-db:get-remote-config', static function () {
     if (!test('[ -d {{current_path}} ]')) {
         return;
@@ -166,8 +180,9 @@ task('sw-build-without-db:get-remote-config', static function () {
 });
 
 task('sw-build-without-db:build', static function () {
-    runLocally('CI=1 SHOPWARE_SKIP_BUNDLE_DUMP=1 ./bin/build-js.sh');
+    runLocally('CI=1 SHOPWARE_SKIP_BUNDLE_DUMP=1 SHOPWARE_SKIP_THEME_COMPILE=1 bin/build-js.sh');
 });
+
 
 task('sw-build-without-db', [
     'sw-build-without-db:get-remote-config',


### PR DESCRIPTION
- Bug fix: the theme is missing on deployed version. Compiling the theme in the sw:deploy task fixes it. Another fix: in CI systems there is no way to compile the theme locally since a database connection is needed. Adding the theme compile skip option at the build-js.sh fixes it as well.

