### PR TITLE
Filter out empty rsync command arguments

### DIFF
--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -71,7 +71,12 @@ class Rsync
         if (!is_array($source)) {
             $source = [$source];
         }
-        $command = array_merge(['rsync', $flags], $options, $source, [$destination]);
+        $command = array_filter(
+            array_merge(['rsync', $flags], $options, $source, [$destination]),
+            function (string $value) {
+                return $value !== '';
+            },
+        );
 
         $commandString = $command[0];
         for ($i = 1; $i < count($command); $i++) {


### PR DESCRIPTION
- [x] Bug fix #3683
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
