### PR TITLE
Added options to fetch function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -553,7 +553,7 @@ Returns current timestamp in UTC timezone in ISO8601 format.
 ## fetch()
 
 ```php
-fetch(string $url, string $method = 'get', array $headers = [], ?string $body = null, ?array &$info = null, bool $nothrow = false): string
+fetch(string $url, string $method = 'get', array $headers = [], ?string $body = null, ?array &$info = null, bool $nothrow = false, array $options = []): string
 ```
 
 Example usage:

--- a/src/functions.php
+++ b/src/functions.php
@@ -933,7 +933,7 @@ function timestamp(): string
  * var_dump($info['http_code'], $result);
  * ```
  */
-function fetch(string $url, string $method = 'get', array $headers = [], ?string $body = null, ?array &$info = null, bool $nothrow = false): string
+function fetch(string $url, string $method = 'get', array $headers = [], ?string $body = null, ?array &$info = null, bool $nothrow = false, array $options = []): string
 {
     $url = parse($url);
     if (strtolower($method) === 'get') {
@@ -949,6 +949,9 @@ function fetch(string $url, string $method = 'get', array $headers = [], ?string
     }
     if ($body !== null) {
         $http = $http->body($body);
+    }
+    foreach($options as $key => $value) {
+        $http = $http->setopt($key, $value);
     }
     return $http->send($info);
 }


### PR DESCRIPTION
When running the `fetch()` function, we can now add options:

```php
fetch(
    'https://httpbin.org/get',
    options: [
        CURLOPT_SSL_VERIFYPEER => false,
        CURLOPT_SSL_VERIFYHOST => false,
        CURLOPT_TIMEOUT => 30,
        ...
    ]
);
```

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
