### PR TITLE
Add missing horizon tasks

### DIFF
--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -444,6 +444,14 @@ Deletes metrics for all jobs and queues.
 
 
 
+### artisan\:horizon\:snapshot {#artisan-horizon-snapshot}
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L218)
+
+Stores a snapshot of the queue metrics.
+
+
+
+
 ### artisan\:schedule\:interrupt {#artisan-schedule-interrupt}
 [Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L225)
 

--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -428,8 +428,24 @@ Publish all of the Horizon resources.
 
 
 
+### artisan\:horizon\:supervisors {#artisan-horizon-supervisors}
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L212)
+
+Lists all of the supervisors.
+
+
+
+
+### artisan\:horizon\:clear-metrics {#artisan-horizon-clear-metrics}
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L215)
+
+Deletes metrics for all jobs and queues.
+
+
+
+
 ### artisan\:schedule\:interrupt {#artisan-schedule-interrupt}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L216)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L225)
 
 Interrupt in-progress schedule:run invocations.
 
@@ -437,7 +453,7 @@ Scheduler.
 
 
 ### artisan\:telescope\:clear {#artisan-telescope-clear}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L223)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L232)
 
 Clears all entries from Telescope.
 
@@ -445,7 +461,7 @@ Telescope.
 
 
 ### artisan\:telescope\:prune {#artisan-telescope-prune}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L226)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L235)
 
 Prunes stale entries from the Telescope database.
 
@@ -453,7 +469,7 @@ Prunes stale entries from the Telescope database.
 
 
 ### artisan\:octane {#artisan-octane}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L233)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L242)
 
 Starts the octane server.
 
@@ -461,7 +477,7 @@ Octane.
 
 
 ### artisan\:octane\:reload {#artisan-octane-reload}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L236)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L245)
 
 Reloads the octane server.
 
@@ -469,7 +485,7 @@ Reloads the octane server.
 
 
 ### artisan\:octane\:stop {#artisan-octane-stop}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L239)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L248)
 
 Stops the octane server.
 
@@ -477,7 +493,7 @@ Stops the octane server.
 
 
 ### artisan\:octane\:status {#artisan-octane-status}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L242)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L251)
 
 Check the status of the octane server.
 
@@ -485,7 +501,7 @@ Check the status of the octane server.
 
 
 ### artisan\:nova\:publish {#artisan-nova-publish}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L249)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L258)
 
 Publish all of the Laravel Nova resources.
 
@@ -493,7 +509,7 @@ Nova.
 
 
 ### artisan\:reverb\:start {#artisan-reverb-start}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L256)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L265)
 
 Starts the Reverb server.
 
@@ -501,7 +517,7 @@ Reverb.
 
 
 ### artisan\:reverb\:restart {#artisan-reverb-restart}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L259)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L268)
 
 Restarts the Reverb server.
 
@@ -509,7 +525,7 @@ Restarts the Reverb server.
 
 
 ### artisan\:pulse\:check {#artisan-pulse-check}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L266)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L275)
 
 Starts the Pulse server.
 
@@ -517,7 +533,7 @@ Pulse.
 
 
 ### artisan\:pulse\:restart {#artisan-pulse-restart}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L269)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L278)
 
 Restarts the Pulse server.
 
@@ -525,7 +541,7 @@ Restarts the Pulse server.
 
 
 ### artisan\:pulse\:purge {#artisan-pulse-purge}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L272)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L281)
 
 Purges all Pulse data from storage.
 
@@ -533,7 +549,7 @@ Purges all Pulse data from storage.
 
 
 ### artisan\:pulse\:work {#artisan-pulse-work}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L275)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L284)
 
 Process incoming Pulse data from the ingest stream.
 
@@ -541,7 +557,7 @@ Process incoming Pulse data from the ingest stream.
 
 
 ### deploy {#deploy}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L281)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L290)
 
 Deploys your project.
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -205,11 +205,11 @@ task('artisan:horizon:status', artisan('horizon:status', ['showOutput']));
 desc('Terminates the master supervisor so it can be restarted');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
 
-desc('Lists all of the supervisors');
-task('artisan:horizon:supervisors', artisan('horizon:supervisors', ['showOutput']));
-
 desc('Publish all of the Horizon resources');
 task('artisan:horizon:publish', artisan('horizon:publish'));
