### PR TITLE
[SHOPWARE] Fix world readable var/cache directory

### DIFF
--- a/docs/recipe/shopware.md
+++ b/docs/recipe/shopware.md
@@ -301,7 +301,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db\:build {#sw-build-without-db-build}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L193)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L197)
 
 
 
@@ -309,7 +309,7 @@ This task is group task which contains next tasks:
 
 
 ### sw-build-without-db {#sw-build-without-db}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L197)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L201)
 
 
 

--- a/recipe/shopware.php
+++ b/recipe/shopware.php
@@ -181,6 +181,10 @@ task('sw-build-without-db:get-remote-config', static function () {
     if (!test('[ -d {{current_path}} ]')) {
         return;
     }
+    // Copy .env files into build directory so we don't default to APP_ENV=dev and APP_DEBUG=1 during build
+    download("{{current_path}}/", "./", [
+        "options" => ["--copy-links", "--include=.env*", "--exclude=*"],
+    ]);
     within('{{current_path}}', function () {
         run('{{bin/php}} ./bin/console bundle:dump');
         download('{{current_path}}/var/plugins.json', './var/');


### PR DESCRIPTION
Added functionality to copy .env files during build process so that we have sane defaults for `APP_ENV` and `APP_DEBUG`.

### The Problem

The reason this matters is because by default, [sw-build-without-db:build](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L194) runs `./bin/build-js.sh` via runLocally, which has no `.env` file (it's git ignored and `deploy:env` only writes one to the release path, much later):

```
The task-tree for deploy:
└── deploy
    ├── deploy:prepare
    │   ├── deploy:info
    │   ├── deploy:setup
    │   ├── deploy:lock
    │   ├── deploy:release
    │   ├── sw-build-without-db
    │   │   ├── sw-build-without-db:get-remote-config
    │   │   └── sw-build-without-db:build                <-- build step
    │   ├── deploy:update_code
    │   ├── deploy:env                                   <-- env step
    │   ├── deploy:shared
    │   └── deploy:writable
    ├── sw:writable:jwt
    ├── sw:deploy
    │   ├── sw:database:migrate
    │   ├── sw:plugin:refresh
    │   ├── sw:theme:refresh
    │   ├── sw:scheduled-task:register
    │   └── sw:cache:clear
    │   ├── sw:plugin:update:all
    │   └── sw:cache:clear
    ├── deploy:clear_paths
    ├── sw:cache:warmup
    └── deploy:publish
        ├── deploy:symlink
        ├── deploy:unlock
        ├── deploy:cleanup
        └── deploy:success
```

Symfony Runtime then falls back to its defaults at [`GenericRuntime.php#L65-L72`](https://github.com/symfony/runtime/blob/v7.4.8/GenericRuntime.php#L65-L72), so `APP_DEBUG` ends up `true` and a few lines down that triggers `umask(0o000)`. Every call inside `build-js.sh` then writes `var/cache` with mode `0777` and files at `0666`.

End result is a world-writable cache directory in every release which is not favorable:

```
drwxrwxrwx+ 4 jrc-36b5-137j jetrails  144 Jun  2 17:05 .
drwxrwxr-x+ 4 jrc-36b5-137j jetrails  149 Jun  2 17:05 ..
-rw-rw-rw-+ 1 jrc-36b5-137j jetrails   43 Jun  2 17:05 CACHEDIR.TAG
drwxrwxrwx+ 6 jrc-36b5-137j jetrails 4096 Jun  2 17:05 dev_ha0db8b6bde55b7202a8839f06a274e40
-rw-rw-rw-+ 1 jrc-36b5-137j jetrails  118 Jun  2 17:05 opcache-preload.php
drwxrwxrwx+ 6 jrc-36b5-137j jetrails 4096 Jun  2 17:05 prod_ha0db8b6bde55b7202a8839f06a274e40
```

### The Proposed Solution

The fix is to seed the build checkout with the user's existing `.env*` files from `current_path` before the build runs. The build phase then boots Symfony with the real `APP_ENV` and `APP_DEBUG` the user already configured, no hardcoded
  values needed. The change goes in [sw-build-without-db:get-remote-config](https://github.com/deployphp/deployer/blob/master/recipe/shopware.php#L180-L191) since it already pulls config from `current_path`. This results in a correctly permissioned `var/cache` directory: 

```
drwxrwxr-x+ 3 jrc-36b5-137j jetrails   99 Jun  2 18:30 .
drwxrwxr-x+ 5 jrc-36b5-137j jetrails  165 Jun  2 18:30 ..
-rw-rw-r--+ 1 jrc-36b5-137j jetrails   43 Jun  2 18:30 CACHEDIR.TAG
-rw-rw-r--+ 1 jrc-36b5-137j jetrails  118 Jun  2 18:30 opcache-preload.php
drwxrwxr-x+ 6 jrc-36b5-137j jetrails 4096 Jun  2 18:30 prod_ha0db8b6bde55b7202a8839f06a274e40
```

### Backwards Compatibility

No backwards compatibility break IMO. The change only adds a download step, it doesn't alter existing task behavior.

On a first deploy where `current_path` doesn't exist, the early return preserves the current behavior exactly. On subsequent deploys, it uses the user's real `APP_ENV` and `APP_DEBUG` instead of falling back to dev/debug values.

For anyone running with `APP_ENV=prod` (the documented default in .env.example), this fixes the world readable permissions in `var/cache`.

For anyone who deliberately runs with `APP_ENV=dev`, the build now correctly reflects that choice and behaves the same as before.

These values are obviously also able to be overwritten by actual environmental variables.

---

- [ ] Bug fix #…? yes but no issue was opened
- [ ] New feature? no
- [ ] BC breaks? no
- [ ] Tests added? no
- [ ] Docs added? no