### PR TITLE
Increase `upload_max_filesize` to 128M

### DIFF
--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -33,12 +33,14 @@ task('provision:php', function () {
     run("sudo sed -i 's/error_reporting = .*/error_reporting = E_ALL/' /etc/php/$version/cli/php.ini");
     run("sudo sed -i 's/display_errors = .*/display_errors = On/' /etc/php/$version/cli/php.ini");
     run("sudo sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/$version/cli/php.ini");
+    run("sudo sed -i 's/upload_max_filesize = .*/upload_max_filesize = 128M/' /etc/php/$version/cli/php.ini");
     run("sudo sed -i 's/;date.timezone.*/date.timezone = UTC/' /etc/php/$version/cli/php.ini");
 
     // Configure PHP-FPM
     run("sed -i 's/error_reporting = .*/error_reporting = E_ALL/' /etc/php/$version/fpm/php.ini");
     run("sed -i 's/display_errors = .*/display_errors = On/' /etc/php/$version/fpm/php.ini");
     run("sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/$version/fpm/php.ini");
+    run("sed -i 's/upload_max_filesize = .*/upload_max_filesize = 128M/' /etc/php/$version/fpm/php.ini");
     run("sed -i 's/;date.timezone.*/date.timezone = UTC/' /etc/php/$version/fpm/php.ini");
     run("sed -i 's/;cgi.fix_pathinfo=1/cgi.fix_pathinfo=0/' /etc/php/$version/fpm/php.ini");
 


### PR DESCRIPTION
Default is `2M`, which isn't enough when uploading documents or video's. Not sure how applicable this setting is for the cli, but I added it for consistency.
