### PR TITLE
add support of multiple values in host label

### DIFF
--- a/docs/selector.md
+++ b/docs/selector.md
@@ -1,7 +1,7 @@
 # Selector
 
 Deployer uses the selector to choose hosts. Each host can have a set of labels. 
-Labels are key-value pairs. 
+Labels are key-value pairs.
 
 For example, `stage: production` or `role: web`. 
 
@@ -23,6 +23,8 @@ host('db.example.com')
         'env' => 'prod',
     ]);
 ```
+or use `->addLables()` method to add labels to the existing host.
+
 
 Now let's define a task to check labels:
 
@@ -54,6 +56,16 @@ task info
 
 Label syntax is represented by [disjunctive normal form](https://en.wikipedia.org/wiki/Disjunctive_normal_form) 
 (**OR of ANDs**).
+```
+(condition1 AND condition2) OR (condition3 AND condition4)
+```
+
+Each condition in the subquery that is represented by [conjunctive normal form](https://en.wikipedia.org/wiki/Conjunctive_normal_form)
+```
+(condition1 OR condition2) AND (condition3 OR condition4)
+```
+
+### Explanation
 
 For example, `type=web,env=prod` is a selector of: `type=web` **OR** `env=prod`.
 
@@ -66,11 +78,21 @@ task info
 
 As you can see, both hosts are selected (as both of them have the `env: prod` label).
 
+
 We can use `&` to define **AND**. For example, `type=web & env=prod` is a selector
 for hosts with `type: web` **AND** `env: prod` labels.
 
 ```bash
 $ dep info 'type=web & env=prod'
+task info
+[web.example.com] type:web env:prod
+```
+
+We can use `|` to define **OR** in a subquery. For example, `type=web|db & env=prod` is a selector
+for hosts with (`type: web` **OR** `type:db`) **AND** `env: prod` labels.
+
+```bash
+$ dep info 'type=web|db & env=prod'
 task info
 [web.example.com] type:web env:prod
 ```
@@ -119,7 +141,7 @@ You can use the [select()](api.md#select) function to select hosts by selector i
 
 ```php
 task('info', function () {
-    $hosts = select('type=web,env=prod');
+    $hosts = select('type=web|db,env=prod');
     foreach ($hosts as $host) {
         writeln('type:' . $host->get('labels')['type'] . ' env:' . $host->get('labels')['env']);
     }
@@ -143,8 +165,10 @@ To restrict a task to run only on selected hosts, you can use the [select()](tas
 ```php
 task('info', function () {
     // ...
-})->select('type=web,env=prod');
+})->select('type=web|db,env=prod');
 ```
+
+
 
 ## Labels in YAML
 

--- a/docs/selector.md
+++ b/docs/selector.md
@@ -1,7 +1,7 @@
 # Selector
 
 Deployer uses the selector to choose hosts. Each host can have a set of labels. 
-Labels are key-value pairs.
+Labels are key-value pairs. 
 
 For example, `stage: production` or `role: web`. 
 
@@ -24,7 +24,6 @@ host('db.example.com')
     ]);
 ```
 or use `->addLables()` method to add labels to the existing host.
-
 
 Now let's define a task to check labels:
 
@@ -78,7 +77,6 @@ task info
 
 As you can see, both hosts are selected (as both of them have the `env: prod` label).
 
-
 We can use `&` to define **AND**. For example, `type=web & env=prod` is a selector
 for hosts with `type: web` **AND** `env: prod` labels.
 
@@ -89,7 +87,7 @@ task info
 ```
 
 We can use `|` to define **OR** in a subquery. For example, `type=web|db & env=prod` is a selector
-for hosts with (`type: web` **OR** `type:db`) **AND** `env: prod` labels.
+for hosts with (`type: web` **OR** `type: db`) **AND** `env: prod` labels.
 
 ```bash
 $ dep info 'type=web|db & env=prod'
@@ -167,8 +165,6 @@ task('info', function () {
     // ...
 })->select('type=web|db,env=prod');
 ```
-
-
 
 ## Labels in YAML
 

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -215,6 +215,13 @@ class Host
         return $this;
     }
 
+    public function addLabels(array $labels): self
+    {
+        $existingLabels = $this->getLabels() ?? [];
+        $this->setLabels(array_replace_recursive($existingLabels, $labels));
+        return $this;
+    }
+
     public function getLabels(): ?array
     {
         return $this->config->get('labels', null);

--- a/tests/src/Task/ScriptManagerTest.php
+++ b/tests/src/Task/ScriptManagerTest.php
@@ -72,7 +72,6 @@ class ScriptManagerTest extends TestCase
         $scriptManager = new ScriptManager($taskCollection);
         self::assertEquals([$a, $b, $c], $scriptManager->getTasks('group'));
         self::assertNull($a->getSelector());
-
         self::assertEquals([[['=', 'stage', ['beta']]]], $b->getSelector());
         self::assertEquals([[['=', 'stage', ['alpha', 'beta']],['=', 'role', ['db']]]], $c->getSelector());
 


### PR DESCRIPTION
# Allow usage of `(c1 OR c2) AND (c3 or c4)` condition to select() query

The existing solution does not allow OR conditions in the scope of single label value in the select query. 
The following example is only possible:
```
task(...).select('stage=prod & role=web, stage=qa & role=web')
```

In other words, only the following conditions could be defined in the query:
```
(condition1 and condition2) or (condition3 and condition4)
```
Example:
```
stage=prod & role=web, stage=qa & role=web, stage=qa & role=db, stage=prod & role=db
```


But in most cases, we need the following query:
```
(condition1 or condition2) and (condition3 or condition4)
```

Example:
```
stage=prod|qa & role=web|db
```


The PR is adding that support. 

## Example of usage: 

### Define hosts
```
host('prod.example.org') 
    ->set('hostname', 'example.cloud.google.com')
    ->setLabel( 'stage' => 'prod' 'role' => ['build','web','redis'] ])
;
host('prod-db.example.org')
    ->set('hostname', 'example.cloud.google.com')
    ->setLabel( 'stage' => 'prod' 'role' => ['db'] ])
; 
host('qa.example.org')
    ->set('hostname', 'example.cloud.google.com')
    ->setLabel( 'stage' => 'qa' 'role' => ['build','web','redis','db'] ]); 

host('dev.example.org')
    ->set('hostname', 'example.cloud.google.com')
    ->setLabel( 'stage' => 'dev' 'role' => ['build','web','redis','db'] ]); 
```

### Define tasks
```
desc('Reload Http');
task('reload:http', function () {
    run('/usr/sbin/service nginx reload &> /dev/null');
})->select('stage=prod|qa|dev & role=web');
```

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [x] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
