### PR TITLE
Using `current_path` instead of hardcoding `current`

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -165,12 +165,12 @@ task('sw-build-without-db:get-remote-config', static function () {
     if (!test('[ -d {{current_path}} ]')) {
         return;
     }
-    within('{{deploy_path}}/current', function () {
+    within('{{current_path}}', function () {
         run('{{bin/php}} ./bin/console bundle:dump');
-        download('{{deploy_path}}/current/var/plugins.json', './var/');
+        download('{{current_path}}/var/plugins.json', './var/');
 
         run('{{bin/php}} ./bin/console theme:dump');
-        download('{{deploy_path}}/current/files/theme-config', './files/');
+        download('{{current_path}}/files/theme-config', './files/');
     });
 });
 


### PR DESCRIPTION
## Problem

The Shopware recipe currently hardcodes the `current` symlink. This creates issues for users who use a different symlink name, such as `live`.

## Solution

The `current_path` variable is already defined, so it should be used to provide flexibility and avoid hardcoding the symlink name.

## Checklist

- [x] Bug fix #…? (no issue opened)
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?