### PR TITLE
Change goo.gl URL to php.net

### DIFF
--- a/src/Utility/Httpie.php
+++ b/src/Utility/Httpie.php
@@ -42,7 +42,7 @@ class Httpie
         if (!extension_loaded('curl')) {
             throw new \Exception(
                 "Please, install curl extension.\n" .
-                "https://goo.gl/yTAeZh"
+                "https://php.net/curl.installation"
             );
         }
     }


### PR DESCRIPTION
Google will be retiring goo.gl redirects, so go ahead and point directly at php.net.