### PR TITLE
Fix crontab for cross platform support.

### DIFF
--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -107,6 +107,6 @@ function getRemoteCrontab(): array
         return [];
     }
 
-    return explode(PHP_EOL, run("$sudo {{bin/crontab}} -l"));
+    return preg_split('/\r\n|\r|\n/', run("$sudo {{bin/crontab}} -l"));
 }
 


### PR DESCRIPTION
This fixes crontab failing to recognize the existing cronjobs when running from Windows and connecting to a say a Linux server.  It would lead to new existing sections not being found, and new ones being added each time it was run.  This was due to trying to explode the crontab lines with `PHP_EOL`, as on a windows system, it would be looking for `\r\n` newlines in the crontab.  However, the crontab was coming from a linux system, and the newlines would be `\n`.

This fix now looks for all types of newlines to split the crontab lines by.


- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
