### PR TITLE
More precise `ObjectProxy` doctypes

### DIFF
--- a/src/Support/ObjectProxy.php
+++ b/src/Support/ObjectProxy.php
@@ -10,13 +10,21 @@ declare(strict_types=1);
 
 namespace Deployer\Support;
 
+use Deployer\Host\Host;
+
+/**
+ * @mixin Host
+ */
 class ObjectProxy
 {
     /**
-     * @var array
+     * @var array<Host>
      */
     private $objects;
 
+    /**
+     * @param array<Host> $objects
+     */
     public function __construct(array $objects)
     {
         $this->objects = $objects;


### PR DESCRIPTION
to prevent errors like 

> Call to an undefined method Host|ObjectProxy::setHostname().

in https://phpstan.org/r/e94b62bf-c573-45a5-9503-3fd6eff433b5 on PHPStan level 7+ in builder patterns like

```
host('production-aws1')
	->setHostname('myhost');
```