### PR TITLE
Avoid php-fpm reloading in Apache

### DIFF
--- a/docs/avoid-php-fpm-reloading.md
+++ b/docs/avoid-php-fpm-reloading.md
@@ -52,3 +52,11 @@ php_fastcgi * unix//run/php/php-fpm.sock {
     resolve_root_symlink
 }
 ```
+
+## Fix for Apache
+
+Enable `revalidate_path` in `php.ini`:
+
+```ini
+opcache.revalidate_path=1
+```


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
