### PR TITLE
Fix creating cron jobs first time

### DIFF
--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -66,7 +66,7 @@ task('crontab:sync', function () {
 
         // Create the section
         $cronJobs[] = $sectionStart;
-        $cronJobs += $cronJobsLocal;
+        $cronJobs = [...$cronJobs, ...$cronJobsLocal];
         $cronJobs[] = $sectionEnd;
         writeln("Crontab: Found no section, created the section with configured jobs");
     } else {


### PR DESCRIPTION
When the cronjobs are set for the first time, only identifiers (`"###< $identifier"` and `"###> $identifier"`) are added to crontab, not the list of jobs. This is because of the PHP union operator (`+`).  For indexed arrays `+` operator completely ignores the second array and returns the first array as it is. Using `array_merge ` or `spread operator` should be the right way to contact local jobs with remote ones.

- [x ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?
