### PR TITLE
style(docs/hosts): correct included words in inline code styling

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -85,7 +85,7 @@ Port of remote ssh server to connect to. Default is `22`.
 Default is `~/.ssh/config`.
 
 :::info Config file
-For best practices, avoid storing connection parameters in the `deploy.php file`, as 
+For best practices, avoid storing connection parameters in the `deploy.php` file, as 
 these can vary based on the deployment execution location. Instead, only include the 
 hostname and remote_user in `deploy.php`, while maintaining other parameters in the
 `~/.ssh/config` file.


### PR DESCRIPTION
- [x] `php bin/docgen` has been run without any files to commit
```bash
Recipes documentation updated.
On branch style/docs/hosts
Your branch is up to date with 'origin/style/docs/hosts'.

nothing to commit, working tree clean
```