### PR TITLE
Bugfix dotenv test in laravel.php

### DIFF
--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -58,12 +58,15 @@ function artisan($command, $options = [])
             return;
         }
 
+        // Get the dotenv path or use default.
+        $dotenv = get('dotenv', '{{release_or_current_path}}/.env');
+
         // Ensure we warn or fail when a command relies on the ".env" file.
-        if (in_array('failIfNoEnv', $options) && !test('[ -s {{release_or_current_path}}/.env ]')) {
+        if (in_array('failIfNoEnv', $options) && !test("[ -s $dotenv ]")) {
             throw new \Exception('Your .env file is empty! Cannot proceed.');
         }
 
-        if (in_array('skipIfNoEnv', $options) && !test('[ -s {{release_or_current_path}}/.env ]')) {
+        if (in_array('skipIfNoEnv', $options) && !test("[ -s $dotenv ]")) {
             warning("Your .env file is empty! Skipping...</>");
             return;
         }


### PR DESCRIPTION
The test to check if .env file is present was not checking if the dotenv variable was set and always used the default. Added getter for dotenv variable.