### PR TITLE
[Symfony] Rename deploy:env to deploy:env:optimize

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -64,7 +64,7 @@ task('deploy:cache:clear', function () {
 });
 
 desc('Optimize environment variables');
-task('deploy:env', function () {
+task('deploy:env:optimize', function () {
     within('{{release_or_current_path}}', function () {
         run('{{bin/composer}} dump-env "${APP_ENV:-prod}"');
     });


### PR DESCRIPTION
due to a naming conflict

- [x] Bug fix https://github.com/deployphp/deployer/pull/3856#issuecomment-2429681879
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

This PR renames a task thats name is already used in the deploy.php (even though the task name was not used Symfony recipes before).