### PR TITLE
feat: guard Deployer singleton before Host construction

### DIFF
--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -174,11 +174,6 @@ class Deployer extends Container
         return self::$instance;
     }
 
-    public static function hasInstance(): bool
-    {
-        return self::$instance !== null;
-    }
-
     /**
      * @internal For tests that need a clean Deployer singleton between cases.
      */

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -66,7 +66,7 @@ use Throwable;
  */
 class Deployer extends Container
 {
-    private static Deployer $instance;
+    private static ?self $instance = null;
 
     public function __construct(Application $console)
     {
@@ -167,7 +167,24 @@ class Deployer extends Container
 
     public static function get(): self
     {
+        if (self::$instance === null) {
+            throw new \RuntimeException('Deployer is not initialized.');
+        }
+
         return self::$instance;
+    }
+
+    public static function hasInstance(): bool
+    {
+        return self::$instance !== null;
+    }
+
+    /**
+     * @internal For tests that need a clean Deployer singleton between cases.
+     */
+    public static function resetInstance(): void
+    {
+        self::$instance = null;
     }
 
     public function init(): void

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -28,10 +28,7 @@ class Host
 
     public function __construct(string $hostname)
     {
-        $parent = null;
-        if (Deployer::hasInstance()) {
-            $parent = Deployer::get()->config;
-        }
+        $parent = Deployer::get()->config;
         $this->config = new Configuration($parent);
         $this->set('#alias', $hostname);
         $this->set('hostname', preg_replace('/\/.+$/', '', $hostname));

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -29,7 +29,7 @@ class Host
     public function __construct(string $hostname)
     {
         $parent = null;
-        if (Deployer::get()) {
+        if (Deployer::hasInstance()) {
             $parent = Deployer::get()->config;
         }
         $this->config = new Configuration($parent);

--- a/tests/phpstan-baseline.neon
+++ b/tests/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: ../src/Command/BlackjackCommand.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: ../src/Host/Host.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: ../src/Import/YamlRecipe.php

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -8,10 +8,16 @@
 namespace Deployer\Host;
 
 use Deployer\Configuration;
+use Deployer\Deployer;
 use PHPUnit\Framework\TestCase;
 
 class HostTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Deployer::resetInstance();
+    }
+
     public function testHost()
     {
         $host = new Host('host');

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -10,9 +10,15 @@ namespace Deployer\Host;
 use Deployer\Configuration;
 use Deployer\Deployer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 
 class HostTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        new Deployer(new Application());
+    }
+
     protected function tearDown(): void
     {
         Deployer::resetInstance();

--- a/tests/src/Selector/SelectorTest.php
+++ b/tests/src/Selector/SelectorTest.php
@@ -2,12 +2,24 @@
 
 namespace Deployer\Selector;
 
+use Deployer\Deployer;
 use Deployer\Host\Host;
 use Deployer\Host\HostCollection;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 
 class SelectorTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        new Deployer(new Application());
+    }
+
+    protected function tearDown(): void
+    {
+        Deployer::resetInstance();
+    }
+
     public function testSelectHosts()
     {
         $prod = (new Host('prod.domain.com'))->set('labels', ['stage' => 'prod']);

--- a/tests/src/Task/TaskTest.php
+++ b/tests/src/Task/TaskTest.php
@@ -7,8 +7,12 @@
 
 namespace Deployer\Task;
 
+use Deployer\Deployer;
 use Deployer\Host\Host;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Output\Output;
 
 use function Deployer\invoke;
 use function Deployer\task;
@@ -20,9 +24,18 @@ interface MockableCallback
 
 class TaskTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $console = new Application();
+        $deployer = new Deployer($console);
+        $deployer['input'] = $this->createStub(Input::class);
+        $deployer['output'] = $this->createStub(Output::class);
+    }
+
     protected function tearDown(): void
     {
         StubTask::$runned = 0;
+        Deployer::resetInstance();
     }
 
     public function testTask()


### PR DESCRIPTION
- [ ] ~Bug fix #…?~
- [x] New feature?
- [x] BC breaks? -> maybe, because the exception changed
- [x] Tests added?
- [x] Docs added? -> comments in the code

### Background
`Host::__construct` used `Deployer::get()` to decide whether to inherit the global recipe config. With a typed, uninitialized static `$instance`, **PHP 8+ throws when get() reads the property before new Deployer(...) has run**. That can break HostTest (and any code path that builds a Host without a bootstrapped singleton).

### Solution
#### Deployer
- Store the singleton as ?self (default null). get() throws a clear RuntimeException if not initialized.
- Add resetInstance() (@internal) for tests that need a clean singleton between cases.

#### Host
Always wire the parent Configuration from Deployer::get()->config. If Deployer is not initialized, get() throws — there is no “host without deployer” path anymore (as discussed in review).

#### Tests
- Tests that construct Host bootstrap Deployer first (e.g. new Deployer(new Application())), and tearDown() still calls Deployer::resetInstance() where needed for isolation.
- Where invoke() / logger paths run, the test Deployer also has input and output set on the container (same idea as other tests that touch the full stack).

#### Tooling
- PHPStan baseline: remove the obsolete ignore that applied to the old Host conditional.

### Behavior / compatibility
- Normal runtime (recipe always creates Deployer before hosts): unchanged.
- Calling Deployer::get() with no instance: invalid; error is a RuntimeException instead of a PHP engine error on an uninitialized typed static.

#### New
new Host(...) without a prior Deployer now always fails fast with that same initialization error instead of silently using a Configuration with no deployer parent.
