### PR TITLE
Enhance documentation with dynamic config example

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -246,23 +246,25 @@ If you need to create a new configuration option based on the overridden one, us
 
 set('dir_name', 'test');
 
+// calling get during recipe initialization will give you the original value defined above
+set('uses_original_dir_name', '/path/to/' . get('dir_name'));
+
+// use dynamic configuration syntax if you need to get a value passed via -o option
 set('uses_overridden_dir_name', function () {
     return '/path/to/' . get('dir_name');
 });
 
-set('uses_original_dir_name', '/path/to/' . get('dir_name'));
-
 task('my_task', function () {
-    writeln('Path: {{uses_overridden_dir_name}}');
     writeln('Path: {{uses_original_dir_name}}');
+    writeln('Path: {{uses_overridden_dir_name}}');
 });
 ```
 
 ```sh
 $ dep my_task deployer.org -v -o dir_name="prod"
 task my_task
-[deployer.org] Path: /path/to/prod
 [deployer.org] Path: /path/to/test
+[deployer.org] Path: /path/to/prod
 ```
 :::
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -239,6 +239,33 @@ task my_task
 
 Since `current_date` is overridden, the callback is never executed.
 
+:::note
+If you need to create a new configuration option based on the overridden one, use dynamic configuration syntax:
+
+```php
+
+set('dir_name', 'test');
+
+set('uses_overridden_dir_name', function () {
+    return '/path/to/' . get('dir_name');
+});
+
+set('uses_original_dir_name', '/path/to/' . get('dir_name'));
+
+task('my_task', function () {
+    writeln('Path: {{uses_overridden_dir_name}}');
+    writeln('Path: {{uses_original_dir_name}}');
+});
+```
+
+```sh
+$ dep my_task deployer.org -v -o dir_name="prod"
+task my_task
+[deployer.org] Path: /path/to/prod
+[deployer.org] Path: /path/to/test
+```
+:::
+
 ---
 
 By now, you should have a solid understanding of Deployer’s basics, from defining tasks and hosts to working with


### PR DESCRIPTION
This pull request improves the documentation in `docs/basics.md` by adding a helpful note on dynamic configuration syntax. The new section demonstrates how to create configuration options that depend on overridden values.
