### PR TITLE
Support config interpolation in array values

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -132,6 +132,10 @@ class Configuration implements \ArrayAccess
             return str_replace("\x00\x00", '{{', $result);
         }
 
+        if (is_array($value)) {
+            return array_map($this->parse(...), $value);
+        }
+
         return $value;
     }
 

--- a/tests/src/Configuration/ConfigurationTest.php
+++ b/tests/src/Configuration/ConfigurationTest.php
@@ -17,6 +17,24 @@ class ConfigurationTest extends TestCase
         self::assertEquals('a b', $config->parse('{{foo}} {{bar}}'));
     }
 
+    public function testParseArray()
+    {
+        $config = new Configuration();
+        $config->set('foo', 'a');
+        $config->set('bar', 'b');
+        $config->set('list', ['{{foo}}', '{{bar}}', 'c']);
+        $config->set('nested', [
+            'key' => '{{foo}}',
+            'deep' => ['{{bar}}', 42, null],
+        ]);
+
+        self::assertEquals(['a', 'b', 'c'], $config->get('list'));
+        self::assertEquals([
+            'key' => 'a',
+            'deep' => ['b', 42, null],
+        ], $config->get('nested'));
+    }
+
     public function testUnset()
     {
         $config = new Configuration();


### PR DESCRIPTION
Make Configuration::parse() recursive so {{ }} placeholders inside array config values (at any depth) are interpolated, not only strings.

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [x] Tests added?
- [ ] Docs added?
