### PR TITLE
Expanded Caddyfile - www redirect, rewrites, encoding, transport headers

### DIFF
--- a/docs/recipe/provision/website.md
+++ b/docs/recipe/provision/website.md
@@ -18,7 +18,7 @@ require 'recipe/provision/website.php';
 
 
 ```php title="Default value"
-return ask(' Domain: ');
+return str_ireplace('www.', '', ask(' Domain: '));
 ```
 
 
@@ -44,7 +44,7 @@ Provision website.
 
 
 ### logs:caddy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision/website.php#L82)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision/website.php#L102)
 
 Shows caddy logs.
 
@@ -52,7 +52,7 @@ Shows caddy logs.
 
 
 ### logs:caddy:syslog
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision/website.php#L87)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/provision/website.php#L107)
 
 Shows caddy syslog.
 


### PR DESCRIPTION
Relates to #3666 

Expands Caddyfile to include a www redirect, rewrites for sensitive files, encoding, and transport headers - all from [here](https://ma.ttias.be/caddyfile-config-example-for-laravel/). The only change not added is defaulting to index.php as 1. I believe the existing config already covers that, and 2) I'm not sure every PHP framework may be using that file (I assume most do, but I'm not sure).

Only change to existing functionality is doing a `str_ireplace` to remove `www.` from domain inputs, so that the new config will cover the www redirect.

This is a draft because I've been struggling to test it. How does Deployer work when installed in repositories? No matter what changes I make to the files in `vendor` in my application, the changes are never followed. 

Side note: Additionally, it's a mission to get provisioning and deployment working out of the bat due to #3542 and #3147 - I'm testing on EC2. The workaround is to essentially follow bad security practices and allow root login into my server to get this to work, which isn't great.