### PR TITLE
docs(recipe/magento2): fix typo in conccurent

### DIFF
--- a/docs/recipe/magento2.md
+++ b/docs/recipe/magento2.md
@@ -191,7 +191,7 @@ This setting supports the same options/structure as [magento_themes](/docs/recip
 ### static_content_jobs
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L64)
 
-Also set the number of conccurent jobs to run. The default is 1
+Also set the number of concurrent jobs to run. The default is 1
 Update using: `set('static_content_jobs', '1');`
 
 ```php title="Default value"

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -59,7 +59,7 @@ set('magento_themes_backend', ['Magento/backend' => null]);
 
 // Configuration
 
-// Also set the number of conccurent jobs to run. The default is 1
+// Also set the number of concurrent jobs to run. The default is 1
 // Update using: `set('static_content_jobs', '1');`
 set('static_content_jobs', '1');
 


### PR DESCRIPTION
- [x] Docs added?
  - [x] Please, regenerate docs by running next command:
      `$ php bin/docgen`

Try #3779 again with changes in the correct file according to: https://github.com/deployphp/deployer/pull/3779#issuecomment-1946738715 :)