### PR TITLE
Enhances provisioning for sudo-only hosts

### DIFF
--- a/recipe/provision/user.php
+++ b/recipe/provision/user.php
@@ -35,11 +35,25 @@ task('provision:user', function () {
         $password = run("mkpasswd -m sha-512 '%password%'", secrets: ['password' => get('sudo_password')]);
         run("usermod --password '%password%' deployer", secrets: ['password' => $password]);
 
-        // Copy root public key to deployer user so user can login without password.
-        run('cp /root/.ssh/authorized_keys /home/deployer/.ssh/authorized_keys');
+        $authorizedKeys = '/root/.ssh/authorized_keys';
+        if (!test("[ -f $authorizedKeys ]")) {
+            $provisionHome = run('getent passwd ' . get('provision_user') . ' | cut -d: -f6');
+            $authorizedKeys = "$provisionHome/.ssh/authorized_keys";
+        }
 
-        // Create ssh key if not already exists.
-        run('ssh-keygen -f /home/deployer/.ssh/id_ed25519 -t ed25519 -N ""');
+        try {
+            // Copy the public key to the deployer user so it can login without password.
+            run("cp $authorizedKeys /home/deployer/.ssh/authorized_keys");
+
+            // Create ssh key if not already exists.
+            run('ssh-keygen -f /home/deployer/.ssh/id_ed25519 -t ed25519 -N ""');
+        } catch (\Throwable $e) {
+            // Copy the public key to the deployer user so it can login without password.
+            run("sudo cp $authorizedKeys /home/deployer/.ssh/authorized_keys");
+
+            // Create ssh key if not already exists.
+            run('sudo ssh-keygen -f /home/deployer/.ssh/id_ed25519 -t ed25519 -N ""');
+        }
 
         try {
             run('chown -R deployer:deployer /home/deployer');
@@ -54,6 +68,9 @@ task('provision:user', function () {
         run('usermod -a -G www-data deployer');
         run('usermod -a -G caddy deployer');
     }
+
+    run("[ -d {{deploy_path}} ] || mkdir -p {{deploy_path}}");
+    run("chown -R deployer:deployer {{deploy_path}}");
 })->oncePerNode();
 
 

--- a/recipe/provision/website.php
+++ b/recipe/provision/website.php
@@ -27,6 +27,9 @@ task('provision:website', function () {
 
     run("[ -d {{deploy_path}}/log ] || mkdir -p {{deploy_path}}/log");
     run("chown deployer:caddy {{deploy_path}}/log");
+    // Group-writable so the caddy daemon (group caddy) can create access.log;
+    // otherwise `service caddy reload` fails to open the log writer.
+    run("chmod 775 {{deploy_path}}/log");
 
     $restoreBecome = become('deployer');
 

--- a/recipe/provision/website.php
+++ b/recipe/provision/website.php
@@ -23,16 +23,15 @@ task('provision:server', function () {
 
 desc('Provision website');
 task('provision:website', function () {
-    $restoreBecome = become('deployer');
+    set('remote_user', get('provision_user'));
 
-    run("[ -d {{deploy_path}} ] || mkdir -p {{deploy_path}}");
-    run("chown -R deployer:deployer {{deploy_path}}");
+    run("[ -d {{deploy_path}}/log ] || mkdir -p {{deploy_path}}/log");
+    run("chown deployer:caddy {{deploy_path}}/log");
+
+    $restoreBecome = become('deployer');
 
     set('deploy_path', run("realpath {{deploy_path}}"));
     cd('{{deploy_path}}');
-
-    run("[ -d log ] || mkdir log");
-    run("chgrp caddy log");
 
     $caddyfile = parse(file_get_contents(__DIR__ . '/Caddyfile'));
 


### PR DESCRIPTION
Improves the provisioning process to support VPS environments that do not provide direct root access, relying instead on a user with `sudo` privileges.

*   **Provision User Setup:**
    *   Dynamically locates the `authorized_keys` file for the `provision_user` if the root user's key isn't available.
    *   Adds robust `sudo` fallbacks for copying public keys and generating SSH keys for the `deployer` user, allowing these operations to succeed even without direct write permissions by leveraging `sudo`.
    *   Ensures the `deploy_path` is created and owned by the `deployer` user during the initial user provisioning, making it ready for deployment.

*   **Website Provisioning:**
    *   Sets the `remote_user` to the `provision_user` for the initial stages of website provisioning, enabling `sudo` operations where necessary before switching to the `deployer` user.
    *   Correctly sets group ownership (`deployer:caddy`) and makes the `log` directory group-writable (`chmod 775`) to ensure the Caddy web server can successfully write access logs, preventing reload failures.