### PR TITLE
Fix/m2 artifact success

### DIFF
--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -732,7 +732,7 @@ This task is group task which contains next tasks:
 
 
 ### artifact:deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L517)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L518)
 
 Actually releases the artifact deployment.
 

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -511,6 +511,7 @@ task('artifact:finish', [
         'cachetool:clear:opcache',
         'deploy:cleanup',
         'deploy:unlock',
+        'deploy:success'
 ]);
 
 desc('Actually releases the artifact deployment');


### PR DESCRIPTION
- [x] Bug fix #…?

Magento 2 successful artifact deployments, never trigger the `deploy:success` task. Which causes slack/discord after success hooks not firing.