### PR TITLE
fix: ssh key file permissions for provisioned user

### DIFF
--- a/recipe/provision/user.php
+++ b/recipe/provision/user.php
@@ -40,11 +40,11 @@ task('provision:user', function () {
 
         // Create ssh key if not already exists.
         run('ssh-keygen -f /home/deployer/.ssh/id_ed25519 -t ed25519 -N ""');
-        run('chmod 700 /home/deployer/.ssh/id_ed25519');
 
         try {
             run('chown -R deployer:deployer /home/deployer');
             run('chmod -R 755 /home/deployer');
+            run('chmod 700 /home/deployer/.ssh/id_ed25519');
         } catch (\Throwable $e) {
             warning($e->getMessage());
         }


### PR DESCRIPTION
- [x] Bug fix

When the deployer user is provisioned, the SSH key file permissions are overwritten by the subsequent recursive chown command.

The permission modification has been moved inside the try/catch block after the recursive command.