### PR TITLE
Fix output of elapsed time in section markers in gitlab

### DIFF
--- a/src/Executor/Messenger.php
+++ b/src/Executor/Messenger.php
@@ -52,7 +52,8 @@ class Messenger
         if (getenv('GITHUB_WORKFLOW')) {
             $this->output->writeln("::group::task {$task->getName()}");
         } else if (getenv('GITLAB_CI')) {
-            $this->output->writeln("\e[0Ksection_start:{$this->startTime}:{$this->startTime}[collapsed=true]\r\e[0K{$task->getName()}");
+            $start = round($this->startTime/1000);
+            $this->output->writeln("\e[0Ksection_start:{$start}:{$start}[collapsed=true]\r\e[0K{$task->getName()}");
         } else {
             $this->output->writeln("<fg=cyan;options=bold>task</> {$task->getName()}");
         }
@@ -77,7 +78,9 @@ class Messenger
         if (getenv('GITHUB_WORKFLOW')) {
             $this->output->writeln("::endgroup::");
         } else if (getenv('GITLAB_CI')) {
-            $this->output->writeln("\e[0Ksection_end:{$endTime}:{$this->startTime}\r\e[0K");
+            $endTime = round($endTime/1000);
+            $start = round($this->startTime/1000);
+            $this->output->writeln("\e[0Ksection_end:{$endTime}:{$start}\r\e[0K");
         } else if ($this->output->isVeryVerbose()) {
             $this->output->writeln("<fg=yellow;options=bold>done</> {$task->getName()} $taskTime");
         }


### PR DESCRIPTION
According to this https://docs.gitlab.com/ee/ci/jobs/#custom-collapsible-section, we need to provide a unix timestamp in seconds, not in milliseconds.


This is a reduced raw output of a deployer-job i just ran:
```
[32;1mSkipping Git submodules setup[0;m
section_end:1691389375:get_sources
[0Ksection_start:1691389375:download_artifacts
[0K[0K[36;1mDownloading artifacts[0;m[0;m
[32;1mDownloading artifacts for build_release_frontend (431863)...[0;m
...
section_end:1691389376:download_artifacts
[...]
[0Ksection_start:1691389377467:1691389377467[collapsed=true]
[0Kdeploy:setup
[0Ksection_end:1691389379794:1691389377467
[0K
```

As you can see, the output generated by gitlab itself has 10-digit-timestamps, but the output generated by deployer is based on millis. This leads to misleading runtimes:
<img width="464" alt="image" src="https://github.com/deployphp/deployer/assets/87075780/913811de-0e7d-4114-bde8-f24072208121">
All of this actions took less than a few secongs but being displayed as various minutes.