### PR TITLE
Fix issue provoked after adding array casting and returning empty fcg…

### DIFF
--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -72,7 +72,9 @@ set('cachetool_options', function () {
         $return = [$fullOptions];
     } elseif (count($options) > 0) {
         foreach ($options as $option) {
-            $return[] = "--fcgi={$option}";
+            if ($option !== '') {
+                $return[] = "--fcgi={$option}";
+            }
         }
     }
 


### PR DESCRIPTION
After adding the cast to the array the `count($options) > 0` always returns true but with an empty array provoking that the command is executed with an empty parameter which ends in the following issue:

> 12:33:34  [dev]  error  in cachetool.php on line 89:
12:33:34  [dev] run cd cachetool.phar opcache:reset --fcgi=
12:33:34  [dev] err In FastCGI.php line 143:
12:33:34  [dev] err FastCGI error: Unable to connect to FastCGI application: Invalid argument (
12:33:34  [dev] err )
12:33:34  [dev] err In Socket.php line 326:
12:33:34  [dev] err Unable to connect to FastCGI application: Invalid argument
12:33:34  [dev] err In Socket.php line 272:
12:33:34  [dev] err stream_socket_client(): Unable to connect to unix:// (Invalid argument)
12:33:34  [dev] err opcache:reset
12:33:34  [dev] exit code 22 (Unknown error)`