### PR TITLE
Add release name to deploy:info

### DIFF
--- a/recipe/deploy/info.php
+++ b/recipe/deploy/info.php
@@ -3,5 +3,5 @@ namespace Deployer;
 
 desc('Displays info about deployment');
 task('deploy:info', function () {
-    info("deploying <fg=magenta;options=bold>{{target}}</>");
+    info("deploying <fg=magenta;options=bold>{{target}}</> (release <fg=magenta;options=bold>{{release_name}}</>)");
 });

--- a/recipe/deploy/info.php
+++ b/recipe/deploy/info.php
@@ -3,5 +3,7 @@ namespace Deployer;
 
 desc('Displays info about deployment');
 task('deploy:info', function () {
-    info("deploying <fg=magenta;options=bold>{{target}}</> (release <fg=magenta;options=bold>{{release_name}}</>)");
+    $releaseName = test('[ -d {{deploy_path}}/.dep ]') ? get('release_name') : 1;
+    
+    info("deploying <fg=magenta;options=bold>{{target}}</> (release <fg=magenta;options=bold>{$releaseName}</>)");
 });


### PR DESCRIPTION
I always find myself adding a task to just show the release name.
Why not add it to the built-in `deploy:info` task?