### PR TITLE
feat: add thin typed wrappers for set/get('branch',..) on the host

### DIFF
--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -71,7 +71,8 @@ The typed setter methods give better IDE autocompletion:
 ```php
 host('example.org')
     ->setHostname('example.cloud.google.com')
-    ->setRemoteUser('deployer');
+    ->setRemoteUser('deployer')
+    ->setBranch('production');
 ```
 
 ---
@@ -130,6 +131,7 @@ set('default_selector', "stage=prod&role=web,role=special");
 | **`ssh_multiplexing`** | Enable SSH multiplexing for performance. Default is `true`.                                    |
 | **`shell`**            | Shell to use. Default is `bash -ls`.                                                           |
 | **`deploy_path`**      | Directory for deployments. E.g., `~/myapp`.                                                    |
+| **`branch`**           | Git branch to deploy for this host. Overrides the global `branch` config when set. Use `setBranch()` for a typed setter. |
 | **`labels`**           | Key-value pairs for host selection.                                                            |
 | **`ssh_arguments`**    | Additional SSH options. E.g., `['-o UserKnownHostsFile=/dev/null']`.                           |
 | **`ssh_control_path`** | Control path for SSH multiplexing. Default is `~/.ssh/%C` or `/dev/shm/%C` in CI environments. |

--- a/src/Host/Host.php
+++ b/src/Host/Host.php
@@ -200,6 +200,17 @@ class Host
         return $this->config->get('deploy_path', null);
     }
 
+    public function setBranch(string $branch): self
+    {
+        $this->config->set('branch', $branch);
+        return $this;
+    }
+
+    public function getBranch(): ?string
+    {
+        return $this->config->get('branch', null);
+    }
+
     public function setLabels(array $labels): self
     {
         $this->config->set('labels', $labels);

--- a/tests/src/Host/HostTest.php
+++ b/tests/src/Host/HostTest.php
@@ -34,7 +34,8 @@ class HostTest extends TestCase
             ->setConfigFile('~/.ssh/config')
             ->setIdentityFile('~/.ssh/id_rsa')
             ->setForwardAgent(true)
-            ->setSshMultiplexing(true);
+            ->setSshMultiplexing(true)
+            ->setBranch('develop');
 
         self::assertEquals('host', $host->getAlias());
         self::assertStringContainsString('host', $host->getTag());
@@ -45,6 +46,7 @@ class HostTest extends TestCase
         self::assertEquals('~/.ssh/id_rsa', $host->getIdentityFile());
         self::assertEquals(true, $host->getForwardAgent());
         self::assertEquals(true, $host->getSshMultiplexing());
+        self::assertEquals('develop', $host->getBranch());
     }
 
     public function testConfigurationAccessor()


### PR DESCRIPTION
- [ ] ~Bug fix #…?~
- [x] New feature?
- [ ] ~BC breaks?~
- [x] Tests added?
- [x] Docs added?

Motivation: Improved IDE support and type safety