### PR TITLE
Added `writable_acl_groups` option to acl mode in `deploy:writable`

### DIFF
--- a/docs/recipe/deploy/writable.md
+++ b/docs/recipe/deploy/writable.md
@@ -91,11 +91,20 @@ The chmod mode.
 ```
 
 
+### writable_acl_groups
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/writable.php#L62)
+
+List of additional groups to give write permission to.
+
+```php title="Default value"
+[]
+```
+
 
 ## Tasks
 
 ### deploy\:writable {#deploy-writable}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/writable.php#L62)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/deploy/writable.php#L65)
 
 Makes writable dirs.
 

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -58,7 +58,7 @@ set('writable_recursive', false);
 // The chmod mode.
 set('writable_chmod_mode', '0755');
 
-// Additional groups to give write permission to.
+// List of additional groups to give write permission to.
 set('writable_acl_groups', []);
 
 desc('Makes writable dirs');

--- a/recipe/deploy/writable.php
+++ b/recipe/deploy/writable.php
@@ -58,6 +58,9 @@ set('writable_recursive', false);
 // The chmod mode.
 set('writable_chmod_mode', '0755');
 
+// Additional groups to give write permission to.
+set('writable_acl_groups', []);
+
 desc('Makes writable dirs');
 task('deploy:writable', function () {
     $dirs = join(' ', get('writable_dirs'));
@@ -103,6 +106,13 @@ task('deploy:writable', function () {
             run("$sudo chmod +a \"$remoteUser allow delete,write,append,file_inherit,directory_inherit\" $dirs");
         } elseif (commandExist('setfacl')) {
             $setFaclUsers = "-m u:\"$httpUser\":rwX";
+            $setFaclGroups = "";
+            foreach (get("writable_acl_groups") as $index => $group) {
+                if ($index > 0) {
+                    $setFaclGroups .= " ";
+                }
+                $setFaclGroups .= "-m g:\"$group\":rwX";
+            }
             // Check if remote user exists, before adding it to setfacl
             $remoteUserExists = test("id -u $remoteUser &>/dev/null 2>&1 || exit 0");
             if ($remoteUserExists === true) {
@@ -119,13 +129,13 @@ task('deploy:writable', function () {
                     $hasfacl = run("getfacl -p $dir | grep \"^user:$httpUser:.*w\" | wc -l");
                     // Set ACL for directory if it has not been set before
                     if (!$hasfacl) {
-                        run("setfacl -L $recursive $setFaclUsers $dir");
-                        run("setfacl -dL $recursive $setFaclUsers $dir");
+                        run("setfacl -L $recursive $setFaclUsers $setFaclGroups $dir");
+                        run("setfacl -dL $recursive $setFaclUsers $setFaclGroups $dir");
                     }
                 }
             } else {
-                run("$sudo setfacl -L $recursive $setFaclUsers $dirs");
-                run("$sudo setfacl -dL $recursive $setFaclUsers $dirs");
+                run("$sudo setfacl -L $recursive $setFaclUsers $setFaclGroups $dirs");
+                run("$sudo setfacl -dL $recursive $setFaclUsers $setFaclGroups $dirs");
             }
         } else {
             $alias = currentHost()->getAlias();


### PR DESCRIPTION
# Overview

Managing writable files owned by the `http_user` can be challenging in environments where multiple auxiliary users need editing access. A common solution is to use `setfacl` to assign appropriate permissions for specified groups.

# What's New?

This PR enhances the `acl` mode in the `deploy:writable` task by introducing a new option: `writable_acl_groups`. This option allows you to specify a list of group names that will be passed to all `setfacl` commands in the `deploy:writable` task.

The `writable_acl_groups` option defaults to `[]`, ensuring full backward compatibility without breaking existing implementations.

# Example Usage

Given the following settings:

```php
// Existing options
set('writable_mode', 'acl');
set('writable_recursive', true);
set('writable_dirs', ['dummy_dir']);
set('remote_user', 'cluster-user');
set('http_user', 'www-data');

// New option
set('writable_acl_groups', ['developer']);
```

Deployer will execute the following commands:

```shell
setfacl -L -R -m u:cluster-user:rwX -m u:www-data:rwX -m g:developer:rwX dummy_dir
setfacl -dL -R -m u:cluster-user:rwX -m u:www-data:rwX -m g:developer:rwX dummy_dir
```

This will produce the following `getfacl` output for directories:

```text
# file: dummy_dir
# owner: cluster-user
# group: developer
user::rwx
user:www-data:rwx
user:cluster-user:rwx
group::r-x
group:developer:rwx
mask::rwx
other::r-x
default:user::rwx
default:user:www-data:rwx
default:user:cluster-user:rwx
default:group::r-x
default:group:developer:rwx
default:mask::rwx
default:other::r-x
```

And the following output for files:

```text
# file: dummy_dir/some-file
# owner: cluster-user
# group: developer
user::rw-
user:www-data:rw-
user:cluster-user:rw-
group::r--
group:developer:rw-
mask::rw-
other::r--
```

# Checklist

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?