### PR TITLE
Remove duplicate Content-type header (7.x)

### DIFF
--- a/contrib/grafana.php
+++ b/contrib/grafana.php
@@ -62,7 +62,6 @@ task('grafana:annotation', function () {
 
     Httpie::post($config['url'])
         ->header('Authorization', 'Bearer ' . $config['token'])
-        ->header('Content-type', 'application/json')
         ->jsonBody($params)
         ->send();
 });


### PR DESCRIPTION
Same change as in https://github.com/deployphp/deployer/pull/4026 for 7.x

- [ ] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
