### PR TITLE
M2 recipe : handle cron stop in try catch

### DIFF
--- a/docs/contrib/cachetool.md
+++ b/docs/contrib/cachetool.md
@@ -123,7 +123,7 @@ Clear opcache cache
 
 
 ### cachetool:clear:apcu
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/cachetool.php#L99)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/cachetool.php#L100)
 
 Clears APCu system cache.
 
@@ -131,7 +131,7 @@ Clear APCu cache
 
 
 ### cachetool:clear:stat
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/cachetool.php#L110)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/cachetool.php#L111)
 
 Clears file status and realpath caches.
 

--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -690,8 +690,32 @@ Cleanup cache id_prefix env files.
 After successful deployment, move the tmp_env.php file to env.php ready for next deployment
 
 
+### magento:cron:stop
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L505)
+
+Remove cron from crontab and kill running cron jobs.
+
+Remove cron from crontab and kill running cron jobs
+To use this feature, add the following to your deployer scripts:
+ ```php
+ after('magento:maintenance:enable-if-needed', 'magento:cron:stop');
+ ```
+
+
+### magento:cron:install
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L521)
+
+Install cron in crontab.
+
+Install cron in crontab
+To use this feature, add the following to your deployer scripts:
+  ```php
+  after('magento:upgrade:db', 'magento:cron:install');
+  ```
+
+
 ### artifact:prepare
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L499)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L527)
 
 Prepares an artifact on the target server.
 
@@ -711,7 +735,7 @@ This task is group task which contains next tasks:
 
 
 ### artifact:finish
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L512)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L540)
 
 Executes the tasks after artifact is released.
 
@@ -726,7 +750,7 @@ This task is group task which contains next tasks:
 
 
 ### artifact:deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L521)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L549)
 
 Actually releases the artifact deployment.
 

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -494,6 +494,34 @@ task('magento:cleanup_cache_prefix', function () {
     run('{{bin/symlink}} {{deploy_path}}/shared/' . ENV_CONFIG_FILE_PATH . ' {{release_path}}/' . ENV_CONFIG_FILE_PATH);
 });
 
+/**
+ * Remove cron from crontab and kill running cron jobs
+ * To use this feature, add the following to your deployer scripts:
+ *  ```php
+ *  after('magento:maintenance:enable-if-needed', 'magento:cron:stop');
+ *  ```
+ */
+desc('Remove cron from crontab and kill running cron jobs');
+task('magento:cron:stop', function () {
+    if (has('previous_release')) {
+        run('{{bin/php}} {{previous_release}}/{{magento_dir}}/bin/magento cron:remove');
+    }
+
+    run('pgrep -U "$(id -u)" -f "bin/magento +(cron:run|queue:consumers:start)" | xargs -r kill');
+});
+
+/**
+ * Install cron in crontab
+ * To use this feature, add the following to your deployer scripts:
+ *   ```php
+ *   after('magento:upgrade:db', 'magento:cron:install');
+ *   ```
+ */
+desc('Install cron in crontab');
+task('magento:cron:install', function () {
+    run('cd {{release_or_current_path}}');
+    run('{{bin/php}} {{bin/magento}} cron:install');
+});
 
 desc('Prepares an artifact on the target server');
 task('artifact:prepare', [

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -504,7 +504,11 @@ task('magento:cleanup_cache_prefix', function () {
 desc('Remove cron from crontab and kill running cron jobs');
 task('magento:cron:stop', function () {
     if (has('previous_release')) {
-        run('{{bin/php}} {{previous_release}}/{{magento_dir}}/bin/magento cron:remove');
+        try {
+            run('{{bin/php}} {{previous_release}}/{{magento_dir}}/bin/magento cron:remove');
+        } catch (RunException $e) {
+            // do nothing
+        }
     }
 
     run('pgrep -U "$(id -u)" -f "bin/magento +(cron:run|queue:consumers:start)" | xargs -r kill');


### PR DESCRIPTION
This change handle the case when cron:remove can not be executed properly, for example when setup:upgrade or Magento 2 installation wasn't done properly.

Try/Catch prevents breaking of deployment (as cron stopping is nice to have, but not required).