### PR TITLE
`update_code` recipe - 3rd option `update_code_strategy` that loads submodule

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -45,6 +45,7 @@ set('target', function () {
 // Can be one of:
 // - archive
 // - clone (if you need the origin repository `.git` dir in your {{release_path}})
+// - close_submodule (same as `clone`, but running `git submodule init` and `git submodule update` as well)
 set('update_code_strategy', 'archive');
 
 // Sets environment variable _GIT_SSH_COMMAND_ for `git clone` command.
@@ -114,6 +115,13 @@ task('deploy:update_code', function () {
         run("$git clone -l $bare .");
         run("$git remote set-url origin $repository", env: $env);
         run("$git checkout --force $target");
+    } elseif (get('update_code_strategy') === 'clone_submodule') {
+        cd('{{release_path}}');
+        run("$git clone -l $bare .");
+        run("$git remote set-url origin $repository", env: $env);
+        run("$git checkout --force $target");
+        run("$git submodule init");
+        run("$git submodule update");
     } else {
         throw new ConfigurationException(parse("Unknown `update_code_strategy` option: {{update_code_strategy}}."));
     }


### PR DESCRIPTION
This adds the ability to use submodules with `update_code` set to `clonse_submodule` while staying backwards compatible.

Issue: <https://github.com/deployphp/deployer/issues/2802>

[Using submodules were possible in Deployer 6 but not 7](https://github.com/deployphp/deployer/issues/148#issuecomment-2047203925) and could be reintroduced like this.

- [ ] Bug fix 
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

> Please, regenerate docs by running next command:
> $ php bin/docgen