+
+desc('Lists all of the supervisors');
+task('artisan:horizon:supervisors', artisan('horizon:supervisors', ['showOutput']));
 
 desc('Deletes metrics for all jobs and queues');
 task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -187,14 +187,17 @@ task('artisan:horizon', artisan('horizon'));
 desc('Deletes all of the jobs from the specified queue');
 task('artisan:horizon:clear', artisan('horizon:clear --force'));
 
-desc('Instructs the master supervisor to continue processing jobs');
-task('artisan:horizon:continue', artisan('horizon:continue'));
+desc('Deletes metrics for all jobs and queues');
+task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));
 
 desc('Lists all of the deployed machines');
 task('artisan:horizon:list', artisan('horizon:list', ['showOutput']));
 
 desc('Pauses the master supervisor');
-task('artisan:horizon:pause', artisan('horizon:pause'));
+task('artisan:horizon:pause ', artisan('horizon:pause'));
+
+desc('Instructs the master supervisor to continue processing jobs');
+task('artisan:horizon:continue', artisan('horizon:continue'));
 
 desc('Terminates any rogue Horizon processes');
 task('artisan:horizon:purge', artisan('horizon:purge'));
@@ -205,8 +208,14 @@ task('artisan:horizon:status', artisan('horizon:status', ['showOutput']));
 desc('Terminates the master supervisor so it can be restarted');
 task('artisan:horizon:terminate', artisan('horizon:terminate'));
 
+desc('Lists all of the supervisors');
+task('artisan:horizon:supervisors', artisan('horizon:supervisors', ['showOutput']));
+
 desc('Publish all of the Horizon resources');
 task('artisan:horizon:publish', artisan('horizon:publish'));
+
+desc('Stores a snapshot of the queue metrics');
+task('horizon:snapshot  ', artisan('horizon:snapshot'));
 
 /*
  * Scheduler.

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -190,14 +190,11 @@ task('artisan:horizon:clear', artisan('horizon:clear --force'));
 desc('Instructs the master supervisor to continue processing jobs');
 task('artisan:horizon:continue', artisan('horizon:continue'));
 
-desc('Deletes metrics for all jobs and queues');
-task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));
-
 desc('Lists all of the deployed machines');
 task('artisan:horizon:list', artisan('horizon:list', ['showOutput']));
 
 desc('Pauses the master supervisor');
-task('artisan:horizon:pause ', artisan('horizon:pause'));
+task('artisan:horizon:pause', artisan('horizon:pause'));
 
 desc('Terminates any rogue Horizon processes');
 task('artisan:horizon:purge', artisan('horizon:purge'));
@@ -213,6 +210,9 @@ task('artisan:horizon:supervisors', artisan('horizon:supervisors', ['showOutput'
 
 desc('Publish all of the Horizon resources');
 task('artisan:horizon:publish', artisan('horizon:publish'));
+
+desc('Deletes metrics for all jobs and queues');
+task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));
 
 desc('Stores a snapshot of the queue metrics');
 task('horizon:snapshot  ', artisan('horizon:snapshot'));

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -187,6 +187,9 @@ task('artisan:horizon', artisan('horizon'));
 desc('Deletes all of the jobs from the specified queue');
 task('artisan:horizon:clear', artisan('horizon:clear --force'));
 
+desc('Instructs the master supervisor to continue processing jobs');
+task('artisan:horizon:continue', artisan('horizon:continue'));
+
 desc('Deletes metrics for all jobs and queues');
 task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));
 
@@ -195,9 +198,6 @@ task('artisan:horizon:list', artisan('horizon:list', ['showOutput']));
 
 desc('Pauses the master supervisor');
 task('artisan:horizon:pause ', artisan('horizon:pause'));
-
-desc('Instructs the master supervisor to continue processing jobs');
-task('artisan:horizon:continue', artisan('horizon:continue'));
 
 desc('Terminates any rogue Horizon processes');
 task('artisan:horizon:purge', artisan('horizon:purge'));

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -215,7 +215,7 @@ desc('Deletes metrics for all jobs and queues');
 task('artisan:horizon:clear-metrics', artisan('horizon:clear-metrics'));
 
 desc('Stores a snapshot of the queue metrics');
-task('horizon:snapshot  ', artisan('horizon:snapshot'));
+task('artisan:horizon:snapshot', artisan('horizon:snapshot'));
 
 /*
  * Scheduler.


### PR DESCRIPTION
I have added the following missing horizon tasks, to laravel recipe:

- `artisan:horizon:supervisors` : Lists all of the supervisors
- `artisan:horizon:clear-metrics`: Deletes metrics for all jobs and queues
- `artisan:horizon:snapshot`: Stores a snapshot of the queue metrics
