### PR TITLE
Use current defined env in dump-env

### DIFF
--- a/recipe/symfony.php
+++ b/recipe/symfony.php
@@ -66,7 +66,7 @@ task('deploy:cache:clear', function () {
 desc('Optimize environment variables');
 task('deploy:dump-env', function () {
     within('{{release_or_current_path}}', function () {
-        run('{{bin/composer}} dump-env "${APP_ENV:-prod}"');
+        run('{{bin/composer}} dump-env');
     });
 });
 


### PR DESCRIPTION
- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen

The dump-env use correctly the current defined env in the `.env.local` file. While in maybe 99% the cases prod is the only envs there might be application having qa, stage, ... envs and in most cases the .env file is not parsed during deployer process, but flex correctly use the defined env from the .env.local file. So this is not needed and can even end in unexpected 
