### PR TITLE
Update dependencies autoload path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
             "Deployer\\": "src/"
         },
         "files": [
-            "deps/vendor/autoload.php",
+            "vendor/autoload.php",
             "src/Support/helpers.php",
             "src/functions.php"
         ]


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

The update moved the dependencies from `deps\vendor` to `vendor`, but didn't update the autoload autoload path in `composer.json`. 

Running Deployer as a composer dependency generated the following output:
`  require(/pat/to/project/vendor/composer/../deployer/deployer/deps/vendor/autoload.php): Failed to open stream: No such file or directory
`
