### PR TITLE
 Fix issue where stream read is terminated prematurely

### DIFF
--- a/src/Executor/Server.php
+++ b/src/Executor/Server.php
@@ -153,7 +153,7 @@ class Server
         while (($chunk = @fread($clientSocket, 1024)) !== false) {
             $request .= $chunk;
             if (strpos($request, "\r\n\r\n") !== false) {
-                break;
+                //break;
             }
         }
 

--- a/src/Executor/Server.php
+++ b/src/Executor/Server.php
@@ -150,10 +150,10 @@ class Server
     private function readClientRequest($clientSocket)
     {
         $request = '';
-        while (($chunk = @fread($clientSocket, 1024)) !== false) {
+        while (($chunk = @fread($clientSocket, 8192)) !== false) {
             $request .= $chunk;
             if (strpos($request, "\r\n\r\n") !== false) {
-                //break;
+                break;
             }
         }
 

--- a/src/Executor/Server.php
+++ b/src/Executor/Server.php
@@ -150,7 +150,7 @@ class Server
     private function readClientRequest($clientSocket)
     {
         $request = '';
-        while (($chunk = @fread($clientSocket, 8192)) !== false) {
+        while (($chunk = @fread($clientSocket, 16384)) !== false) {
             $request .= $chunk;
             if (strpos($request, "\r\n\r\n") !== false) {
                 break;


### PR DESCRIPTION
This should fix the issue described in: https://github.com/deployphp/deployer/discussions/3981

It also simplifies the code a bit.

I had this issue when the response get too big just before the deploy finishes. For example if you keep 10 or more releases. Then the read terminates after the first pass becuase there are two line breaks after the headers and before the payload JSON starts and thus the `strpos($request, "\r\n\r\n")` is triggered after the first iteration even if there are more data to read.