### PR TITLE
`add-apt-repository` pre-requisites

### DIFF
--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -130,7 +130,10 @@ task('provision:update', function () {
     run('apt install -y curl gpg software-properties-common', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
 
     // PHP
-    run('LC_ALL=C.UTF-8 apt-add-repository ppa:ondrej/php -y', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
+    run('apt-add-repository ppa:ondrej/php -y', env: [
+        'DEBIAN_FRONTEND' => 'noninteractive',
+        'LC_ALL' => 'C.UTF-8',
+    ]);
 
     // Caddy
     run("curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor --yes -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg");

--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -123,6 +123,12 @@ desc('Adds repositories and update');
 task('provision:update', function () {
     set('remote_user', get('provision_user'));
 
+    // Update before installing anything
+    run('apt-get update', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
+
+    // Pre-requisites
+    run('apt install -y curl gpg software-properties-common', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
+
     // PHP
     run('apt-add-repository ppa:ondrej/php -y', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
 

--- a/recipe/provision.php
+++ b/recipe/provision.php
@@ -130,7 +130,7 @@ task('provision:update', function () {
     run('apt install -y curl gpg software-properties-common', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
 
     // PHP
-    run('apt-add-repository ppa:ondrej/php -y', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
+    run('LC_ALL=C.UTF-8 apt-add-repository ppa:ondrej/php -y', env: ['DEBIAN_FRONTEND' => 'noninteractive']);
 
     // Caddy
     run("curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor --yes -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg");


### PR DESCRIPTION
On a fresh VM, VPS or LXC, Ubuntu 24 doesn't have `gpg`, `add-apt-repository` and `curl`.

Shouldn't introduce any breaking change.
