### PR TITLE
Fix race condition in local_archive strategy on parallel deploys

### DIFF
--- a/recipe/deploy/update_code.php
+++ b/recipe/deploy/update_code.php
@@ -81,11 +81,12 @@ task('deploy:update_code', function () {
 
     if ($strategy === 'local_archive') {
         $gitRoot = runLocally("git rev-parse --show-toplevel");
-        runLocally("git -C " . quote($gitRoot) . " archive $targetWithDir -o archive.tar");
-        upload("$gitRoot/archive.tar", '{{release_path}}/archive.tar');
+        $archive = tempnam(sys_get_temp_dir(), 'deployer_archive_');
+        runLocally("git -C " . quote($gitRoot) . " archive $targetWithDir -o " . quote($archive));
+        upload($archive, '{{release_path}}/archive.tar');
         run("tar -xf {{release_path}}/archive.tar -C {{release_path}}");
         run("rm {{release_path}}/archive.tar");
-        unlink("$gitRoot/archive.tar");
+        unlink($archive);
 
         $rev = quote(runLocally("git rev-list $target -1"));
     } else {

--- a/tests/spec/LocalArchiveTest.php
+++ b/tests/spec/LocalArchiveTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Deployer;
+
+use spec\SpecTest;
+use Symfony\Component\Console\Output\Output;
+
+class LocalArchiveTest extends SpecTest
+{
+    public const RECIPE = __DIR__ . '/recipe/local_archive.php';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        putenv('DEPLOYER_LOCAL_WORKER=false');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        putenv('DEPLOYER_LOCAL_WORKER=true');
+        parent::tearDownAfterClass();
+    }
+
+    public function testParallelLocalArchiveDeploy()
+    {
+        $this->init(self::RECIPE);
+        $this->tester->run([
+            'deploy',
+            'selector' => 'all',
+            '-f' => self::RECIPE,
+        ], [
+            'verbosity' => Output::VERBOSITY_VERBOSE,
+        ]);
+
+        $display = $this->tester->getDisplay();
+        self::assertEquals(0, $this->tester->getStatusCode(), $display);
+
+        foreach ($this->deployer->hosts as $host) {
+            $deployPath = $host->get('deploy_path');
+            self::assertFileExists($deployPath . '/current/README.md', $display);
+        }
+
+        $gitRoot = trim((string) shell_exec('git rev-parse --show-toplevel'));
+        self::assertFileDoesNotExist($gitRoot . '/archive.tar');
+    }
+}

--- a/tests/spec/recipe/local_archive.php
+++ b/tests/spec/recipe/local_archive.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Deployer;
+
+require 'recipe/common.php';
+
+set('update_code_strategy', 'local_archive');
+set('deploy_path', sys_get_temp_dir() . '/deployer/{{hostname}}');
+set('sub_directory', 'tests/fixtures/repository');
+set('keep_releases', 1);
+
+localhost('alpha');
+localhost('beta');
+localhost('gamma');


### PR DESCRIPTION
When deploying to multiple hosts in parallel, deploy:update_code runs once per host in its own worker, but all workers shared the same local archive file. The first host to finish unlinked it, so slower hosts failed with "No such file or directory"; a rebuild could also truncate an in-flight upload. Build the archive into a unique per-host file instead.

Refs #4232

- [x] Bug fix #4232
- [ ] New feature?
- [ ] BC breaks?
- [x] Tests added
- [ ] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
