### PR TITLE
Update docker base image to PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli-alpine
+FROM php:8.5-cli-alpine
 
 RUN set -eux; \
     apk add --no-cache \


### PR DESCRIPTION
This just changes the base image to update PHP to 8.5.

The new image builds without any errors and contains all necessary extensions, see: [featdd/deployerphp:v8.0.0-rc-8.5](https://hub.docker.com/repository/docker/featdd/deployerphp/tags/v8.0.0-rc-8.5)