### PR TITLE
Update avoid-php-fpm-reloading.md

### DIFF
--- a/docs/avoid-php-fpm-reloading.md
+++ b/docs/avoid-php-fpm-reloading.md
@@ -27,7 +27,7 @@ _current_ in the path, your server configured incorrectly.
 
 ## Fix for Nginx
 
-Nginx has special variable `$realpath_root`, use it to set up `SCRIPT_FILENAME`:
+Nginx has special variable `$realpath_root`, use it to set up `SCRIPT_FILENAME` and `DOCUMENT_ROOT`:
 
 ```diff
 location ~ \.php$ {
@@ -35,6 +35,8 @@ location ~ \.php$ {
   fastcgi_pass unix:/var/run/php/php-fpm.sock;
 - fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 + fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+- fastcgi_param DOCUMENT_ROOT $document_root;
++ fastcgi_param DOCUMENT_ROOT $realpath_root;
 }
 ```
 


### PR DESCRIPTION
I've also been setting `DOCUMENT_ROOT` to also include the fix. I'm sure `SCRIPT_FILENAME` is enough in most cases, but also setting `DOCUMENT_ROOT` would ensure the expectation in all scenarios.

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
