### PR TITLE
Feat: add thin typed wrappers for set('path', ...) and get('path', ...)

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -76,6 +76,16 @@ host('example.org')
     ->setRemoteUser('deployer');
 ```
 
+### Path
+
+You can store an arbitrary path string in the `path` config (for example to reuse in `{{path}}` placeholders). On a host, prefer `setPath()` over `set('path', …)` so the value is typed as a string and IDEs or static analysis can catch mistakes such as passing a number, which the generic `set()` method does not flag. In the recipe file (outside a host definition), use the global [set()](api.md#set) function—for example `set('path', '/var/www/myapp')`.
+
+```php
+host('example.org')->setPath('/var/www/myapp');
+
+set('path', '/var/www/myapp');
+```
+
 ---
 
 ## Host Labels
@@ -128,6 +138,7 @@ set('default_selector', "stage=prod&role=web,role=special");
 | **`port`**             | SSH port. Default is `22`.                                                                     |
 | **`config_file`**      | SSH config file location. Default is `~/.ssh/config`.                                          |
 | **`identity_file`**    | SSH private key file. E.g., `~/.ssh/id_rsa`.                                                   |
+| **`path`**             | Optional path string for custom use (e.g. `{{path}}`). Use `setPath()` on the host for a typed setter. |
 | **`forward_agent`**    | Enable SSH agent forwarding. Default is `true`.                                                |
 | **`ssh_multiplexing`** | Enable SSH multiplexing for performance. Default is `true`.                                    |
 | **`shell`**            | Shell to use. Default is `bash -ls`.                                                           |

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -78,10 +78,10 @@ host('example.org')
 
 ### Path
 
-You can store an arbitrary path string in the `path` config (for example to reuse in `{{path}}` placeholders). On a host, prefer `setPath()` over `set('path', …)` so the value is typed as a string and IDEs or static analysis can catch mistakes such as passing a number, which the generic `set()` method does not flag. In the recipe file (outside a host definition), use the global [set()](api.md#set) function—for example `set('path', '/var/www/myapp')`.
+You can store an arbitrary path string in the `path` config (for example to reuse in `{{path}}` placeholders). On a host, prefer `setPathConfig()` over `set('path', …)` so the name reflects that this is the `path` *configuration* value (and not, for example, the deployment root), and so the value is typed as a string. IDEs or static analysis can then catch mistakes such as passing a number, which the generic `set()` method does not flag. In the recipe file (outside a host definition), use the global [set()](api.md#set) function—for example `set('path', '/var/www/myapp')`.
 
 ```php
