### PR TITLE
remove deployer 6.x leftovers

### DIFF
--- a/contrib/chatwork.php
+++ b/contrib/chatwork.php
@@ -77,7 +77,7 @@ before('deploy', 'chatwork:notify');
 If you want to notify about successful end of deployment add this too:
 
 ```php
-after('success', 'chatwork:notify:success');
+after('deploy:success', 'chatwork:notify:success');
 ```
 If you want to notify about failed deployment add this too:
 

--- a/docs/contrib/chatwork.md
+++ b/docs/contrib/chatwork.md
@@ -74,7 +74,7 @@ before('deploy', 'chatwork:notify');
 ```
 If you want to notify about successful end of deployment add this too:
 ```php
-after('success', 'chatwork:notify:success');
+after('deploy:success', 'chatwork:notify:success');
 ```
 If you want to notify about failed deployment add this too:
 ```php


### PR DESCRIPTION
since deployer 7.x the `success` task is named `deploy:success`