### PR TITLE
Fix version variables in Contao recipe

### DIFF
--- a/docs/recipe/contao.md
+++ b/docs/recipe/contao.md
@@ -84,7 +84,9 @@ return '{{bin/php}} {{release_or_current_path}}/vendor/bin/contao-console';
 
 
 ```php title="Default value"
-return run('{{bin/console}} contao:version');
+$result = run('{{bin/console}} --version');
+preg_match_all('/(\d+\.?)+/', $result, $matches);
+return $matches[0][0] ?? 'n/a';
 ```
 
 

--- a/docs/recipe/contao.md
+++ b/docs/recipe/contao.md
@@ -90,11 +90,25 @@ return $matches[0][0] ?? 'n/a';
 ```
 
 
+### symfony_version
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L39)
+
+Overrides [symfony_version](/docs/recipe/symfony.md#symfony_version) from `recipe/symfony.php`.
+
+
+
+```php title="Default value"
+$result = run('{{bin/console}} about');
+preg_match_all('/(\d+\.?)+/', $result, $matches);
+return $matches[0][0] ?? 5.0;
+```
+
+
 
 ## Tasks
 
 ### contao:migrate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L47)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L55)
 
 Run Contao migrations.
 
@@ -110,7 +124,7 @@ task('contao:migrate', function () {
 
 
 ### contao:manager:download
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L53)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L61)
 
 Download the Contao Manager.
 
@@ -118,7 +132,7 @@ Downloads the `contao-manager.phar.php` into the public path.
 
 
 ### contao:install:lock
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L59)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L67)
 
 Lock the Contao Install Tool.
 
@@ -126,7 +140,7 @@ Locks the Contao install tool which is useful if you don't use it.
 
 
 ### contao:manager:lock
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L65)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L73)
 
 Lock the Contao Manager.
 
@@ -134,7 +148,7 @@ Locks the Contao Manager which is useful if you only need the API of the Manager
 
 
 ### contao:maintenance:enable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L71)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L79)
 
 Enable maintenance mode.
 
@@ -142,7 +156,7 @@ Enable maintenance mode.
 
 
 ### contao:maintenance:disable
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L86)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L94)
 
 Disable maintenance mode.
 
@@ -150,7 +164,7 @@ Disable maintenance mode.
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L98)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/contao.php#L106)
 
 Deploy the project.
 

--- a/recipe/contao.php
+++ b/recipe/contao.php
@@ -31,7 +31,15 @@ set('bin/console', function () {
 });
 
 set('contao_version', function () {
-    return run('{{bin/console}} contao:version');
+    $result = run('{{bin/console}} --version');
+    preg_match_all('/(\d+\.?)+/', $result, $matches);
+    return $matches[0][0] ?? 'n/a';
+});
+
+set('symfony_version', function () {
+    $result = run('{{bin/console}} about');
+    preg_match_all('/(\d+\.?)+/', $result, $matches);
+    return $matches[0][0] ?? 5.0;
 });
 
 // This task updates the database. A database backup is saved automatically as a default.


### PR DESCRIPTION
- [x] Bug fix

This PR fixes default values of config variables `contao_version` and `symfony_version`.

**Context:**

When installed, Contao overrides output of Symfony's console command `bin/console --version`, so that it returns Contao's version instead of Symfony's. The only way the get Symfony's version in this case is to run `bin/console about`.

In addition, `bin/console contao:version` command is deprecated since Contao 4.13 (current LTS), and no longer works in Contao 5.2 (current latest). Thus, in Contao 4.13 both `console --version` and `console contao:version` show Contao's version and neither of them shows Symfony's. In Contao 5.2, `console --version` shows Contao's version, and `console contao:version` fails.

This PR fixes it by parsing output of `bin/console --version` into `contao_version` variable, and `bin/console about` – into `symfony_version`. The fix works for both Contao 4.13 and Contao 5.2 versions. The parsing is done in the same way as in the bare Symfony's recipe:

https://github.com/deployphp/deployer/blob/a0a21e22a33860356d94bb14b67ecd37673bd1b8/recipe/symfony.php#L8-L12

