### PR TITLE
Cast SSH port to string before adding to connection options array

### DIFF
--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -278,7 +278,7 @@ class Host
             }
         }
         if ($this->has('port')) {
-            $options = array_merge($options, ['-p', $this->getPort()]);
+            $options = array_merge($options, ['-p', (string) $this->getPort()]);
         }
         if ($this->has('config_file')) {
             $options = array_merge($options, ['-F', parse_home_dir($this->getConfigFile())]);


### PR DESCRIPTION
This function is hinted as a `string[]` but `Host::getPort()` can return an int or string.

This causes issues in the `rsync_rsh` function has it passes the values of the array to functions that require a string to be used.

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?
