### PR TITLE
Fix sentry commits retrieval with local_archive strategy

### DIFF
--- a/contrib/sentry.php
+++ b/contrib/sentry.php
@@ -258,13 +258,20 @@ function getGitCommitsRefs(): Closure
         }
 
         try {
-            if (get('update_code_strategy') === 'archive') {
-                cd('{{deploy_path}}/.dep/repo');
-            } else {
-                cd('{{release_path}}');
-            }
+            $gitLog = sprintf('git rev-list --pretty="%s" %s', 'format:%H#%an#%ae#%at#%s', $commitRange);
 
-            $result = run(sprintf('git rev-list --pretty="%s" %s', 'format:%H#%an#%ae#%at#%s', $commitRange));
+            if (get('update_code_strategy') === 'local_archive') {
+                // The git repository only exists on the local machine.
+                $result = runLocally($gitLog);
+            } else {
+                if (get('update_code_strategy') === 'archive') {
+                    cd('{{deploy_path}}/.dep/repo');
+                } else {
+                    cd('{{release_path}}');
+                }
+
+                $result = run($gitLog);
+            }
             $lines = array_filter(
                 // limit number of commits for first release with many commits
                 array_map('trim', array_slice(explode("\n", $result), 0, 200)),


### PR DESCRIPTION
With update_code_strategy set to local_archive, the release path contains an extracted git archive without a .git directory, and there is no .dep/repo mirror on the host. Run git rev-list locally instead, where the repository actually exists.

- [x] Bug fix #…?
- [ ] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [ ] Docs added?


