### PR TITLE
Lint sources on PHP 7.x via Github Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: [ '7.4' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: cs2pr, parallel-lint
+          extensions: mbstring, intl
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Lint sources
+        run: composer exec --no-interaction -- parallel-lint bin/ contrib/ recipe/ src/ tests/ --checkstyle | cs2pr

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,20 +22,5 @@ jobs:
           tools: cs2pr, parallel-lint
           extensions: mbstring, intl
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
       - name: Lint sources
         run: composer exec --no-interaction -- parallel-lint bin/ contrib/ recipe/ src/ tests/ --checkstyle | cs2pr

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: cs2pr, parallel-lint
-          extensions: mbstring, intl
 
       - name: Lint sources
         run: composer exec --no-interaction -- parallel-lint bin/ contrib/ recipe/ src/ tests/ --checkstyle | cs2pr

--- a/src/Component/PharUpdate/Update.php
+++ b/src/Component/PharUpdate/Update.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.0
+<?php
 
 declare(strict_types=1);
 
@@ -101,7 +101,7 @@ class Update
             );
         }
 
-        $mode = 0o755;
+        $mode = 0755;
 
         if (file_exists($file)) {
             $mode = fileperms($file) & 511;

--- a/src/Component/PharUpdate/Update.php
+++ b/src/Component/PharUpdate/Update.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 declare(strict_types=1);
 

--- a/src/Documentation/DocGen.php
+++ b/src/Documentation/DocGen.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 declare(strict_types=1);
 

--- a/tests/legacy/recipe/named_arguments.php
+++ b/tests/legacy/recipe/named_arguments.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Deployer;
 


### PR DESCRIPTION
adds a new Github Action workflow via lints against PHP 7.x to prevent problems like https://github.com/deployphp/deployer/discussions/3976 which got fixed in https://github.com/deployphp/deployer/commit/f1f7b6169a1b48d7f715a10e8eb8323703cb9ab7

the newly added check skips the following files, as these currently contain PHP8+ only syntax:
```
Script parallel-lint handling the __exec_command event returned with error code 1
Error: Parse error: syntax error, unexpected 'o755' (T_STRING), expecting ')' in src/Documentation/DocGen.php on line 311
Error: Parse error: syntax error, unexpected 'o755' (T_STRING) in src/Component/PharUpdate/Update.php on line 104
Error: Parse error: syntax error, unexpected ':', expecting ')' in tests/legacy/recipe/named_arguments.php on line 8
```