### PR TITLE
Fix tasks to start/restart Laravel Reverb

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -254,10 +254,10 @@ task('artisan:nova:publish', artisan('nova:publish'));
  */
 
 desc('Starts the Reverb server');
-task('artisan:reverb:start', artisan('pulse:start'));
+task('artisan:reverb:start', artisan('reverb:start'));
 
 desc('Restarts the Reverb server');
-task('artisan:reverb:restart', artisan('pulse:restart'));
+task('artisan:reverb:restart', artisan('reverb:restart'));
 
 /*
  * Pulse.


### PR DESCRIPTION
Just renames the wrong command.

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
