### PR TITLE
Fix the Rsync command filter to rekey the array

### DIFF
--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -71,12 +71,12 @@ class Rsync
         if (!is_array($source)) {
             $source = [$source];
         }
-        $command = array_filter(
+        $command = array_values(array_filter(
             array_merge(['rsync', $flags], $options, $source, [$destination]),
             function (string $value) {
                 return $value !== '';
             },
-        );
+        ));
 
         $commandString = $command[0];
         for ($i = 1; $i < count($command); $i++) {


### PR DESCRIPTION
Passing an empty argument causes error during the `for` loop of `$command` array. `upload('source', 'destination', ['flags' => '']);`

This is a fix for bug introduced in #3683 