### PR TITLE
Fix: change slack success and fail messages

### DIFF
--- a/contrib/slack.php
+++ b/contrib/slack.php
@@ -76,8 +76,8 @@ set('slack_title', function () {
 
 // Deploy message
 set('slack_text', '_{{user}}_ deploying `{{target}}` to *{{hostname}}*');
-set('slack_success_text', 'Deploy to *{{target}}* successful');
-set('slack_failure_text', 'Deploy to *{{target}}* failed');
+set('slack_success_text', 'Deploy of `{{target}}` to *{{hostname}}* successful');
+set('slack_failure_text', 'Deploy of `{{target}}` to *{{hostname}}* failed');
 set('slack_rollback_text', '_{{user}}_ rolled back changes on *{{target}}*');
 set('slack_fields', []);
 

--- a/docs/contrib/slack.md
+++ b/docs/contrib/slack.md
@@ -96,7 +96,7 @@ Deploy message
 
 
 ```php title="Default value"
-'Deploy to *{{target}}* successful'
+'Deploy of `{{target}}` to *{{hostname}}* successful'
 ```
 
 
@@ -106,7 +106,7 @@ Deploy message
 
 
 ```php title="Default value"
-'Deploy to *{{target}}* failed'
+'Deploy of `{{target}}` to *{{hostname}}* failed'
 ```
 
 


### PR DESCRIPTION
- [x] Bug fix (Slack Messages)
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Slack message was as follows:

```
MyProject
Deploy to *HEAD* successful
```

Where something like below was intended.

```
MyProject
Deploy to *myproject.com* successful
```
I changed it to:
     
```
MyProject
Deploy of `HEAD` to *myproject.com* successful
```

Same for failed message.