### PR TITLE
Add setShellPath method to customize shell path in Host class

### DIFF
--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -198,6 +198,17 @@ class Host
         return $this->config->get('shell', null);
     }
 
+    public function setShellPath(string $path): self
+    {
+        $this->config->set('shell_path', $path);
+        return $this;
+    }
+
+    public function getShellPath(): ?string
+    {
+        return $this->config->get('shell_path', null);
+    }
+
     public function setDeployPath(string $path): self
     {
         $this->config->set('deploy_path', $path);


### PR DESCRIPTION
- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

### Description

This PR adds a `setShellPath` method to the `Host` class, allowing users to define a custom shell path more easily when using Deployer.

### Why this change is necessary

When using MySecureShell or other shell environments that do not support the `-l` option, Deployer's SSH command fails. By providing a dedicated method for setting the shell path, users can work around this issue without needing to manually override the shell path in the configuration.

### What this PR does

- Adds `setShellPath` and `getShellPath` methods to the `Host` class.
- Allows users to set a custom shell path via the `deploy.php` configuration file.

### Example

```php
host('production')
    ->setHostname('your-hostname')
    ->setRemoteUser('your-user')
    ->setIdentityFile('~/.ssh/your-key')
    ->setShellPath('/bin/bash');  // Sets the shell path to /bin/bash