### PR TITLE
Add ability to customize & overwrite deployer stock commands

### DIFF
--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -21,7 +21,13 @@ class InitCommand extends Command
 {
     use CommandCommon;
 
-    protected function configure()
+    protected $recipePath;
+    protected $template;
+    protected $repository;
+    protected $project;
+    protected $hosts;
+
+    protected function configure(): void
     {
         $this
             ->setName('init')

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -57,7 +57,7 @@ class InitCommand extends Command
         return 0;
     }
 
-    private function php(): string
+    protected function php(): string
     {
         $h = "";
         foreach ($this->hosts as $host) {
@@ -90,7 +90,7 @@ after('deploy:failed', 'deploy:unlock');
 PHP;
     }
 
-    private function yaml(): string
+    protected function yaml(): string
     {
         $h = "";
         foreach ($this->hosts as $host) {
@@ -120,7 +120,7 @@ after:
 YAML;
     }
 
-    private function getAdditionalConfigs(string $template): string
+    protected function getAdditionalConfigs(string $template): string
     {
         if ($template !== 'common') {
             return '';
@@ -137,7 +137,7 @@ YAML;
 YAML;
     }
 
-    private function recipes(): array
+    protected function recipes(): array
     {
         $recipes = [];
         $dir = new \DirectoryIterator(__DIR__ . '/../../recipe');

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -21,12 +21,39 @@ class InitCommand extends Command
 {
     use CommandCommon;
 
+    /**
+     * @var string $recipePath
+     */
     protected $recipePath;
+
+    /**
+     * @var string $language
+     */
     protected $language;
+
+    /**
+     * @var string $template
+     */
     protected $template;
+
+    /**
+     * @var string $repository
+     */
     protected $repository;
+
+    /**
+     * @var string $project
+     */
     protected $project;
+
+    /**
+     * @var array $hosts
+     */
     protected $hosts;
+
+    /**
+     * @var string $tempHostFile
+     */
     protected $tempHostFile;
 
     protected function configure(): void

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -22,6 +22,7 @@ class InitCommand extends Command
     use CommandCommon;
 
     protected $recipePath;
+    protected $language;
     protected $template;
     protected $repository;
     protected $project;
@@ -48,9 +49,10 @@ class InitCommand extends Command
         $this->setProject($io);
         $this->setHosts($io);
 
+        $language = $this->language;
         file_put_contents(
             $this->recipePath,
-            $this->language(
+            $this->$language(
                 $this->template,
                 $this->project,
                 $this->repository,
@@ -211,7 +213,8 @@ EOF
     protected function setRecipePath(InputInterface $input, SymfonyStyle $io): void
     {
         $this->language = $io->choice('Select recipe language', ['php', 'yaml'], 'php');
-        if (empty($this->recipePath)) {
+
+        if (!$this->recipePath) {
             $this->recipePath = "deploy.$this->language";
         }
 
@@ -223,8 +226,6 @@ EOF
                 exit(1);
             }
         }
-
-        $this->recipePath = $input->getOption('path');
     }
 
     protected function setTemplate(SymfonyStyle $io): void

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -41,14 +41,7 @@ class InitCommand extends Command
     {
         $this->printHeader($output);
 
-        $io = new SymfonyStyle($input, $output);
-
-        $this->setRecipePath($input, $io);
-        $this->setTemplate($io);
-        $this->setRepository($io);
-        $this->guessHost();
-        $this->setProject($io);
-        $this->setHosts($io);
+        $this->setTemplateVars($input, $output);
 
         $language = $this->language;
         file_put_contents(
@@ -167,6 +160,18 @@ YAML;
 
         sort($recipes);
         return $recipes;
+    }
+
+    protected function setTemplateVars(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $this->setRecipePath($input, $io);
+        $this->setTemplate($io);
+        $this->setRepository($io);
+        $this->setProject($io);
+        $this->guessHost();
+        $this->setHosts($io);
     }
 
     protected function printHeader(OutputInterface $output): void

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -37,122 +37,31 @@ class InitCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (getenv('COLORTERM') === 'truecolor') {
-            $output->write(<<<EOF
-╭───────────────────────────────────────╮
-│                                       │
-│                                       │
-│    \e[38;2;94;231;223m_\e[39m\e[38;2;95;231;226m_\e[39m\e[38;2;96;230;228m_\e[39m\e[38;2;96;229;230m_\e[39m          \e[38;2;97;226;230m_\e[39m                    │
-│   \e[38;2;98;223;229m|\e[39m    \e[38;2;98;220;229m\\\e[39m \e[38;2;99;216;228m_\e[39m\e[38;2;100;213;228m_\e[39m\e[38;2;101;210;228m_\e[39m \e[38;2;101;208;227m_\e[39m\e[38;2;102;205;227m_\e[39m\e[38;2;103;202;227m_\e[39m\e[38;2;104;199;226m|\e[39m \e[38;2;104;196;226m|\e[39m\e[38;2;105;194;225m_\e[39m\e[38;2;106;191;225m_\e[39m\e[38;2;106;188;225m_\e[39m \e[38;2;107;186;224m_\e[39m \e[38;2;108;183;224m_\e[39m \e[38;2;109;181;224m_\e[39m\e[38;2;109;178;223m_\e[39m\e[38;2;110;176;223m_\e[39m \e[38;2;111;174;222m_\e[39m\e[38;2;111;171;222m_\e[39m\e[38;2;112;169;222m_\e[39m    │
-│   \e[38;2;113;167;221m|\e[39m  \e[38;2;113;165;221m|\e[39m  \e[38;2;114;163;221m|\e[39m \e[38;2;115;160;220m-\e[39m\e[38;2;115;158;220m_\e[39m\e[38;2;116;156;219m|\e[39m \e[38;2;117;155;219m.\e[39m \e[38;2;117;153;219m|\e[39m \e[38;2;118;151;218m|\e[39m \e[38;2;119;149;218m.\e[39m \e[38;2;119;147;218m|\e[39m \e[38;2;120;145;217m|\e[39m \e[38;2;121;144;217m|\e[39m \e[38;2;121;142;216m-\e[39m\e[38;2;122;140;216m_\e[39m\e[38;2;123;139;216m|\e[39m  \e[38;2;123;137;215m_\e[39m\e[38;2;124;136;215m|\e[39m   │
-│   \e[38;2;124;134;215m|\e[39m\e[38;2;125;133;214m_\e[39m\e[38;2;126;132;214m_\e[39m\e[38;2;126;130;214m_\e[39m\e[38;2;127;129;213m_\e[39m\e[38;2;127;128;213m/\e[39m\e[38;2;130;128;212m|\e[39m\e[38;2;132;129;212m_\e[39m\e[38;2;134;129;212m_\e[39m\e[38;2;137;130;211m_\e[39m\e[38;2;139;131;211m|\e[39m  \e[38;2;141;131;211m_\e[39m\e[38;2;143;132;210m|\e[39m\e[38;2;145;132;210m_\e[39m\e[38;2;147;133;209m|\e[39m\e[38;2;149;133;209m_\e[39m\e[38;2;151;134;209m_\e[39m\e[38;2;153;135;208m_\e[39m\e[38;2;155;135;208m|\e[39m\e[38;2;157;136;208m_\e[39m  \e[38;2;159;136;207m|\e[39m\e[38;2;161;137;207m_\e[39m\e[38;2;162;137;206m_\e[39m\e[38;2;164;138;206m_\e[39m\e[38;2;166;139;206m|\e[39m\e[38;2;167;139;205m_\e[39m\e[38;2;169;140;205m|\e[39m     │
-│             \e[38;2;170;140;205m|\e[39m\e[38;2;172;141;204m_\e[39m\e[38;2;173;141;204m|\e[39m       \e[38;2;175;142;203m|\e[39m\e[38;2;176;142;203m_\e[39m\e[38;2;177;143;203m_\e[39m\e[38;2;179;143;202m_\e[39m\e[38;2;180;144;202m|\e[39m           │
-│                                       │
-│                                       │
-╰───────────────────────────────────────╯
-
-EOF
-            );
-        } else {
-            $output->write(<<<EOF
-╭───────────────────────────────────────╮
-│                                       │
-│                                       │
-│    ____          _                    │
-│   |    \ ___ ___| |___ _ _ ___ ___    │
-│   |  |  | -_| . | | . | | | -_|  _|   │
-│   |____/|___|  _|_|___|_  |___|_|     │
-│             |_|       |___|           │
-│                                       │
-│                                       │
-╰───────────────────────────────────────╯
-
-EOF
-            );
-        }
+        $this->printHeader($output);
 
         $io = new SymfonyStyle($input, $output);
-        $recipePath = $input->getOption('path');
 
-        $language = $io->choice('Select recipe language', ['php', 'yaml'], 'php');
-        if (empty($recipePath)) {
-            $recipePath = "deploy.$language";
-        }
+        $this->setRecipePath($input, $io);
+        $this->setTemplate($io);
+        $this->setRepository($io);
+        $this->guessHost();
+        $this->setProject($io);
+        $this->setHosts($io);
 
-        // Avoid accidentally override of existing file.
-        if (file_exists($recipePath)) {
-            $io->warning("$recipePath already exists");
-            if (!$io->confirm("Do you want to override the existing file?", false)) {
-                $io->block('👍🏻');
-                exit(1);
-            }
-        }
-
-        // Template
-        $template = $io->choice('Select project template', $this->recipes(), 'common');
-
-        // Repo
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('git remote get-url origin');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
-        $repository = $io->ask('Repository', $default);
-
-        // Guess host
-        if (preg_match('/github.com:(?<org>[A-Za-z0-9_.\-]+)\//', $repository, $m)) {
-            $org = $m['org'];
-            $tempHostFile = tempnam(sys_get_temp_dir(), 'temp-host-file');
-            $php = new PhpProcess(<<<EOF
-<?php
-\$ch = curl_init('https://api.github.com/orgs/$org');
-curl_setopt(\$ch, CURLOPT_USERAGENT, 'Deployer');
-curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, 'GET');
-curl_setopt(\$ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt(\$ch, CURLOPT_FOLLOWLOCATION, true);
-curl_setopt(\$ch, CURLOPT_MAXREDIRS, 10);
-curl_setopt(\$ch, CURLOPT_CONNECTTIMEOUT, 5);
-curl_setopt(\$ch, CURLOPT_TIMEOUT, 5);
-\$result = curl_exec(\$ch);
-curl_close(\$ch);
-\$json = json_decode(\$result);
-\$host = parse_url(\$json->blog, PHP_URL_HOST);
-file_put_contents('$tempHostFile', \$host);
-EOF
-            );
-            $php->start();
-        }
-
-        // Project
-        $default = '';
-        try {
-            $process = Process::fromShellCommandline('basename "$PWD"');
-            $default = $process->mustRun()->getOutput();
-            $default = trim($default);
-        } catch (RuntimeException $e) {
-        }
-        $project = $io->ask('Project name', $default);
-
-        // Hosts
-        $host = null;
-        if (isset($tempHostFile)) {
-            $host = file_get_contents($tempHostFile);
-        }
-        $hostsString = $io->ask('Hosts (comma separated)', $host);
-        if ($hostsString !== null) {
-            $hosts = explode(',', $hostsString);
-        } else {
-            $hosts = [];
-        }
-
-        file_put_contents($recipePath, $this->$language($template, $project, $repository, $hosts));
+        file_put_contents(
+            $this->recipePath,
+            $this->language(
+                $this->template,
+                $this->project,
+                $this->repository,
+                $this->hosts
+            )
+        );
 
         $this->telemetry();
         $output->writeln(sprintf(
             '<info>Successfully created</info> <comment>%s</comment>',
-            $recipePath
+            $this->recipePath
         ));
         return 0;
     }
@@ -260,5 +169,135 @@ YAML;
 
         sort($recipes);
         return $recipes;
+    }
+
+    protected function printHeader(OutputInterface $output): void
+    {
+        if (getenv('COLORTERM') === 'truecolor') {
+            $output->write(<<<EOF
+╭───────────────────────────────────────╮
+│                                       │
+│                                       │
+│    \e[38;2;94;231;223m_\e[39m\e[38;2;95;231;226m_\e[39m\e[38;2;96;230;228m_\e[39m\e[38;2;96;229;230m_\e[39m          \e[38;2;97;226;230m_\e[39m                    │
+│   \e[38;2;98;223;229m|\e[39m    \e[38;2;98;220;229m\\\e[39m \e[38;2;99;216;228m_\e[39m\e[38;2;100;213;228m_\e[39m\e[38;2;101;210;228m_\e[39m \e[38;2;101;208;227m_\e[39m\e[38;2;102;205;227m_\e[39m\e[38;2;103;202;227m_\e[39m\e[38;2;104;199;226m|\e[39m \e[38;2;104;196;226m|\e[39m\e[38;2;105;194;225m_\e[39m\e[38;2;106;191;225m_\e[39m\e[38;2;106;188;225m_\e[39m \e[38;2;107;186;224m_\e[39m \e[38;2;108;183;224m_\e[39m \e[38;2;109;181;224m_\e[39m\e[38;2;109;178;223m_\e[39m\e[38;2;110;176;223m_\e[39m \e[38;2;111;174;222m_\e[39m\e[38;2;111;171;222m_\e[39m\e[38;2;112;169;222m_\e[39m    │
+│   \e[38;2;113;167;221m|\e[39m  \e[38;2;113;165;221m|\e[39m  \e[38;2;114;163;221m|\e[39m \e[38;2;115;160;220m-\e[39m\e[38;2;115;158;220m_\e[39m\e[38;2;116;156;219m|\e[39m \e[38;2;117;155;219m.\e[39m \e[38;2;117;153;219m|\e[39m \e[38;2;118;151;218m|\e[39m \e[38;2;119;149;218m.\e[39m \e[38;2;119;147;218m|\e[39m \e[38;2;120;145;217m|\e[39m \e[38;2;121;144;217m|\e[39m \e[38;2;121;142;216m-\e[39m\e[38;2;122;140;216m_\e[39m\e[38;2;123;139;216m|\e[39m  \e[38;2;123;137;215m_\e[39m\e[38;2;124;136;215m|\e[39m   │
+│   \e[38;2;124;134;215m|\e[39m\e[38;2;125;133;214m_\e[39m\e[38;2;126;132;214m_\e[39m\e[38;2;126;130;214m_\e[39m\e[38;2;127;129;213m_\e[39m\e[38;2;127;128;213m/\e[39m\e[38;2;130;128;212m|\e[39m\e[38;2;132;129;212m_\e[39m\e[38;2;134;129;212m_\e[39m\e[38;2;137;130;211m_\e[39m\e[38;2;139;131;211m|\e[39m  \e[38;2;141;131;211m_\e[39m\e[38;2;143;132;210m|\e[39m\e[38;2;145;132;210m_\e[39m\e[38;2;147;133;209m|\e[39m\e[38;2;149;133;209m_\e[39m\e[38;2;151;134;209m_\e[39m\e[38;2;153;135;208m_\e[39m\e[38;2;155;135;208m|\e[39m\e[38;2;157;136;208m_\e[39m  \e[38;2;159;136;207m|\e[39m\e[38;2;161;137;207m_\e[39m\e[38;2;162;137;206m_\e[39m\e[38;2;164;138;206m_\e[39m\e[38;2;166;139;206m|\e[39m\e[38;2;167;139;205m_\e[39m\e[38;2;169;140;205m|\e[39m     │
+│             \e[38;2;170;140;205m|\e[39m\e[38;2;172;141;204m_\e[39m\e[38;2;173;141;204m|\e[39m       \e[38;2;175;142;203m|\e[39m\e[38;2;176;142;203m_\e[39m\e[38;2;177;143;203m_\e[39m\e[38;2;179;143;202m_\e[39m\e[38;2;180;144;202m|\e[39m           │
+│                                       │
+│                                       │
+╰───────────────────────────────────────╯
+
+EOF
+            );
+        } else {
+            $output->write(<<<EOF
+╭───────────────────────────────────────╮
+│                                       │
+│                                       │
+│    ____          _                    │
+│   |    \ ___ ___| |___ _ _ ___ ___    │
+│   |  |  | -_| . | | . | | | -_|  _|   │
+│   |____/|___|  _|_|___|_  |___|_|     │
+│             |_|       |___|           │
+│                                       │
+│                                       │
+╰───────────────────────────────────────╯
+
+EOF
+            );
+        }
+    }
+
+    protected function setRecipePath(InputInterface $input, SymfonyStyle $io): void
+    {
+        $this->language = $io->choice('Select recipe language', ['php', 'yaml'], 'php');
+        if (empty($this->recipePath)) {
+            $this->recipePath = "deploy.$this->language";
+        }
+
+        // Avoid accidentally override of existing file.
+        if (file_exists($this->recipePath)) {
+            $io->warning("$this->recipePath already exists");
+            if (!$io->confirm("Do you want to override the existing file?", false)) {
+                $io->block('👍🏻');
+                exit(1);
+            }
+        }
+
+        $this->recipePath = $input->getOption('path');
+    }
+
+    protected function setTemplate(SymfonyStyle $io): void
+    {
+        $this->template = $io->choice('Select project template', $this->recipes(), 'common');
+    }
+
+    protected function setRepository(SymfonyStyle $io): void
+    {
+        $default = '';
+        try {
+            $process = Process::fromShellCommandline('git remote get-url origin');
+            $default = $process->mustRun()->getOutput();
+            $default = trim($default);
+        } catch (RuntimeException $e) {
+            //@TODO Throw error $e->getMessage();
+        }
+
+        $this->repository = $io->ask('Repository', $default);
+    }
+
+    protected function guessHost(): void
+    {
+        if (preg_match('/github.com:(?<org>[A-Za-z0-9_.\-]+)\//', $this->repository, $m)) {
+            $org = $m['org'];
+            $tempHostFile = tempnam(sys_get_temp_dir(), 'temp-host-file');
+            $php = new PhpProcess(<<<EOF
+<?php
+\$ch = curl_init('https://api.github.com/orgs/$org');
+curl_setopt(\$ch, CURLOPT_USERAGENT, 'Deployer');
+curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt(\$ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt(\$ch, CURLOPT_FOLLOWLOCATION, true);
+curl_setopt(\$ch, CURLOPT_MAXREDIRS, 10);
+curl_setopt(\$ch, CURLOPT_CONNECTTIMEOUT, 5);
+curl_setopt(\$ch, CURLOPT_TIMEOUT, 5);
+\$result = curl_exec(\$ch);
+curl_close(\$ch);
+\$json = json_decode(\$result);
+\$host = parse_url(\$json->blog, PHP_URL_HOST);
+file_put_contents('$tempHostFile', \$host);
+EOF
+            );
+            $php->start();
+        }
+    }
+
+    protected function setProject(SymfonyStyle $io): void
+    {
+        $default = '';
+        try {
+            $process = Process::fromShellCommandline('basename "$PWD"');
+            $default = $process->mustRun()->getOutput();
+            $default = trim($default);
+        } catch (RuntimeException $e) {
+            //@TODO Throw error $e->getMessage();
+        }
+        $this->project = $io->ask('Project name', $default);
+    }
+
+    protected function setHosts(SymfonyStyle $io): void
+    {
+        $host = null;
+        if (isset($tempHostFile)) {
+            $host = file_get_contents($tempHostFile);
+        }
+        $hostsString = $io->ask('Hosts (comma separated)', $host);
+        if ($hostsString !== null) {
+            $hosts = explode(',', $hostsString);
+        } else {
+            $hosts = [];
+        }
+
+        $this->hosts = $hosts;
     }
 }

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -205,7 +205,6 @@ class Deployer extends Container
      */
     public function init()
     {
-        $this->addTaskCommands();
         $this->getConsole()->add(new BlackjackCommand());
         $this->getConsole()->add(new ConfigCommand($this));
         $this->getConsole()->add(new WorkerCommand($this));
@@ -221,6 +220,7 @@ class Deployer extends Container
             $this->getConsole()->add($selfUpdate);
             $this->getConsole()->getHelperSet()->set(new PharUpdateHelper());
         }
+        $this->addTaskCommands();
     }
 
     /**

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -205,6 +205,7 @@ class Deployer extends Container
      */
     public function init()
     {
+        $this->addTaskCommands();
         $this->getConsole()->add(new BlackjackCommand());
         $this->getConsole()->add(new ConfigCommand($this));
         $this->getConsole()->add(new WorkerCommand($this));
@@ -220,7 +221,7 @@ class Deployer extends Container
             $this->getConsole()->add($selfUpdate);
             $this->getConsole()->getHelperSet()->set(new PharUpdateHelper());
         }
-        $this->addTaskCommands();
+        $this->maybeAddCustomCommands();
     }
 
     /**


### PR DESCRIPTION
- [ ]  Bug fix #…?
- [x]  New feature?
- [ ]  BC breaks?
- [ ]  Tests added?
- [ ]  Docs added?

I've reworked the `init()` function of `Deployer.php` to include a `maybeAddCustomCommands()` function, which checks for a `DeployerCommands` dir in the project root and, if any exist, integrate them with Deployer accordingly. Custom commands can either override stock Deployer commands or create new commands. These changes are 100% backwards-compatible, in that if no `DeployerCommands` dir is present, there are no changes to the current functionality.

One of the primary advantages of this restructure is the ability to customize the `deployer.php` templates being used, to include additional information or additional formats.

[Here is a gist](https://gist.github.com/cornelisonc/6e51d6d945e4f5e252152c04995c1c80) demonstrating an example implementation of a customized `InitCommand.php` file, which would be placed inside `DeployerCommands/` at the project root. In this example file, I've customized

1. `configure()` -- customized the `init` command description
2. `setDomain()` -- new functionality to set project domain on initialization
3. `guessHost()` -- an example of a customized host-guessing procedure where our site includes a `host.php` file serving the hostname; this hostname can later be used in the `deployer.php` script

An alternative implementation of `guessHost()` could also integrate with a registrar's API, implement `nslookup`, just for a few examples.

For developers or engineering teams, the ability to override Deployer's stock commands and templates would make a huge improvement in standardizing implementation across projects, and allow them to script out many of the initial configuration steps for `deployer.php` which aren't quite covered by custom recipes.