### PR TITLE
Disable the http:cache:warm:up step for Shopware 6.6+

### DIFF
--- a/docs/recipe/shopware.md
+++ b/docs/recipe/shopware.md
@@ -166,11 +166,23 @@ Please note that the files in `config/jwt/*` receive special attention in the `s
 ```
 
 
+### shopware_version
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L75)
+
+This sets the shopware version to the version of the shopware console command.
+
+```php title="Default value"
+$versionOutput = run('cd {{release_path}} && {{bin/console}} -V');
+preg_match('/(\d+\.\d+\.\d+\.\d+)/', $versionOutput, $matches);
+return $matches[0] ?? '6.6.0';
+```
+
+
 
 ## Tasks
 
 ### sw\:cache\:clear {#sw-cache-clear}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L75)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L82)
 
 
 
@@ -178,7 +190,7 @@ This task remotely executes the `cache:clear` console command on the target serv
 
 
 ### sw\:cache\:warmup {#sw-cache-warmup}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L81)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L88)
 
 
 
@@ -187,7 +199,7 @@ visits the website, doesn't have to wait for the cache to be built up.
 
 
 ### sw\:database\:migrate {#sw-database-migrate}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L87)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L98)
 
 
 
@@ -195,7 +207,7 @@ This task remotely executes the `database:migrate` console command on the target
 
 
 ### sw\:plugin\:refresh {#sw-plugin-refresh}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L91)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L102)
 
 
 
@@ -203,7 +215,7 @@ This task remotely executes the `database:migrate` console command on the target
 
 
 ### sw\:scheduled-task\:register {#sw-scheduled-task-register}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L95)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L106)
 
 
 
@@ -211,7 +223,7 @@ This task remotely executes the `database:migrate` console command on the target
 
 
 ### sw\:theme\:refresh {#sw-theme-refresh}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L99)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L110)
 
 
 
@@ -219,7 +231,7 @@ This task remotely executes the `database:migrate` console command on the target
 
 
 ### sw\:theme\:compile {#sw-theme-compile}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L105)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L116)
 
 
 
@@ -228,7 +240,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw\:plugin\:update\:all {#sw-plugin-update-all}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L117)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L128)
 
 
 
@@ -236,7 +248,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw\:writable\:jwt {#sw-writable-jwt}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L127)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L138)
 
 
 
@@ -244,7 +256,7 @@ to build the theme remotely instead of locally.
 
 
 ### sw\:deploy {#sw-deploy}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L134)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L145)
 
 
 
@@ -262,7 +274,7 @@ This task is group task which contains next tasks:
 
 
 ### deploy {#deploy}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L145)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L156)
 
 Deploys your project.
 
@@ -279,7 +291,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db\:get-remote-config {#sw-build-without-db-get-remote-config}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L164)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L175)
 
 
 
@@ -287,7 +299,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db\:build {#sw-build-without-db-build}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L177)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L188)
 
 
 
@@ -295,7 +307,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db {#sw-build-without-db}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L181)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L192)
 
 
 

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -71,6 +71,13 @@ set('writable_dirs', [
     'var',
 ]);
 
+// This sets the shopware version to the version of the shopware console command.
+set('shopware_version', function () {
+    $versionOutput = run('cd {{release_path}} && {{bin/console}} -V');
+    preg_match('/(\d+\.\d+\.\d+\.\d+)/', $versionOutput, $matches);
+    return $matches[0] ?? '6.6.0';
+});
+
 // This task remotely executes the `cache:clear` console command on the target server.
 task('sw:cache:clear', static function () {
     run('cd {{release_path}} && {{bin/console}} cache:clear --no-warmup');
@@ -80,7 +87,11 @@ task('sw:cache:clear', static function () {
 // visits the website, doesn't have to wait for the cache to be built up.
 task('sw:cache:warmup', static function () {
     run('cd {{release_path}} && {{bin/console}} cache:warmup');
-    run('cd {{release_path}} && {{bin/console}} http:cache:warm:up');
+
+    // Shopware 6.6+ dropped support for the http:cache:warmup command, so only execute it if the version is less than 6.6
+    if (version_compare(get('shopware_version'), '6.6.0') < 0) {
+        run('cd {{release_path}} && {{bin/console}} http:cache:warm:up');
+    }
 });
 
 // This task remotely executes the `database:migrate` console command on the target server.


### PR DESCRIPTION
We've seen a few complaints about how Shopware 6.6+ appeared to have dropped support for http:cache:warm:up. This is why we've added conditional logic to check the current shopware version, very similar to how Magento's version check works [as can be seen here](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L111).

The change in Shopware was loosely mentioned here: https://github.com/shopware/shopware/blob/932d232e999f06cf340ed00708047b9721b253b0/UPGRADE-6.6.md?plain=1#L1035

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
