### PR TITLE
refactor(shopware): Optimize `getPlugins` to use json output

### DIFF
--- a/docs/recipe/shopware.md
+++ b/docs/recipe/shopware.md
@@ -225,7 +225,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw:plugin:update:all
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L138)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L114)
 
 
 
@@ -233,7 +233,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw:writable:jwt
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L148)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L124)
 
 
 
@@ -241,7 +241,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw:deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L155)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L131)
 
 
 
@@ -259,7 +259,7 @@ This task is group task which contains next tasks:
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L166)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L142)
 
 Deploys your project.
 
@@ -276,7 +276,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db:get-remote-config
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L175)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L151)
 
 
 
@@ -284,7 +284,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db:build
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L188)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L164)
 
 
 
@@ -292,7 +292,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L192)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L168)
 
 
 

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -105,32 +105,8 @@ task('sw:theme:compile', function () {
 
 function getPlugins(): array
 {
-    $output = explode("\n", run('cd {{release_path}} && {{bin/console}} plugin:list'));
-
-    // Take line over headlines and count "-" to get the size of the cells.
-    $lengths = array_filter(array_map('strlen', explode(' ', $output[4])));
-    $splitRow = function ($row) use ($lengths) {
-        $columns = [];
-        foreach ($lengths as $length) {
-            $columns[] = trim(substr($row, 0, $length));
-            $row = substr($row, $length + 1);
-        }
-        return $columns;
-    };
-    $headers = $splitRow($output[5]);
-    $splitRowIntoStructure = function ($row) use ($splitRow, $headers) {
-        $columns = $splitRow($row);
-        return array_combine($headers, $columns);
-    };
-
-    // Ignore first seven lines (headline, title, table, ...).
-    $rows = array_slice($output, 7, -3);
-
-    $plugins = [];
-    foreach ($rows as $row) {
-        $pluginInformation = $splitRowIntoStructure($row);
-        $plugins[] = $pluginInformation;
-    }
+    $output = run('cd {{release_path}} && {{bin/console}} plugin:list --json');
+    $plugins = json_decode($output);
 
     return $plugins;
 }
@@ -138,9 +114,9 @@ function getPlugins(): array
 task('sw:plugin:update:all', static function () {
     $plugins = getPlugins();
     foreach ($plugins as $plugin) {
-        if ($plugin['Installed'] === 'Yes') {
-            writeln("<info>Running plugin update for " . $plugin['Plugin'] . "</info>\n");
-            run("cd {{release_path}} && {{bin/console}} plugin:update " . $plugin['Plugin']);
+        if ($plugin->installedAt && $plugin->upgradeVersion) {
+            writeln("<info>Running plugin update for " . $plugin->name . "</info>\n");
+            run("cd {{release_path}} && {{bin/console}} plugin:update " . $plugin->name);
         }
     }
 });


### PR DESCRIPTION
Refactoring the `getPlugins` function to not parse regular commandline output anymore, instead use the --json flag `plugin:list`. Refactoring 'sw:plugin:update:all' to not upgrade every installed plugin, but every installed plugin that in fact is upgradable.

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
