### PR TITLE
[SHOPWARE] Fixed edge case where `config/jwt/` folder is empty and shell expansion fails.

### DIFF
--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -141,7 +141,7 @@ task('sw:writable:jwt', static function () {
     if (!test('[ -d {{deploy_path}}/config/jwt/ ]')) {
         return;
     }
-    run('cd {{release_path}} && chmod -R 660 config/jwt/*');
+    run('cd {{release_path}} && find config/jwt/ -type f -exec chmod -R 660 {} +');
 });
 
 /**


### PR DESCRIPTION
I ran into an issue where the `sw:writable:jwt` task fails whenever the `config/jwt` folder does not contain any visible files.

From my understanding this is because shells by default do not have the "nullglob" option set. So when it tries to glob the config/jwt directory for files, it does not find any and returns the literal string containing the asterisk. This leads to the error you see below:

```
...
task sw:writable:jwt
[localhost]  error  in deploy.php on line 56:
[localhost] run cd /var/www/example.com/releases/2025-07-30-001 && chmod -R 660 config/jwt/*
[localhost] err chmod: cannot access 'config/jwt/*': No such file or directory
[localhost] exit code 1 (General error)
```

One way to fix this is to use the `find` command instead, which is the change I propose we merge in.

---

- [x] Bug fix (no issue opened)
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
