### PR TITLE
Allow Continue on Failure on Teams Notifications

### DIFF
--- a/contrib/ms-teams.php
+++ b/contrib/ms-teams.php
@@ -80,6 +80,9 @@ set('teams_title', function () {
     return get('application', 'Project');
 });
 
+// Allow Continue on Failure
+set('teams_failure_continue', false);
+
 // Deploy message
 set('teams_text', '_{{user}}_ deploying `{{what}}` to *{{where}}*');
 set('teams_success_text', 'Deploy to *{{where}}* successful');
@@ -97,10 +100,19 @@ task('teams:notify', function () {
         return;
     }
 
-    Httpie::post(get('teams_webhook'))->jsonBody([
-        "themeColor" => get('teams_color'),
-        'text'       => get('teams_text'),
-    ])->send();
+    try {
+        Httpie::post(get('teams_webhook'))->jsonBody([
+            "themeColor" => get('teams_color'),
+            'text'       => get('teams_text'),
+        ])->send();
+    } catch (\Exception $e) {
+        if (get('teams_failure_continue', false)) {
+            warning('Error sending Teams Notification: ' . $e->getMessage());
+        } else {
+            throw $e;
+        }
+    }
+
 })
     ->once()
     ->hidden();
@@ -112,10 +124,18 @@ task('teams:notify:success', function () {
         return;
     }
 
-    Httpie::post(get('teams_webhook'))->jsonBody([
-        "themeColor" => get('teams_success_color'),
-        'text'       => get('teams_success_text'),
-    ])->send();
+    try {
+        Httpie::post(get('teams_webhook'))->jsonBody([
+            "themeColor" => get('teams_success_color'),
+            'text'       => get('teams_success_text'),
+        ])->send();
+    } catch (\Exception $e) {
+        if (get('teams_failure_continue', false)) {
+            warning('Error sending Teams Notification: ' . $e->getMessage());
+        } else {
+            throw $e;
+        }
+    }
 })
     ->once()
     ->hidden();
@@ -127,10 +147,18 @@ task('teams:notify:failure', function () {
         return;
     }
 
-    Httpie::post(get('teams_webhook'))->jsonBody([
-        "themeColor" => get('teams_failure_color'),
-        'text'       => get('teams_failure_text'),
-    ])->send();
+    try {
+        Httpie::post(get('teams_webhook'))->jsonBody([
+            "themeColor" => get('teams_failure_color'),
+            'text'       => get('teams_failure_text'),
+        ])->send();
+    } catch (\Exception $e) {
+        if (get('teams_failure_continue', false)) {
+            warning('Error sending Teams Notification: ' . $e->getMessage());
+        } else {
+            throw $e;
+        }
+    }
 })
     ->once()
     ->hidden();

--- a/docs/contrib/ms-teams.md
+++ b/docs/contrib/ms-teams.md
@@ -41,6 +41,10 @@ after('deploy:failed', 'teams:notify:failure');
   set('teams_webhook', 'https://outlook.office.com/webhook/...');
   ```
 - `teams_title` – the title of application, default `{{application}}`
+- `teams_failure_continue` - allow deploys to continue on failure
+  ```
+  set('teams_failure_continue', true);
+  ```
 - `teams_text` – notification message template, markdown supported
   ```
   set('teams_text', '_{{user}}_ deploying `{{what}}` to *{{where}}*');
@@ -56,6 +60,7 @@ after('deploy:failed', 'teams:notify:failure');
 - `teams_color` – color's attachment
 - `teams_success_color` – success color's attachment
 - `teams_failure_color` – failure color's attachment
+
 ## Usage
 If you want to notify only about beginning of deployment add this line only:
 ```php
@@ -79,6 +84,15 @@ Title of project
 
 ```php title="Default value"
 return get('application', 'Project');
+```
+
+### teams_failure_continue
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/ms-teams.php#L79)
+
+Allow Continue on Failure
+
+```php title="Continue on Failure"
+return get('teams_failure_continue', false)
 ```
 
 


### PR DESCRIPTION
Since a Teams notification is not necessarily an essential part of a deploy, we should allow users to continue the deploy should a notification fail to send.

- [No] Bug fix #…?
- [Yes] New feature?
- [No] BC breaks?
- [Yes ] Tests added?
- [Yes] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
