### PR TITLE
Fixed Collection->remove incorrect throw

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -45,7 +45,6 @@ class Collection implements Countable, IteratorAggregate
         if ($this->has($name)) {
             unset($this->values[$name]);
         }
-        throw $this->notFound($name);
     }
 
     public function count(): int


### PR DESCRIPTION
The remove function always throws an error, even when the name is valid.