### PR TITLE
Removing wrong information regarding reverse DNS

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,8 +31,8 @@ Make sure the image is **Ubuntu 20.04 LTS** as this version is supported by
 Deployer's [provision](recipe/provision.md) recipe.
 
 :::tip
-Configure Reverse DNS or RDNS on your server. This will allow you to ssh into
-the server using the domain name instead of the IP address.
+Configure a DNS record for your domain that points to the IP address of your server. 
+This will allow you to ssh into the server using your domain name instead of the IP address.
 :::
 
 Our **deploy.php** recipe contains a host definition with a few important params:


### PR DESCRIPTION
This pull request fixes a factual error in the current getting started documentation.

The current version is recommending setting a **reverse** DNS record for a server in order to allow to SSH into it using a domain name instead of an IP address. However, this is the whole purpose of a **DNS record** * (without "reverse").

DNS translates a hostname ("domain") to an IP address (which is what we want here).
Reverse DNS does the exact opposite: Translating an IP address back to a hostname which is e.g. required for running a mail server but is completely unrelated to reaching a server by its hostname/domain.