### PR TITLE
Fix performance of task "releases"

### DIFF
--- a/recipe/deploy/release.php
+++ b/recipe/deploy/release.php
@@ -179,14 +179,16 @@ task('releases', function () {
             } else {
                 $status = "<info>$release</info>";
             }
+            try {
+                $revision = run("cat releases/$release/REVISION");
+            } catch (\Throwable $e) {
+                $revision = 'unknown';
+            }
+        } else {
+            $revision = 'unknown';
         }
         if ($release === $currentRelease) {
             $status .= ' (current)';
-        }
-        try {
-            $revision = run("cat releases/$release/REVISION");
-        } catch (\Throwable $e) {
-            $revision = 'unknown';
         }
         $table[] = [
             $date->format("Y-m-d H:i:s"),


### PR DESCRIPTION
Fix performance of task `releases` by checking `cat releases/$release/REVISION` only for existing releases and not all past releases stored in `releases_log`.

A real example data to compare results.
In `releases_log` there are 160 releases logs.   
In `releases_list` there are 5 releases folders.

Before fix: 57 seconds.
After fix: 7 seconds.

- [x] Bug fix
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

