### PR TITLE
Correct step name

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,5 +58,5 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
-      - name: Run test suite
+      - name: Run PHP_CodeSniffer
         run: composer phpcs


### PR DESCRIPTION
This PR correct the step name from `Run test suite` to `Run PHP_CodeSniffer` when running PHP_CodeSniffer.

It is expected to be a copy-paste left over originating from `.github/workflows/test.yml`. Given this code doesn't touch any application logic there doesn't seem to be a need to regenerate the documentation.