### PR TITLE
Make default_selector a fallback rather than an override (#3950)

### DIFF
--- a/src/Command/SelectCommand.php
+++ b/src/Command/SelectCommand.php
@@ -51,7 +51,8 @@ abstract class SelectCommand extends Command
         if (!$output->isDecorated() && !defined('NO_ANSI')) {
             define('NO_ANSI', 'true');
         }
-        $selector = Deployer::get()->config->get('default_selector', $input->getArgument('selector'));
+        $selector = $input->getArgument('selector');
+        $selector = empty($selector) ? Deployer::get()->config->get('default_selector') : $selector;
         $selectExpression = is_array($selector) ? implode(',', $selector) : $selector;
 
         if (empty($selectExpression)) {


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

The `default_selector` config is acting like the supplied input parameter that overrides any defaults set. Any selector provided in the console command will be ignored because there's a `default_selector` config set that will always override. Fix this so that `default_selector` is a fallback, as intended, rather than an override.