### PR TITLE
[MAGENTO] Check That `bin/magento` Exists In Previous Release

### DIFF
--- a/recipe/magento2.php
+++ b/recipe/magento2.php
@@ -595,7 +595,7 @@ task('magento:cleanup_cache_prefix', function () {
  */
 desc('Remove cron from crontab and kill running cron jobs');
 task('magento:cron:stop', function () {
-    if (has('previous_release')) {
+    if (has('previous_release') && test("[ -f {{previous_release}}/{{magento_dir}}/bin/magento ]")) {
         run('{{bin/php}} {{previous_release}}/{{magento_dir}}/bin/magento cron:remove');
     }
 


### PR DESCRIPTION
### Problem

During the [magento:cron:stop](https://github.com/deployphp/deployer/blob/master/recipe/magento2.php#L597-L603) task, we check to see if the `previous_release` variable is set. If it is then we try to run `bin/magento cron:remove` from the previous release's directory.

The problem is if the previous release fails before copying data into the release directory, then there is no `bin/magento` in the previous release folder.

The `previous_release` variable is set by just sorting the release names and not considering if its a successful release ([release.php#L139-L141](https://github.com/deployphp/deployer/blob/master/recipe/deploy/release.php#L139-L141)).

When this happens it fails with this kind of error message:

```
[localhost] err Could not open input file: /var/www/example.com/releases/2026-06-08-004/./bin/magento
```

### Solution

The solution is really simple, just test if the `bin/magento` file exists in the previous release folder:

```diff
-    if (has('previous_release') {
+    if (has('previous_release') && test("[ -f {{previous_release}}/{{magento_dir}}/bin/magento ]")) {
```

---

- [x] Bug fix #…? Yes but no issue number
- [x] New feature? No
- [x] BC breaks? No
- [x] Tests added? No
- [x] Docs added? Ran command, nothing changed

      Please, regenerate docs by running next command:
      $ php bin/docgen
