### PR TITLE
Add no_throw check to CLI running

### DIFF
--- a/src/Component/ProcessRunner/ProcessRunner.php
+++ b/src/Component/ProcessRunner/ProcessRunner.php
@@ -73,13 +73,15 @@ class ProcessRunner
             $process->mustRun($callback);
             return $process->getOutput();
         } catch (ProcessFailedException $exception) {
-            throw new RunException(
-                $host,
-                $command,
-                $process->getExitCode(),
-                $process->getOutput(),
-                $process->getErrorOutput()
-            );
+            if (!$config['no_throw']) {
+                throw new RunException(
+                    $host,
+                    $command,
+                    $process->getExitCode(),
+                    $process->getOutput(),
+                    $process->getErrorOutput()
+                );
+            }
         } catch (ProcessTimedOutException $exception) { // @phpstan-ignore-line can be thrown but is absent from the phpdoc
             throw new TimeoutException(
                 $command,


### PR DESCRIPTION
The `no_throw` option is ignored in the CLI process running.

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
