### PR TITLE
Update Craft CMS deploy recipe

### DIFF
--- a/docs/recipe/craftcms.md
+++ b/docs/recipe/craftcms.md
@@ -99,10 +99,18 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 ## Tasks
 
-### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L64)
+### craft:gc
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L120)
 
-deploy.
+Runs garbage collection.
+
+
+
+
+### deploy
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L127)
+
+Deploys Craft CMS.
 
 
 

--- a/recipe/craftcms.php
+++ b/recipe/craftcms.php
@@ -27,9 +27,11 @@ set('writable_dirs', [
  * Run a craft command.
  *
  * Supported options:
+ *  - 'showOutput': Show the output of the command if given.
  *
  * @param string $command The craft command (with cli options if any).
  * @param array $options The options that define the behaviour of the command.
+ *
  * @return callable A function that can be used as a task.
  */
 function craft($command, $options = [])
@@ -39,14 +41,10 @@ function craft($command, $options = [])
             throw new \Exception('Your .env file is empty! Cannot proceed.');
         }
 
-        try {
-            $output = run("cd {{release_path}} && {{bin/php}} craft $command");
+        $output = run("{{bin/php}} {{release_path}}/craft $command");
 
-            if (in_array('showOutput', $options)) {
-                writeln("<info>$output</info>");
-            }
-        } catch (\Throwable $e) {
-            writeln("<error>{$e->getMessage()}</error>");
+        if (in_array('showOutput', $options)) {
+            writeln("<info>$output</info>");
         }
     };
 }


### PR DESCRIPTION
- [ ] Bug fix #…?

- [x] New feature?

Added the `--interactive=0` flag to each command, with an option to not add it.
Added new `cache-clear`, `gc`, `setup/app-id` and `setup/security-key` tasks.

- [x] BC breaks?

Removed the `try {} catch` for any `craft()` command. 
This resulted in Deployer thinking a deploy was successful when it was not.

- [ ] Tests added?

- [x] Docs added?

Documented options for the `craft()` command
