### PR TITLE
Rename docker bin name to /bin/dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM php:8.3-cli-alpine
 
 RUN apk add --no-cache bash git openssh-client rsync
 
-COPY deployer.phar /bin/deployer.phar
+COPY --chmod=755 deployer.phar /bin/dep
 
 WORKDIR /app
 
-ENTRYPOINT ["php", "/bin/deployer.phar"]
+ENTRYPOINT ["/bin/dep"]

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -61,7 +61,7 @@ stages:
 deploy:
   stage: deploy
   image:
-    name: deployphp/deployer:7
+    name: deployphp/deployer:v7
     entrypoint: [""]
   before_script:
     - mkdir -p ~/.ssh


### PR DESCRIPTION
- [x] Bug fix #3738, #3707 
- [x] Docs added? No changes
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?

More in https://github.com/deployphp/deployer/discussions/3924#discussioncomment-11014453

- Fix typo in docs, where `v` was missing in image version.
- Edit Dockerfile. `dep` command is now available and default as entrypoint.