### PR TITLE
Typo in update_code.php comment

### DIFF
--- a/docs/recipe/cakephp.md
+++ b/docs/recipe/cakephp.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Cakephp** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/codeigniter.md
+++ b/docs/recipe/codeigniter.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Codeigniter** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/contao.md
+++ b/docs/recipe/contao.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Contao** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/craftcms.md
+++ b/docs/recipe/craftcms.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Craftcms** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/deploy/update_code.md
+++ b/docs/recipe/deploy/update_code.md
@@ -67,7 +67,7 @@ Specifies a sub directory within the repository to deploy.
 Works only when [`update_code_strategy`](#update_code_strategy) is set to `archive` (default).
 
 Example:
- - set value to `src` if you want to deploy the folder that lives at `/src/api`.
+ - set value to `src` if you want to deploy the folder that lives at `/src`.
  - set value to `src/api` if you want to deploy the folder that lives at `/src/api`.
 
 Note: do not use a leading `/`!

--- a/docs/recipe/drupal7.md
+++ b/docs/recipe/drupal7.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Drupal 7** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:publish](/docs/recipe/common.md#deploypublish) – Publishes the release

--- a/docs/recipe/drupal8.md
+++ b/docs/recipe/drupal8.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Drupal 8** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:publish](/docs/recipe/common.md#deploypublish) – Publishes the release

--- a/docs/recipe/flow_framework.md
+++ b/docs/recipe/flow_framework.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Flow Framework** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/fuelphp.md
+++ b/docs/recipe/fuelphp.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Fuelphp** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/joomla.md
+++ b/docs/recipe/joomla.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Joomla** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:publish](/docs/recipe/common.md#deploypublish) – Publishes the release

--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Laravel** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/magento.md
+++ b/docs/recipe/magento.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Magento** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:cache:clear](/docs/recipe/magento.md#deploycacheclear) – Clears cache

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Magento 2** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors
@@ -90,7 +90,7 @@ The [artifact:build](#artifact:build) command of **Magento 2** consists of: * [b
 
  The [artifact:deploy](#artifact:deploy) command of **Magento 2** consists of:
 * [artifact:prepare](/docs/recipe/magento2.md#artifactprepare) – Prepares an artifact on the target server
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
@@ -699,7 +699,7 @@ Prepares an artifact on the target server.
 
 
 This task is group task which contains next tasks:
-* [deploy:info](/docs/recipe/typo3.md#deployinfo)
+* [deploy:info](/docs/recipe/deploy/info.md#deployinfo)
 * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup)
 * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock)
 * [deploy:release](/docs/recipe/deploy/release.md#deployrelease)

--- a/docs/recipe/pimcore.md
+++ b/docs/recipe/pimcore.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Pimcore** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/prestashop.md
+++ b/docs/recipe/prestashop.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Prestashop** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/shopware.md
+++ b/docs/recipe/shopware.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Shopware** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [sw:deploy](/docs/recipe/shopware.md#swdeploy) – 

--- a/docs/recipe/silverstripe.md
+++ b/docs/recipe/silverstripe.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Silverstripe** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/statamic.md
+++ b/docs/recipe/statamic.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Statamic** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/sulu.md
+++ b/docs/recipe/sulu.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Sulu** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/symfony.md
+++ b/docs/recipe/symfony.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Symfony** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/wordpress.md
+++ b/docs/recipe/wordpress.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **WordPress** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:publish](/docs/recipe/common.md#deploypublish) – Publishes the release

--- a/docs/recipe/yii.md
+++ b/docs/recipe/yii.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Yii2** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/docs/recipe/zend_framework.md
+++ b/docs/recipe/zend_framework.md
@@ -29,11 +29,11 @@ You can read more about Deployer in [Getting Started](/docs/getting-started.md).
 
 The [deploy](#deploy) task of **Zend Framework** consists of:
 * [deploy:prepare](/docs/recipe/common.md#deployprepare) – Prepares a new release
-  * [deploy:info](/docs/recipe/typo3.md#deployinfo) – 
+  * [deploy:info](/docs/recipe/deploy/info.md#deployinfo) – Displays info about deployment
   * [deploy:setup](/docs/recipe/deploy/setup.md#deploysetup) – Prepares host for deploy
   * [deploy:lock](/docs/recipe/deploy/lock.md#deploylock) – Locks deploy
   * [deploy:release](/docs/recipe/deploy/release.md#deployrelease) – Prepares release
-  * [deploy:update_code](/docs/recipe/typo3.md#deployupdate_code) – 
+  * [deploy:update_code](/docs/recipe/deploy/update_code.md#deployupdate_code) – Updates code
   * [deploy:shared](/docs/recipe/deploy/shared.md#deployshared) – Creates symlinks for shared files and dirs
   * [deploy:writable](/docs/recipe/deploy/writable.md#deploywritable) – Makes writable dirs
 * [deploy:vendors](/docs/recipe/deploy/vendors.md#deployvendors) – Installs vendors

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -57,7 +57,7 @@ set('git_ssh_command', 'ssh -o StrictHostKeyChecking=accept-new');
  * Works only when [`update_code_strategy`](#update_code_strategy) is set to `archive` (default).
  *
  * Example:
- *  - set value to `src` if you want to deploy the folder that lives at `/src/api`.
+ *  - set value to `src` if you want to deploy the folder that lives at `/src`.
  *  - set value to `src/api` if you want to deploy the folder that lives at `/src/api`.
  *
  * Note: do not use a leading `/`!


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Fixed typo in docs where sub_directory examples would both resolve to the same directory:

 - set value to `src` if you want to deploy the folder that lives at `/src/api`.
 - set value to `src/api` if you want to deploy the folder that lives at `/src/api`.
