### PR TITLE
Added: encode responses in the file server

### DIFF
--- a/recipe/provision/Caddyfile
+++ b/recipe/provision/Caddyfile
@@ -1,5 +1,6 @@
 {{domain}} {
   root * {{deploy_path}}/current/{{public_path}}
+  encode zstd gzip
   file_server
   php_fastcgi * unix//run/php/php{{php_version}}-fpm.sock {
     resolve_root_symlink
@@ -16,6 +17,7 @@
       expression {http.error.status_code} == 404
     }
     rewrite @404 /404.html
+    encode zstd gzip
     file_server {
       root /var/deployer
     }


### PR DESCRIPTION
I was kind of shocked to see that compression was not enabled in the server by default. Seems pretty important to me.

- [ ] Bug fix #…?
- [X] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?
