### PR TITLE
Php composer parsing

### DIFF
--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -6,6 +6,11 @@ set('php_version', function () {
     $defaultPhpVersion = file_exists('composer.json')
         ? explode('|', preg_replace('/[^0-9.|]+/', '', json_decode(file_get_contents('composer.json'), true)['require']['php'] ?? '8.3'))[0]
         : '8.3';
+
+    if (count(($parts = explode('.', $defaultPhpVersion))) > 2) {
+        $defaultPhpVersion = "$parts[0].$parts[1]";
+    }
+
     return ask(' What PHP version to install? ', $defaultPhpVersion, ['5.6', '7.4', '8.0', '8.1', '8.2']);
 });
 

--- a/recipe/provision/php.php
+++ b/recipe/provision/php.php
@@ -11,7 +11,7 @@ set('php_version', function () {
         $defaultPhpVersion = "$parts[0].$parts[1]";
     }
 
-    return ask(' What PHP version to install? ', $defaultPhpVersion, ['5.6', '7.4', '8.0', '8.1', '8.2']);
+    return ask(' What PHP version to install? ', $defaultPhpVersion, ['5.6', '7.4', '8.0', '8.1', '8.2', '8.3']);
 });
 
 desc('Installs PHP packages');


### PR DESCRIPTION
`composer.json` can contain: `"php": "^8.2.0"`, in this case `php8.2.0` will be used for provisioning, and `php8.2.0-*` packages don't exist.

Also added `8.3` in the choices (as it was already the default)