### PR TITLE
Update cachetool to latest version

### DIFF
--- a/contrib/cachetool.php
+++ b/contrib/cachetool.php
@@ -56,7 +56,7 @@ set('cachetool', '');
  * CacheTool 8.x works with PHP >=8.0
  * CacheTool 7.x works with PHP >=7.3
  */
-set('cachetool_url', 'https://github.com/gordalina/cachetool/releases/download/9.0.0/cachetool.phar');
+set('cachetool_url', 'https://github.com/gordalina/cachetool/releases/download/9.1.0/cachetool.phar');
 set('cachetool_args', '');
 set('bin/cachetool', function () {
     if (!test('[ -f {{release_or_current_path}}/cachetool.phar ]')) {


### PR DESCRIPTION
Cachetool has newer release. This PR updates the version number. It would be also possible to use "https://github.com/gordalina/cachetool/releases/latest/download/cachetool.phar" for the latest version. See https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases