### PR TITLE
PHPStan: raise to level 6

### DIFF
--- a/contrib/cpanel.php
+++ b/contrib/cpanel.php
@@ -179,7 +179,7 @@ function getCpanel()
     return $cpanel;
 }
 
-function getDomainInfo()
+function getDomainInfo(): array
 {
     $domain = vsprintf(get('cpanel')['create_domain_format'], get('cpanel')['create_domain_values']);
     $cleanDomain = str_replace(['.', ',', ' ', '/', '-'], '', $domain);

--- a/contrib/ispmanager.php
+++ b/contrib/ispmanager.php
@@ -694,7 +694,7 @@ task('ispmanager:process', function () {
     }
 });
 
-function ispmanagerRequest($method, $requestData)
+function ispmanagerRequest(string $method, array $requestData): mixed
 {
     $config = get('ispmanager');
     $dsnData = parse_url($config['api']['dsn']);
@@ -722,7 +722,7 @@ function ispmanagerRequest($method, $requestData)
     }
 }
 
-function ispmanagerAuthRequest($url, $login, $pass)
+function ispmanagerAuthRequest(string $url, string $login, string $pass): void
 {
     $authRequestData = [
         'func' => 'auth',
@@ -743,7 +743,7 @@ function ispmanagerAuthRequest($url, $login, $pass)
     }
 }
 
-function prepareRequest($requestData)
+function prepareRequest(array $requestData): array
 {
     $config = get('ispmanager');
     $dsnData = parse_url($config['api']['dsn']);
@@ -763,9 +763,9 @@ function prepareRequest($requestData)
     return $requestData;
 }
 
-function generatePassword($lenght)
+function generatePassword(int $length): string
 {
-    return substr(md5(uniqid()), 0, $lenght);
+    return substr(md5(uniqid()), 0, $length);
 }
 
 // Callbacks before actions under domains

--- a/contrib/sentry.php
+++ b/contrib/sentry.php
@@ -184,7 +184,7 @@ task(
     },
 );
 
-function getPreviousReleaseRevision()
+function getPreviousReleaseRevision(): ?string
 {
     switch (get('update_code_strategy')) {
         case 'local_archive':
@@ -206,7 +206,7 @@ function getPreviousReleaseRevision()
     }
 }
 
-function getCurrentReleaseRevision()
+function getCurrentReleaseRevision(): string
 {
     switch (get('update_code_strategy')) {
         case 'local_archive':

--- a/contrib/slack.php
+++ b/contrib/slack.php
@@ -87,7 +87,7 @@ set('slack_success_color', '#00c100');
 set('slack_failure_color', '#ff0909');
 set('slack_rollback_color', '#eba211');
 
-function checkSlackAnswer($result)
+function checkSlackAnswer(mixed $result): bool
 {
     if ('invalid_token' === $result) {
         warning('Invalid Slack token');

--- a/contrib/supervisord-monitor.php
+++ b/contrib/supervisord-monitor.php
@@ -91,7 +91,7 @@ namespace Deployer;
 
 use Deployer\Utility\Httpie;
 
-function supervisordCheckConfig()
+function supervisordCheckConfig(): void
 {
     $config = get('supervisord', []);
     foreach ($config as $key => $value) {
@@ -108,12 +108,12 @@ function supervisordCheckConfig()
     }
 }
 
-function supervisordGetBasicAuthToken()
+function supervisordGetBasicAuthToken(): string
 {
     return 'Basic ' . base64_encode(get('supervisord_basic_auth_user') . ':' . get('supervisord_basic_auth_password'));
 }
 
-function supervisordIsAuthenticated()
+function supervisordIsAuthenticated(): bool
 {
     supervisordCheckConfig();
 
@@ -123,7 +123,7 @@ function supervisordIsAuthenticated()
     return $authResponseInfo['http_code'] === 200;
 }
 
-function supervisordControlAction($name, $action = 'stop')
+function supervisordControlAction(string $name, string $action = 'stop'): bool
 {
     $stopResponseInfo = [];
     Httpie::post(get('supervisord_uri') . '/control/' . $action . '/localhost/' . $name)->header('Authorization', supervisordGetBasicAuthToken())->send($stopResponseInfo);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - tests/phpstan-baseline.neon
 
 parameters:
-    level: 5
+    level: 6
     paths:
         - bin
         - src
@@ -23,3 +23,7 @@ parameters:
         - "#^Constant MASTER_TOKEN not found\\.$#"
         - "#CpanelPhp#"
         - "#AMQPMessage#"
+        - identifier: missingType.iterableValue
+        -
+            identifier: missingType.generics
+            path: src/Component/Pimple/Container.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,9 +9,16 @@ parameters:
         - recipe
         - contrib
 
+    bootstrapFiles:
+        - tests/constants.php
+
+    dynamicConstantNames:
+        DEPLOYER_VERSION: string
+        DEPLOYER_BIN: string
+        MASTER_ENDPOINT: string
+        MASTER_TOKEN: string
+
     ignoreErrors:
-        - "#^Constant DEPLOYER_VERSION not found\\.$#"
-        - "#^Constant DEPLOYER_BIN not found\\.$#"
         - "#^Constant MASTER_ENDPOINT not found\\.$#"
         - "#^Constant MASTER_TOKEN not found\\.$#"
         - "#CpanelPhp#"

--- a/recipe/codeigniter4.php
+++ b/recipe/codeigniter4.php
@@ -80,7 +80,7 @@ function spark($command, $options = [])
     };
 }
 
-function codeigniter4_version_compare($version, $comparator)
+function codeigniter4_version_compare(string $version, string $comparator): bool
 {
     return version_compare(get('codeigniter4_version'), $version, $comparator);
 }

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -74,7 +74,7 @@ function artisan($command, $options = [])
     };
 }
 
-function laravel_version_compare($version, $comparator)
+function laravel_version_compare(string $version, string $comparator): bool
 {
     return version_compare(get('laravel_version'), $version, $comparator);
 }

--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -253,7 +253,7 @@ task('magento:deploy:assets:frontend', function () {
  *
  * @throws ConfigurationException
  */
-function magentoDeployAssetsSplit(string $area)
+function magentoDeployAssetsSplit(string $area): void
 {
     if (!in_array($area, ['frontend', 'backend'], true)) {
         throw new ConfigurationException("\$area must be either 'frontend' or 'backend', '$area' given");

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -13,6 +13,9 @@ namespace Deployer\Collection;
 use Countable;
 use IteratorAggregate;
 
+/**
+ * @implements IteratorAggregate<string, mixed>
+ */
 class Collection implements Countable, IteratorAggregate
 {
     protected array $values = [];
@@ -35,7 +38,7 @@ class Collection implements Countable, IteratorAggregate
         return array_key_exists($name, $this->values);
     }
 
-    public function set(string $name, mixed $object)
+    public function set(string $name, mixed $object): void
     {
         $this->values[$name] = $object;
     }

--- a/src/Command/BlackjackCommand.php
+++ b/src/Command/BlackjackCommand.php
@@ -302,12 +302,12 @@ class BlackjackCommand extends Command
         return $sum;
     }
 
-    private function print(string $text = "")
+    private function print(string $text = ""): void
     {
         $this->output->writeln(" $text");
     }
 
-    private function printHand(array $hand, int $offset = 1)
+    private function printHand(array $hand, int $offset = 1): void
     {
         $cards = [];
         for ($i = 0; $i < count($hand) - $offset; $i++) {
@@ -345,7 +345,7 @@ class BlackjackCommand extends Command
         }
     }
 
-    private function printWhiskey(int $whiskeyLevel)
+    private function printWhiskey(int $whiskeyLevel): void
     {
         if ($whiskeyLevel == 4) {
             echo <<<ASCII

--- a/src/Command/CustomOption.php
+++ b/src/Command/CustomOption.php
@@ -18,7 +18,7 @@ trait CustomOption
      * @param Host[] $hosts
      * @param string[] $options
      */
-    protected function applyOverrides(array $hosts, array $options)
+    protected function applyOverrides(array $hosts, array $options): void
     {
         $override = [];
         foreach ($options as $option) {

--- a/src/Command/MainCommand.php
+++ b/src/Command/MainCommand.php
@@ -167,7 +167,7 @@ class MainCommand extends SelectCommand
         return $exitCode;
     }
 
-    private function checkUpdates()
+    private function checkUpdates(): void
     {
         try {
             fwrite(STDERR, Httpie::get('https://deployer.org/check-updates/' . DEPLOYER_VERSION)->send()->body());
@@ -176,7 +176,7 @@ class MainCommand extends SelectCommand
         }
     }
 
-    private function showBanner()
+    private function showBanner(): void
     {
         if (getenv('DO_NOT_SHOW_BANNER') === 'true') {
             return;

--- a/src/Command/TreeCommand.php
+++ b/src/Command/TreeCommand.php
@@ -70,12 +70,12 @@ class TreeCommand extends Command
         return 0;
     }
 
-    private function buildTree(string $taskName)
+    private function buildTree(string $taskName): void
     {
         $this->createTreeFromTaskName($taskName, '', true);
     }
 
-    private function createTreeFromTaskName(string $taskName, string $postfix = '', bool $isLast = false)
+    private function createTreeFromTaskName(string $taskName, string $postfix = '', bool $isLast = false): void
     {
         $task = $this->deployer->tasks->get($taskName);
 
@@ -130,7 +130,7 @@ class TreeCommand extends Command
         }
     }
 
-    private function addTaskToTree(string $taskName, bool $isLast = false)
+    private function addTaskToTree(string $taskName, bool $isLast = false): void
     {
         $this->tree[] = [
             'taskName' => $taskName,
@@ -140,7 +140,7 @@ class TreeCommand extends Command
         ];
     }
 
-    private function outputTree(string $taskName)
+    private function outputTree(string $taskName): void
     {
         $this->output->writeln("The task-tree for <info>$taskName</info>:");
 

--- a/src/Component/Pimple/Container.php
+++ b/src/Component/Pimple/Container.php
@@ -19,6 +19,8 @@ use Deployer\Component\Pimple\Exception\UnknownIdentifierException;
  * Container main class.
  *
  * @author Fabien Potencier
+ *
+ * @implements \ArrayAccess<string, mixed>
  */
 class Container implements \ArrayAccess
 {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -17,6 +17,9 @@ use function Deployer\Support\array_merge_alternate;
 use function Deployer\Support\is_closure;
 use function Deployer\Support\normalize_line_endings;
 
+/**
+ * @implements \ArrayAccess<string, mixed>
+ */
 class Configuration implements \ArrayAccess
 {
     private ?Configuration $parent;

--- a/src/Documentation/DocGen.php
+++ b/src/Documentation/DocGen.php
@@ -318,7 +318,7 @@ class DocGen
         return null;
     }
 
-    public function generateRecipesIndex(string $destination)
+    public function generateRecipesIndex(string $destination): void
     {
         $index = "# All Recipes\n\n";
         $list = [];
@@ -333,7 +333,7 @@ class DocGen
         file_put_contents("$destination/recipe/README.md", $index);
     }
 
-    public function generateContribIndex(string $destination)
+    public function generateContribIndex(string $destination): void
     {
         $index = "# All Contrib Recipes\n\n";
         $list = [];

--- a/src/Executor/Planner.php
+++ b/src/Executor/Planner.php
@@ -63,7 +63,7 @@ class Planner
         $this->table->addRow($row);
     }
 
-    public function render()
+    public function render(): void
     {
         $this->table->render();
     }

--- a/src/Import/MamlRecipe.php
+++ b/src/Import/MamlRecipe.php
@@ -12,6 +12,7 @@ namespace Deployer\Import;
 
 use Deployer\Exception\Exception;
 use Deployer\Exception\SchemaException;
+use Deployer\Task\Task;
 use Maml\Ast\ArrayNode;
 use Maml\Ast\BooleanNode;
 use Maml\Ast\ObjectNode;
@@ -293,7 +294,7 @@ class MamlRecipe
         }
     }
 
-    private function createTask(string $name, ArrayNode $array, string $desc)
+    private function createTask(string $name, ArrayNode $array, string $desc): ?Task
     {
         $isGroupTask = true;
         $groupTasks = [];
@@ -307,7 +308,7 @@ class MamlRecipe
 
         if ($isGroupTask) {
             task($name, $groupTasks)->desc($desc);
-            return;
+            return null;
         }
 
         $body = function () {

--- a/src/Import/YamlRecipe.php
+++ b/src/Import/YamlRecipe.php
@@ -53,7 +53,7 @@ class YamlRecipe
         Import::import($paths);
     }
 
-    protected static function hosts(array $hosts)
+    protected static function hosts(array $hosts): void
     {
         foreach ($hosts as $alias => $config) {
             if ($config['local'] ?? false) {
@@ -69,14 +69,14 @@ class YamlRecipe
         }
     }
 
-    protected static function config(array $config)
+    protected static function config(array $config): void
     {
         foreach ($config as $key => $value) {
             set($key, $value);
         }
     }
 
-    protected static function tasks(array $tasks)
+    protected static function tasks(array $tasks): void
     {
         $buildTask = function ($name, $steps) {
             $body = function () {};
@@ -181,7 +181,7 @@ class YamlRecipe
         }
     }
 
-    protected static function after(array $after)
+    protected static function after(array $after): void
     {
         foreach ($after as $key => $value) {
             if (is_array($value)) {
@@ -194,7 +194,7 @@ class YamlRecipe
         }
     }
 
-    protected static function before(array $before)
+    protected static function before(array $before): void
     {
         foreach ($before as $key => $value) {
             if (is_array($value)) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,10 +21,7 @@ if (!$loaded) {
 set_include_path(__DIR__ . '/..' . PATH_SEPARATOR . get_include_path());
 
 putenv('DEPLOYER_LOCAL_WORKER=true');
-define('DEPLOYER_BIN', __DIR__ . '/../bin/dep');
-define('__FIXTURES__', __DIR__ . '/fixtures');
-define('__REPOSITORY__', __DIR__ . '/fixtures/repository');
-define('__TEMP_DIR__', sys_get_temp_dir() . '/deployer');
+require_once __DIR__ . '/constants.php';
 
 require_once __DIR__ . '/spec/SpecTest.php';
 

--- a/tests/constants.php
+++ b/tests/constants.php
@@ -1,0 +1,7 @@
+<?php
+
+define('DEPLOYER_BIN', __DIR__ . '/../bin/dep');
+define('DEPLOYER_VERSION', 'dev-master');
+define('__FIXTURES__', __DIR__ . '/fixtures');
+define('__REPOSITORY__', __DIR__ . '/fixtures/repository');
+define('__TEMP_DIR__', sys_get_temp_dir() . '/deployer');


### PR DESCRIPTION
requires https://github.com/deployphp/deployer/pull/4222

- adds all missing return- and parameter-types
- make sure newly added code will PHPStan error if return- and parameter-types missing
- ignores less important level 6 errors, which can be cleaned up in a future iteration