### PR TITLE
Run `craft up` on deploy so content migrations see project config

### DIFF
--- a/docs/recipe/craftcms.md
+++ b/docs/recipe/craftcms.md
@@ -100,8 +100,16 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 ## Tasks
 
+### craft\:up {#craft-up}
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L89)
+
+Applies pending migrations and project config changes.
+
+Combined update
+
+
 ### craft\:gc {#craft-gc}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L120)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L127)
 
 Runs garbage collection.
 
@@ -109,7 +117,7 @@ Garbage collection
 
 
 ### deploy {#deploy}
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L127)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/craftcms.php#L134)
 
 Deploys Craft CMS.
 

--- a/recipe/craftcms.php
+++ b/recipe/craftcms.php
@@ -82,6 +82,13 @@ desc('Applies project config file changes.');
 task('craft:project-config/apply', craft('project-config/apply'));
 
 /*
+ * Combined update
+ */
+
+desc('Applies pending migrations and project config changes');
+task('craft:up', craft('up'));
+
+/*
  * Caches
  */
 
@@ -128,8 +135,7 @@ task('deploy', [
     'deploy:prepare',
     'deploy:vendors',
     'craft:clear-caches/compiled-classes',
-    'craft:migrate/all',
-    'craft:project-config/apply',
+    'craft:up',
     'craft:gc',
     'craft:clear-caches/all',
     'deploy:publish',


### PR DESCRIPTION
- [x] Bug fix

The deploy task runs content migrations before project config is applied. A content migration therefore can't use a section, entry type or field that arrives with project config in the same deploy. It fails on the first deploy, when the schema it needs doesn't exist yet.

Craft's own up command orders the three phases correctly, and does so identically in Craft 4 and 5.

```
$this->run('migrate/all', ['noContent' => true, ...]);
$this->run('project-config/apply');
$this->run('migrate/up', ['track' => MigrationManager::TRACK_CONTENT]);
```

This PR adds a craft:up task and uses it in deploy. `craft:migrate/all` and `craft:project-config/apply` keep their current behaviour and stay available.

- [ ] New feature?
- [x] BC breaks?

 Content migrations now run after project config. This is a behaviour change, but now in-line with the [Craft CMS docs](https://craftcms.com/docs/5.x/deploy.html#migrate).

- [ ] Tests added?
- [x] Docs added?
