### PR TITLE
Fix formatting in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,8 +13,8 @@ First, [install Deployer](installation.md). Once installed, navigate to your pro
 dep init
 ```
 
-Deployer will prompt you with a series of questions. After completing them, you'll have a **deploy.php** or *
-*deploy.yaml** file—your deployment recipe. This file defines hosts, tasks, and dependencies on other recipes.
+Deployer will prompt you with a series of questions. After completing them, you'll have a **deploy.php** or 
+**deploy.yaml** file—your deployment recipe. This file defines hosts, tasks, and dependencies on other recipes.
 Framework-specific recipes provided by Deployer are based on the [common](recipe/common.md) recipe.
 
 ---


### PR DESCRIPTION
This pull request makes a minor formatting correction in the documentation to improve readability. Specifically, it fixes the formatting of the file names in the deployment recipe section.

* Fixed formatting in `docs/getting-started.md` by removing an unnecessary line break and correcting the emphasis for `deploy.php` and `deploy.yaml` file names.

Currently it’s formatted incorrectly:
![IMG_0049](https://github.com/user-attachments/assets/1260464b-c068-4591-98d8-29adce6b1cde)
