### PR TITLE
Remove duplicate Content-type header

### DIFF
--- a/contrib/grafana.php
+++ b/contrib/grafana.php
@@ -61,7 +61,6 @@ task('grafana:annotation', function () {
 
     Httpie::post($config['url'])
         ->header('Authorization', 'Bearer ' . $config['token'])
-        ->header('Content-type', 'application/json')
         ->jsonBody($params)
         ->send();
 });


### PR DESCRIPTION
The Grafana plugin is broken, because the generated request has two http header (Content-**t**ype and Content-**T**ype). The later one, it the correct header and its added by ```\Deployer\Utility\Httpie::jsonBody```

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
