### PR TITLE
fix: run cachetool without args

### DIFF
--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -3,14 +3,14 @@
 
 ## Configuration
 
-- **cachetool** *(optional)*: accepts a *string* or an *array* of strings with the unix socket or ip address to php-fpm. If `cachetool` is not given, then the application will look for a `cachetool.yml` file and read the configuration from there.
+- **cachetool** *(optional)*: accepts a *string* or an *array* of strings with the unix socket or ip address to php-fpm. If `cachetool` is not given, then the application will look for a configuration file. The file must be named .cachetool.yml or .cachetool.yaml. CacheTool will look for this file on the current directory and in any parent directory until it finds one. If the paths above fail it will try to load /etc/cachetool.yml or /etc/cachetool.yaml configuration file.
 
     ```php
     set('cachetool', '/var/run/php-fpm.sock');
     // or
     set('cachetool', '127.0.0.1:9000');
     // or
-    set('cachetool', ['/var/run/php-fpm.sock', '/var/run/php-fpm-other.sock]);
+    set('cachetool', ['/var/run/php-fpm.sock', '/var/run/php-fpm-other.sock']);
     ```
 
 You can also specify different cachetool settings for each host:
@@ -72,13 +72,13 @@ set('cachetool_options', function () {
         $return = [$fullOptions];
     } elseif (count($options) > 0) {
         foreach ($options as $option) {
-            if ($option !== '') {
+            if (is_string($option) && $option !== '') {
                 $return[] = "--fcgi={$option}";
             }
         }
     }
 
-    return $return;
+    return $return ?: [''];
 });
 
 /**
@@ -93,7 +93,7 @@ task('cachetool:clear:opcache', function () {
 });
 
 /**
- * Clear APCU cache
+ * Clear APCu cache
  */
 desc('Clears APCu system cache');
 task('cachetool:clear:apcu', function () {

--- a/docs/contrib/cachetool.md
+++ b/docs/contrib/cachetool.md
@@ -15,14 +15,14 @@ require 'contrib/cachetool.php';
 
 ## Configuration
 
-- **cachetool** *(optional)*: accepts a *string* or an *array* of strings with the unix socket or ip address to php-fpm. If `cachetool` is not given, then the application will look for a `cachetool.yml` file and read the configuration from there.
+- **cachetool** *(optional)*: accepts a *string* or an *array* of strings with the unix socket or ip address to php-fpm. If `cachetool` is not given, then the application will look for a configuration file. The file must be named .cachetool.yml or .cachetool.yaml. CacheTool will look for this file on the current directory and in any parent directory until it finds one. If the paths above fail it will try to load /etc/cachetool.yml or /etc/cachetool.yaml configuration file.
 
     ```php
     set('cachetool', '/var/run/php-fpm.sock');
     // or
     set('cachetool', '127.0.0.1:9000');
     // or
-    set('cachetool', ['/var/run/php-fpm.sock', '/var/run/php-fpm-other.sock]);
+    set('cachetool', ['/var/run/php-fpm.sock', '/var/run/php-fpm-other.sock']);
     ```
 
 You can also specify different cachetool settings for each host:
@@ -127,7 +127,7 @@ Clear opcache cache
 
 Clears APCu system cache.
 
-Clear APCU cache
+Clear APCu cache
 
 
 ### cachetool:clear:stat


### PR DESCRIPTION
fixes a regression bug introduced with https://github.com/deployphp/deployer/commit/266554d3c7fea23c27ece48e3256d0120f88b138

- [x] Bug fix #3741
- [x] New feature? No
- [x] BC breaks? No, restores backward compatibility
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
