### PR TITLE
Bugfix pimcore build classes

### DIFF
--- a/recipe/pimcore.php
+++ b/recipe/pimcore.php
@@ -14,6 +14,7 @@ add('writable_dirs', ['public/var', 'var/cache/dev']);
 
 desc('Rebuilds Pimcore Classes');
 task('pimcore:rebuild-classes', function () {
+    run('{{bin/console}} pimcore:build:classes');
     run('{{bin/console}} pimcore:deployment:classes-rebuild --create-classes --delete-classes --no-interaction');
 });
 


### PR DESCRIPTION
In order for the objects to be created correctly, ‘pimcore:build:classes’ must be executed

https://github.com/deployphp/deployer/discussions/3448

- [x] Bug fix pimcore build classes