-host('example.org')->setPath('/var/www/myapp');
+host('example.org')->setPathConfig('/var/www/myapp');
 
 set('path', '/var/www/myapp');
 ```
@@ -138,7 +138,7 @@ set('default_selector', "stage=prod&role=web,role=special");
 | **`port`**             | SSH port. Default is `22`.                                                                     |
 | **`config_file`**      | SSH config file location. Default is `~/.ssh/config`.                                          |
 | **`identity_file`**    | SSH private key file. E.g., `~/.ssh/id_rsa`.                                                   |
-| **`path`**             | Optional path string for custom use (e.g. `{{path}}`). Use `setPath()` on the host for a typed setter. |
+| **`path`**             | Optional path string for custom use (e.g. `{{path}}`). Use `setPathConfig()` on the host for a typed setter. |
 | **`forward_agent`**    | Enable SSH agent forwarding. Default is `true`.                                                |
 | **`ssh_multiplexing`** | Enable SSH multiplexing for performance. Default is `true`.                                    |
 | **`shell`**            | Shell to use. Default is `bash -ls`.                                                           |

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -123,6 +123,17 @@ class Host
         return $this->config->get('port', null);
     }
 
+    public function setPath(string $path): self
+    {
+        $this->config->set('path', $path);
+        return $this;
+    }
+
+    public function getPath(): ?string
+    {
+        return $this->config->get('path', null);
+    }
+
     public function setConfigFile(string $file): self
     {
         $this->config->set('config_file', $file);

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -123,17 +123,6 @@ class Host
         return $this->config->get('port', null);
     }
 
-    public function setPath(string $path): self
-    {
-        $this->config->set('path', $path);
-        return $this;
-    }
-
-    public function getPath(): ?string
-    {
-        return $this->config->get('path', null);
-    }
-
     public function setConfigFile(string $file): self
     {
         $this->config->set('config_file', $file);
@@ -209,6 +198,29 @@ class Host
     public function getDeployPath(): ?string
     {
         return $this->config->get('deploy_path', null);
+    }
+
+    /**
+     * Set the optional `path` configuration value (the `path` key).
+     *
+     * Use it for recipe-defined or host-specific data exposed as `{{path}}` in task strings. This is
+     * not the remote deployment root; for that, use `setDeployPath()`.
+     */
+    public function setPathConfig(string $value): self
+    {
+        $this->config->set('path', $value);
+        return $this;
+    }
+
+    /**
+     * Get the optional `path` configuration value, or `null` if the key is not set.
+     *
+     * This is the `path` key (e.g. for `{{path}}` in tasks), not the remote deployment directory;
+     * for that, use `getDeployPath()`.
+     */
+    public function getPathConfig(): ?string
+    {
+        return $this->get('path', null);
     }
 
     public function setLabels(array $labels): self

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -30,7 +30,7 @@ class HostTest extends TestCase
         $host
             ->setHostname('hostname')
             ->setRemoteUser('remote_user')
-            ->setPath('/var/www')
+            ->setPathConfig('/var/www')
             ->setPort(22)
             ->setConfigFile('~/.ssh/config')
             ->setIdentityFile('~/.ssh/id_rsa')
@@ -41,7 +41,7 @@ class HostTest extends TestCase
         self::assertStringContainsString('host', $host->getTag());
         self::assertEquals('hostname', $host->getHostname());
         self::assertEquals('remote_user', $host->getRemoteUser());
-        self::assertEquals('/var/www', $host->getPath());
+        self::assertEquals('/var/www', $host->getPathConfig());
         self::assertEquals(22, $host->getPort());
         self::assertEquals('~/.ssh/config', $host->getConfigFile());
         self::assertEquals('~/.ssh/id_rsa', $host->getIdentityFile());
@@ -89,7 +89,7 @@ class HostTest extends TestCase
             ->set('env', $value)
             ->set('path', '{{env}}');
 
-        self::assertEquals($value, $host->getPath());
+        self::assertEquals($value, $host->getPathConfig());
     }
 
     public function testHostWithUserFromConfig()

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -30,6 +30,7 @@ class HostTest extends TestCase
         $host
             ->setHostname('hostname')
             ->setRemoteUser('remote_user')
+            ->setPath('/var/www')
             ->setPort(22)
             ->setConfigFile('~/.ssh/config')
             ->setIdentityFile('~/.ssh/id_rsa')
@@ -40,6 +41,7 @@ class HostTest extends TestCase
         self::assertStringContainsString('host', $host->getTag());
         self::assertEquals('hostname', $host->getHostname());
         self::assertEquals('remote_user', $host->getRemoteUser());
+        self::assertEquals('/var/www', $host->getPath());
         self::assertEquals(22, $host->getPort());
         self::assertEquals('~/.ssh/config', $host->getConfigFile());
         self::assertEquals('~/.ssh/id_rsa', $host->getIdentityFile());

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -81,6 +81,17 @@ class HostTest extends TestCase
         self::assertEquals($value, $host->getIdentityFile());
     }
 
+    public function testHostWithPathFromParams()
+    {
+        $host = new Host('host');
+        $value = 'new_value';
+        $host
+            ->set('env', $value)
+            ->set('path', '{{env}}');
+
+        self::assertEquals($value, $host->getPath());
+    }
+
     public function testHostWithUserFromConfig()
     {
         $parent = new Configuration();


### PR DESCRIPTION
- [ ] ~Bug fix #…?~
- [x] New feature?
- [ ] ~BC breaks?~
- [x] Tests added?
- [x] Docs added?

**Changes:**
This PR adds two thin typed wrappers ` setPath(string $path): self` and `getPath(): ?string`, which are wrapping `$this->config->set('path', $path);` and `$this->config->get('path', null);` respectively.

**Motivation:**
Improve IDE/static analysis support by providing a typed function to use.
