### PR TITLE
Fix caddy import path resolution

### DIFF
--- a/recipe/provision/website.php
+++ b/recipe/provision/website.php
@@ -23,12 +23,13 @@ task('provision:server', function () {
 
 desc('Provision website');
 task('provision:website', function () {
+    set('deploy_path', run("realpath {{deploy_path}}"));
+
     $restoreBecome = become('deployer');
 
     run("[ -d {{deploy_path}} ] || mkdir -p {{deploy_path}}");
     run("chown -R deployer:deployer {{deploy_path}}");
 
-    set('deploy_path', run("realpath {{deploy_path}}"));
     cd('{{deploy_path}}');
 
     run("[ -d log ] || mkdir log");


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

In deploy.php having `deploy_path` set to `~/apps/domain.com` and `remote_user` set to ubuntu,
causes Caddy web server configuration to look for files in `/home/deployer/apps/domain.com` and `deploy` to clone the repo into `/home/ubuntu/apps/domain.com`.

The reason I moved `realpath` before become deployer to keep consisten home path with deploy script which does not require root.

Reproduce:
1) Provision with `dep provision -o become=root -o provision_user=ubuntu`
2) Deploy with `dep deploy`