### PR TITLE
Update docker image due to missing/depracated dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM php:8.4-cli-alpine
 
-RUN apk add --no-cache bash git openssh-client rsync zip unzip libzip-dev \
+RUN apk update && apk add --no-cache linux-headers bash git openssh-client rsync zip unzip libzip-dev curl-dev
 
-RUN docker-php-ext-install mbstring mcrypt pcntl sockets curl zip
+RUN docker-php-ext-install pcntl sockets curl zip
 
 COPY --chmod=755 deployer.phar /bin/dep
 


### PR DESCRIPTION
The current docker image fails because of the missing sockets extension for PHP.

For successfull build and execution "linux-headers" & "curl-dev" needed to be added.

I build a custom image for v8.0.0-rc, see [featdd/deployerphp:v8.0.0-rc](https://hub.docker.com/repository/docker/featdd/deployerphp/tags/v8.0.0-rc) and now it works fine for me.