### PR TITLE
Fix check_remote: Check for REVISION file with archive update_code_st…

### DIFF
--- a/recipe/deploy/check_remote.php
+++ b/recipe/deploy/check_remote.php
@@ -17,10 +17,12 @@ task('deploy:check_remote', function () {
         if (!test('[ -f {{current_path}}/REVISION ]')) {
             return;
         }
+        $lastDeployedRevision = run('cat {{current_path}}/REVISION');
     } elseif (get('update_code_strategy') === 'clone') {
         if (!test('[ -d {{current_path}}/.git ]')) {
             return;
         }
+        $lastDeployedRevision = trim(run(sprintf('cd {{current_path}} && %s rev-parse HEAD', get('bin/git'))));
     } else {
         throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
     }
@@ -50,15 +52,6 @@ task('deploy:check_remote', function () {
 
     // Compare commit hashes. We use strpos to support short versions.
     $targetRevision = trim($targetRevision);
-
-    if (get('update_code_strategy') === 'archive') {
-        $lastDeployedRevision = run('cat {{current_path}}/REVISION');
-    } elseif (get('update_code_strategy') === 'clone') {
-        $lastDeployedRevision = trim(run(sprintf('cd {{current_path}} && %s rev-parse HEAD', get('bin/git'))));
-    } else {
-        throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
-    }
-
     if ($targetRevision && strpos($lastDeployedRevision, $targetRevision) === 0) {
         throw new GracefulShutdownException("Already up-to-date.");
     }

--- a/recipe/deploy/check_remote.php
+++ b/recipe/deploy/check_remote.php
@@ -2,6 +2,7 @@
 
 namespace Deployer;
 
+use Deployer\Exception\ConfigurationException;
 use Deployer\Exception\Exception;
 use Deployer\Exception\GracefulShutdownException;
 
@@ -12,8 +13,16 @@ task('deploy:check_remote', function () {
     $repository = get('repository');
 
     // Skip if there is no current deployment to compare
-    if (!test('[ -d {{current_path}}/.git ]')) {
-        return;
+    if (get('update_code_strategy') === 'archive') {
+        if (!test('[ -f {{current_path}}/REVISION ]')) {
+            return;
+        }
+    } elseif (get('update_code_strategy') === 'clone') {
+        if (!test('[ -d {{current_path}}/.git ]')) {
+            return;
+        }
+    } else {
+        throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
     }
 
     // Determine the hash of the remote revision about to be deployed
@@ -41,7 +50,15 @@ task('deploy:check_remote', function () {
 
     // Compare commit hashes. We use strpos to support short versions.
     $targetRevision = trim($targetRevision);
-    $lastDeployedRevision = run('cat {{current_path}}/REVISION');
+
+    if (get('update_code_strategy') === 'archive') {
+        $lastDeployedRevision = run('cat {{current_path}}/REVISION');
+    } elseif (get('update_code_strategy') === 'clone') {
+        $lastDeployedRevision = trim(run(sprintf('cd {{current_path}} && %s rev-parse HEAD', get('bin/git'))));
+    } else {
+        throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
+    }
+
     if ($targetRevision && strpos($lastDeployedRevision, $targetRevision) === 0) {
         throw new GracefulShutdownException("Already up-to-date.");
     }

--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -109,6 +109,9 @@ task('deploy:update_code', function () {
     // Copy to release_path.
     if (get('update_code_strategy') === 'archive') {
         run("$git archive $targetWithDir | tar -x -f - -C {{release_path}} 2>&1");
+        // Save git revision in REVISION file.
+        $rev = escapeshellarg(run("$git rev-list $target -1"));
+        run("echo $rev > {{release_path}}/REVISION");
     } elseif (get('update_code_strategy') === 'clone') {
         cd('{{release_path}}');
         run("$git clone -l $bare .");
@@ -117,8 +120,4 @@ task('deploy:update_code', function () {
     } else {
         throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
     }
-
-    // Save git revision in REVISION file.
-    $rev = escapeshellarg(run("$git rev-list $target -1"));
-    run("echo $rev > {{release_path}}/REVISION");
 });


### PR DESCRIPTION
…rategy and check for .git folder with clone update_code_strategy

With update_code_strategy === ‘archive’ there is no .git folder and therefore the check is never executed.

After updating from v6 to v7, an error occurs because the REVISION file does not yet exist.

My suggestion would be to use the REVISION file for update_code_strategy === ‘archive’ and the .git folder for update_code_strategy === ‘clone’.