### PR TITLE
Move Caddy file in to separate file

### DIFF
--- a/recipe/provision/Caddyfile
+++ b/recipe/provision/Caddyfile
@@ -1,0 +1,22 @@
+{{domain}} {
+
+	root * {{deploy_path}}/current/{{public_path}}
+	file_server
+	php_fastcgi * unix//run/php/php{{php_version}}-fpm.sock {
+		resolve_root_symlink
+	}
+
+	log {
+		output file {{deploy_path}}/log/access.log
+	}
+
+	handle_errors {
+		@404 {
+			expression {http.error.status_code} == 404
+		}
+		rewrite @404 /404.html
+		file_server {
+			root /var/dep/html
+		}
+	}
+}


### PR DESCRIPTION
- Move `Caddyfile` in to separate file to increase readability.
- Make use of `{{vars}}` instead of `$vars` (`realpath` had to be set for `deploy_path`)

This might be the first step for a better configurable `Caddyfile` in the future.