### PR TITLE
Fix typo in `rollback.php`

### DIFF
--- a/docs/recipe/deploy/rollback.md
+++ b/docs/recipe/deploy/rollback.md
@@ -15,10 +15,10 @@ require 'recipe/deploy/rollback.php';
 ### rollback_candidate
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/rollback.php#L19)
 
-Rollback candidate automatically will be automatically chosen by
-looking at output of `ls` command and content of `.dep/releases_log`.
+Rollback candidate will be automatically chosen by looking
+at output of `ls` command and content of `.dep/releases_log`.
 
-If rollback candidate marked as **BAD_RELEASE**, it will be skipped.
+If rollback candidate is marked as **BAD_RELEASE**, it will be skipped.
 
 :::tip
 You can override rollback candidate via:

--- a/recipe/deploy/rollback.php
+++ b/recipe/deploy/rollback.php
@@ -4,8 +4,8 @@ namespace Deployer;
 use Deployer\Exception\Exception;
 
 /*
- * Rollback candidate automatically will be automatically chosen by
- * looking at output of `ls` command and content of `.dep/releases_log`.
+ * Rollback candidate will be automatically chosen by looking
+ * at output of `ls` command and content of `.dep/releases_log`.
  *
  * If rollback candidate marked as **BAD_RELEASE**, it will be skipped.
  *

--- a/recipe/deploy/rollback.php
+++ b/recipe/deploy/rollback.php
@@ -7,7 +7,7 @@ use Deployer\Exception\Exception;
  * Rollback candidate will be automatically chosen by looking
  * at output of `ls` command and content of `.dep/releases_log`.
  *
- * If rollback candidate marked as **BAD_RELEASE**, it will be skipped.
+ * If rollback candidate is marked as **BAD_RELEASE**, it will be skipped.
  *
  * :::tip
  * You can override rollback candidate via:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
Typos in the documentation for the `rollback` command (https://deployer.org/docs/7.x/recipe/deploy/rollback#rollback_candidate).


**What is the new behavior (if this is a feature change)?**
Typos fixed


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
-