### PR TITLE
Add .env to shared, remove unecessary writable config

### DIFF
--- a/recipe/craftcms.php
+++ b/recipe/craftcms.php
@@ -13,15 +13,14 @@ set('shared_dirs', [
     'web/assets',
 ]);
 
+set('shared_files', ['.env']);
+
 set('writable_dirs', [
     'config/project',
     'storage',
     'web/assets',
     'web/cpresources',
 ]);
-
-set('writable_mode', 'chmod');
-set('writable_recursive', true);
 
 
 /**


### PR DESCRIPTION
- [ ] Bug fix #3584

This is to make two small changes to the Craft CMS recipe to add the .env file to shared & remove the writable config which causes issues for our own deployments. Since no other recipes add writable config I presume this is unnecessary.

Once merged in: 

      Please, regenerate docs by running next command:
      $ php bin/docgen
