### PR TITLE
Report missing repository config in update-code task

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -74,6 +74,10 @@ task('deploy:update_code', function () {
     $repository = get('repository');
     $target = get('target');
 
+    if (empty($repository)) {
+        throw new ConfigurationException("Missing 'repository' configuration.");
+    }
+
     $targetWithDir = $target;
     if (!empty(get('sub_directory'))) {
         $targetWithDir .= ':{{sub_directory}}';


### PR DESCRIPTION
when upgrading from v6 to v7 - in which the `repository` config was not necessary, the `update-code` task might be invoked without this expected config beeing set.

report a proper exception for better DX