### PR TITLE
Fix #4036: Escape shell argument when setting remote crontab

### DIFF
--- a/contrib/crontab.php
+++ b/contrib/crontab.php
@@ -24,6 +24,8 @@ add('crontab:jobs', [
 
 namespace Deployer;
 
+use function Deployer\Support\escape_shell_argument;
+
 // Get path to bin
 set('bin/crontab', function () {
     return which('crontab');
@@ -135,7 +137,7 @@ function setRemoteCrontab(array $lines): void
     }
 
     foreach ($lines as $line) {
-        run("echo '" . $line . "' >> $tmpCrontabPath");
+        run("echo " . escape_shell_argument($line) . " >> $tmpCrontabPath");
     }
 
     run("$sudo {{bin/crontab}} " . $tmpCrontabPath);

--- a/docs/contrib/crontab.md
+++ b/docs/contrib/crontab.md
@@ -29,21 +29,8 @@ add('crontab:jobs', [
 
 ## Configuration
 ### bin/crontab
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L28)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L30)
 
-Recipe for adding crontab jobs.
-This recipe creates a new section in the crontab file with the configured jobs.
-The section is identified by the *crontab:identifier* variable, by default the application name.
-## Configuration
-- *crontab:jobs* - An array of strings with crontab lines.
-## Usage
-```php
-require 'contrib/crontab.php';
-after('deploy:success', 'crontab:sync');
-add('crontab:jobs', [
-    '* * * * * cd {{current_path}} && {{bin/php}} artisan schedule:run >> /dev/null 2>&1',
-]);
-```
 Get path to bin
 
 ```php title="Default value"
@@ -52,7 +39,7 @@ return which('crontab');
 
 
 ### crontab:identifier
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L33)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L35)
 
 Set the identifier used in the crontab, application name by default
 
@@ -62,7 +49,7 @@ return get('application', 'application');
 
 
 ### crontab:use_sudo
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L38)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L40)
 
 Use sudo to run crontab. When running crontab with sudo, you can use the `-u` parameter to change a crontab for a different user.
 
@@ -75,7 +62,7 @@ false
 ## Tasks
 
 ### crontab\:sync {#crontab-sync}
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L41)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L43)
 
 Sync crontab jobs.
 
@@ -83,7 +70,7 @@ Sync crontab jobs.
 
 
 ### crontab\:remove {#crontab-remove}
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L85)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/crontab.php#L87)
 
 Remove crontab jobs.
 


### PR DESCRIPTION
- [x] Bug fix #4036 
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?