### PR TITLE
Update theme:dump with new non-interactive option

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -169,7 +169,7 @@ task('sw-build-without-db:get-remote-config', static function () {
         run('{{bin/php}} ./bin/console bundle:dump');
         download('{{current_path}}/var/plugins.json', './var/');
 
-        run('{{bin/php}} ./bin/console theme:dump');
+        run('{{bin/php}} ./bin/console theme:dump -n');
         download('{{current_path}}/files/theme-config', './files/');
     });
 });


### PR DESCRIPTION
- [ ] Bug fix #…?
- [ ] New feature?
- [x] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

Since some newer Shopware version, the `theme:dump` command is interactive by default and since 6.6.9.0, a non-interactive parameter was added: https://github.com/shopware/shopware/blob/v6.6.9.0/changelog/release-6-6-9-0/2024-11-21-theme-dump-interactive-part-should-be-optional.md

Without `-n`, the deploy fails.