### PR TITLE
Shopware has switched to `.env.local`

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -35,7 +35,7 @@ set('default_timeout', 3600); // Increase when tasks take longer than that.
 
 // These files are shared among all releases.
 set('shared_files', [
-    '.env',
+    '.env.local',
     'install.lock',
     'public/.htaccess',
     'public/.user.ini',


### PR DESCRIPTION
Shopware has switched to `.env.local` for modifications since [6.5.0.0](https://docs.shopware.com/en/shopware-6-en/tutorials-and-faq/notes-to-the-APP-URL), whereas the `.env` provides sane defaults now.

- [x] Bug fix #…?
- [ ] New feature?
- [x] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

I guess this can break old setups, depending on how `deploy:update_code` was implemented. Since the basic recipe is not working anyway at the moment, I guess it can be changed though…