### PR TITLE
Create parent folders if needed

### DIFF
--- a/recipe/provision/website.php
+++ b/recipe/provision/website.php
@@ -11,7 +11,7 @@ set('public_path', function () {
 
 desc('Provision website');
 task('provision:website', function () {
-    run("[ -d {{deploy_path}} ] || mkdir {{deploy_path}}");
+    run("[ -d {{deploy_path}} ] || mkdir -p {{deploy_path}}");
     run("chown -R deployer:deployer {{deploy_path}}");
 
     $domain = get('domain');


### PR DESCRIPTION
Bumped into the situation where the parent folder didn't exist yet , fixable with -p flag.

See https://man7.org/linux/man-pages/man1/mkdir.1.html
